### PR TITLE
CLI npm search 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Python `pip` | 지원 | 지원 | PyPI 검색/버전 조회/다운로드 |
 | Python `conda` | 지원 | 지원 | 채널 선택 지원 |
 | Java `maven` | 지원 | 지원 | 네이티브 classifier 확인 지원 |
-| Node.js `npm` | 지원 | 부분 지원 | CLI `download`는 지원하지만 `search`는 아직 미구현 |
+| Node.js `npm` | 지원 | 지원 | npm Registry 검색/버전 조회/다운로드 |
 | OS `yum` | 지원 | 부분 지원 | CLI는 `os` 네임스페이스 중심이며 `download/cache`는 재구현 중 |
 | OS `apt` | 지원 | 부분 지원 | CLI `os download`는 재구현 중 안내만 출력 |
 | OS `apk` | 지원 | 부분 지원 | GUI 기준 기능이 더 완전함 |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,7 +91,7 @@ depssmuggler download -t pip -p flask -f tar.gz
 
 ## `search`
 
-일반 패키지 검색 명령입니다. 구현상 `pip`, `conda`, `maven`, `docker`만 직접 검색합니다.
+일반 패키지 검색 명령입니다. 구현상 `pip`, `conda`, `maven`, `npm`, `docker`를 직접 검색합니다.
 
 ### 사용법
 
@@ -111,13 +111,13 @@ depssmuggler search <query> [옵션]
 ```bash
 depssmuggler search requests -t pip
 depssmuggler search spring -t maven -l 10
+depssmuggler search react -t npm
 depssmuggler search nginx -t docker
 ```
 
 ### 참고
 
 - `yum`, `apt`, `apk`를 `search`로 호출하면 CLI는 `os search` 사용을 안내하고 종료합니다.
-- `npm`은 현재 일반 `search` 명령에 구현되어 있지 않습니다.
 
 ## `os`
 
@@ -197,7 +197,6 @@ depssmuggler cache list
 ## 현재 한계
 
 - CLI는 GUI보다 지원 범위가 좁습니다.
-- 일반 `search` 명령에는 `npm`이 아직 연결되어 있지 않습니다.
 - OS 패키지 CLI는 조회 중심이며 다운로드/캐시는 GUI 흐름이 기준입니다.
 - `cache list`는 현재 캐시 루트가 디렉터리 위주라는 가정을 두고 있어, `cache-manifest.json` 같은 일반 파일이 섞인 경우 실패할 수 있습니다.
 

--- a/docs/superpowers/specs/2026-04-13-cli-npm-search-design.md
+++ b/docs/superpowers/specs/2026-04-13-cli-npm-search-design.md
@@ -1,0 +1,29 @@
+# CLI npm Search Design
+
+## 배경
+
+CLI `search` 명령은 `pip`, `conda`, `maven`, `docker`만 직접 검색하고 있었지만, npm downloader에는 이미 `searchPackages()` 구현이 존재한다. 이 불일치 때문에 README와 CLI 문서도 npm search를 미지원으로 설명하고 있다.
+
+## 목표
+
+- `depssmuggler search <query> -t npm`를 기존 검색 타입과 같은 출력 형식으로 지원한다.
+- 성공, 빈 결과, 실패 처리 메시지를 기존 `search` 명령의 패턴과 동일하게 유지한다.
+- 변경 범위는 CLI search 명령, 관련 테스트, 그리고 영향받는 문서로 제한한다.
+
+## 설계
+
+### 접근
+
+- `src/cli/commands/search.ts`에 `npm` 분기를 추가한다.
+- 구현은 기존 `getNpmDownloader().searchPackages(query)`를 그대로 재사용한다.
+- 결과 매핑은 다른 타입과 동일하게 `{ name, version, description }` 구조로 변환한다.
+- 기존 `limit` 절단, 테이블 출력, 다운로드 예시 출력, 실패 처리 코드는 공통 흐름을 그대로 사용한다.
+
+### 테스트
+
+- 새 CLI 단위 테스트에서 npm 검색 성공, 빈 결과, 실패를 고정한다.
+- downloader 자체 검색 구현은 이미 별도 테스트가 있으므로 CLI에서는 분기 연결과 출력/종료 동작만 검증한다.
+
+### 문서
+
+- `docs/cli.md`와 `README.md`에서 npm CLI search 지원 여부를 실제 구현 기준으로 갱신한다.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,10 @@
 ## 로컬 검증 명령
 
 ```bash
+# 표준 worktree 검증 진입점
+bash scripts/ensure_verify_worktree.sh "$PWD"
+bash scripts/verify-worktree.sh
+
 # 단위 테스트
 npm run test
 
@@ -20,6 +24,8 @@ npm run test:coverage
 npm run lint
 npx tsc --noEmit
 ```
+
+`scripts/verify-worktree.sh`는 현재 저장소의 `scripts.test` 계약을 그대로 호출하는 얇은 래퍼이며, worktree에서 공통 검증 진입점으로 사용합니다. 현재 자동 생성 범위는 `test`만 포함하고 `lint`/`typecheck`는 별도 명령으로 유지합니다.
 
 ## 테스트 종류
 

--- a/scripts/ensure_verify_worktree.sh
+++ b/scripts/ensure_verify_worktree.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WT_PATH="${1:-$(pwd)}"
+
+if [ ! -d "$WT_PATH" ]; then
+  echo "worktree 경로를 찾을 수 없습니다: $WT_PATH" >&2
+  exit 1
+fi
+
+cd "$WT_PATH"
+
+if [ ! -f package.json ]; then
+  echo "package.json이 없는 저장소는 자동 검증 스크립트 생성을 지원하지 않습니다." >&2
+  exit 1
+fi
+
+PACKAGE_MANAGER="npm"
+if [ -f pnpm-lock.yaml ]; then
+  PACKAGE_MANAGER="pnpm"
+elif [ -f yarn.lock ]; then
+  PACKAGE_MANAGER="yarn"
+elif [ -f package-lock.json ]; then
+  PACKAGE_MANAGER="npm"
+fi
+
+TEST_SCRIPT="$(node -e "const fs = require('node:fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); const test = pkg.scripts && pkg.scripts.test; if (typeof test === 'string') process.stdout.write(test);")"
+
+if [ -z "$TEST_SCRIPT" ]; then
+  echo "scripts.test가 없어 verify-worktree.sh를 자동 생성할 수 없습니다." >&2
+  exit 1
+fi
+
+mkdir -p scripts
+
+cat > scripts/verify-worktree.sh <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="\$(cd "\${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_MANAGER="${PACKAGE_MANAGER}"
+TEST_SCRIPT='${TEST_SCRIPT}'
+
+cd "\$REPO_ROOT"
+
+echo "[verify-worktree] package manager: \$PACKAGE_MANAGER"
+echo "[verify-worktree] script: \$TEST_SCRIPT"
+
+if [ "\$#" -gt 0 ]; then
+  case "\$PACKAGE_MANAGER" in
+    pnpm)
+      pnpm run test -- "\$@"
+      ;;
+    yarn)
+      yarn test "\$@"
+      ;;
+    *)
+      npm run test -- "\$@"
+      ;;
+  esac
+else
+  case "\$PACKAGE_MANAGER" in
+    pnpm)
+      pnpm run test
+      ;;
+    yarn)
+      yarn test
+      ;;
+    *)
+      npm run test
+      ;;
+  esac
+fi
+EOF
+
+chmod +x scripts/verify-worktree.sh
+echo "생성 완료: scripts/verify-worktree.sh (${PACKAGE_MANAGER} / scripts.test)"

--- a/scripts/verify-worktree.sh
+++ b/scripts/verify-worktree.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_MANAGER="npm"
+TEST_SCRIPT='vitest run'
+
+cd "$REPO_ROOT"
+
+echo "[verify-worktree] package manager: $PACKAGE_MANAGER"
+echo "[verify-worktree] script: $TEST_SCRIPT"
+
+if [ "$#" -gt 0 ]; then
+  case "$PACKAGE_MANAGER" in
+    pnpm)
+      pnpm run test -- "$@"
+      ;;
+    yarn)
+      yarn test "$@"
+      ;;
+    *)
+      npm run test -- "$@"
+      ;;
+  esac
+else
+  case "$PACKAGE_MANAGER" in
+    pnpm)
+      pnpm run test
+      ;;
+    yarn)
+      yarn test
+      ;;
+    *)
+      npm run test
+      ;;
+  esac
+fi

--- a/src/cli/commands/search.test.ts
+++ b/src/cli/commands/search.test.ts
@@ -81,7 +81,7 @@ describe('searchCommand', () => {
 
     await searchCommand('react', { type: 'npm', limit: '1' });
 
-    expect(searchPackages).toHaveBeenCalledWith('react');
+    expect(searchPackages).toHaveBeenCalledWith('react', 1);
 
     const output = vi.mocked(console.log).mock.calls.flat().join('\n');
     expect(output).toContain("'react' 검색 중...");
@@ -100,6 +100,14 @@ describe('searchCommand', () => {
     const output = vi.mocked(console.log).mock.calls.flat().join('\n');
     expect(output).toContain('✓ 0개 결과 찾음');
     expect(output).toContain('검색 결과가 없습니다');
+  });
+
+  it('npm 검색 limit이 잘못되면 기본값 20으로 보정한다', async () => {
+    searchPackages.mockResolvedValue([]);
+
+    await searchCommand('react', { type: 'npm', limit: 'invalid' });
+
+    expect(searchPackages).toHaveBeenCalledWith('react', 20);
   });
 
   it('npm 검색 실패 시 기존 에러 처리와 동일하게 종료한다', async () => {

--- a/src/cli/commands/search.test.ts
+++ b/src/cli/commands/search.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchCommand } from './search';
+
+const { searchPackages } = vi.hoisted(() => ({
+  searchPackages: vi.fn(),
+}));
+
+vi.mock('chalk', () => ({
+  default: new Proxy(
+    {},
+    {
+      get: () => (value: string) => value,
+    }
+  ),
+}));
+
+vi.mock('cli-table3', () => ({
+  default: class TableMock {
+    private rows: string[][] = [];
+
+    push(row: string[]): void {
+      this.rows.push(row);
+    }
+
+    toString(): string {
+      return this.rows.map((row) => row.join(' | ')).join('\n');
+    }
+  },
+}));
+
+vi.mock('../../core/downloaders/pip', () => ({
+  getPipDownloader: vi.fn(() => ({ searchPackages: vi.fn() })),
+}));
+
+vi.mock('../../core/downloaders/conda', () => ({
+  getCondaDownloader: vi.fn(() => ({ searchPackages: vi.fn() })),
+}));
+
+vi.mock('../../core/downloaders/maven', () => ({
+  getMavenDownloader: vi.fn(() => ({ searchPackages: vi.fn() })),
+}));
+
+vi.mock('../../core/downloaders/npm', () => ({
+  getNpmDownloader: vi.fn(() => ({ searchPackages })),
+}));
+
+vi.mock('../../core/downloaders/docker', () => ({
+  getDockerDownloader: vi.fn(() => ({ searchPackages: vi.fn() })),
+}));
+
+describe('searchCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('npm 검색 결과를 기존 테이블 포맷으로 출력한다', async () => {
+    searchPackages.mockResolvedValue([
+      {
+        type: 'npm',
+        name: 'react',
+        version: '19.2.0',
+        metadata: {
+          description: 'React is a JavaScript library for building user interfaces.',
+        },
+      },
+      {
+        type: 'npm',
+        name: 'react-dom',
+        version: '19.2.0',
+        metadata: {
+          description: 'React package for working with the DOM.',
+        },
+      },
+    ]);
+
+    await searchCommand('react', { type: 'npm', limit: '1' });
+
+    expect(searchPackages).toHaveBeenCalledWith('react');
+
+    const output = vi.mocked(console.log).mock.calls.flat().join('\n');
+    expect(output).toContain("'react' 검색 중...");
+    expect(output).toContain('✓ 1개 결과 찾음');
+    expect(output).toContain('[NPM] 검색 결과:');
+    expect(output).toContain('react | 19.2.0 | React is a JavaScript library for building user interfaces.');
+    expect(output).not.toContain('react-dom');
+    expect(output).toContain('depssmuggler download -t npm -p react -V 19.2.0');
+  });
+
+  it('npm 검색 결과가 없으면 기존 안내 문구를 출력한다', async () => {
+    searchPackages.mockResolvedValue([]);
+
+    await searchCommand('nonexistent-package', { type: 'npm', limit: '20' });
+
+    const output = vi.mocked(console.log).mock.calls.flat().join('\n');
+    expect(output).toContain('✓ 0개 결과 찾음');
+    expect(output).toContain('검색 결과가 없습니다');
+  });
+
+  it('npm 검색 실패 시 기존 에러 처리와 동일하게 종료한다', async () => {
+    searchPackages.mockRejectedValue(new Error('Network Error'));
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+
+    await expect(
+      searchCommand('react', { type: 'npm', limit: '20' })
+    ).rejects.toThrow('process.exit');
+
+    const output = vi.mocked(console.log).mock.calls.flat().join('\n');
+    const errors = vi.mocked(console.error).mock.calls.flat().join('\n');
+
+    expect(output).toContain('✗ 검색 실패');
+    expect(errors).toContain('오류: Network Error');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -21,6 +21,8 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
 
   try {
     let results: Array<{ name: string; version: string; description?: string }> = [];
+    const parsedLimit = Number.parseInt(options.limit, 10);
+    const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? 20 : parsedLimit;
 
     // 타입별 다운로더 호출
     switch (options.type) {
@@ -56,7 +58,7 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
 
       case 'npm':
         const npmDownloader = getNpmDownloader();
-        const npmResults = await npmDownloader.searchPackages(query);
+        const npmResults = await npmDownloader.searchPackages(query, limit);
         results = npmResults.map((pkg) => ({
           name: pkg.name,
           version: pkg.version,
@@ -87,7 +89,6 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
     }
 
     // 결과 제한
-    const limit = parseInt(options.limit, 10);
     if (results.length > limit) {
       results = results.slice(0, limit);
     }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -4,6 +4,7 @@ import { PackageType } from '../../types';
 import { getPipDownloader } from '../../core/downloaders/pip';
 import { getCondaDownloader } from '../../core/downloaders/conda';
 import { getMavenDownloader } from '../../core/downloaders/maven';
+import { getNpmDownloader } from '../../core/downloaders/npm';
 import { getDockerDownloader } from '../../core/downloaders/docker';
 
 // 검색 옵션
@@ -47,6 +48,16 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
         const mavenDownloader = getMavenDownloader();
         const mavenResults = await mavenDownloader.searchPackages(query);
         results = mavenResults.map((pkg) => ({
+          name: pkg.name,
+          version: pkg.version,
+          description: pkg.metadata?.description as string,
+        }));
+        break;
+
+      case 'npm':
+        const npmDownloader = getNpmDownloader();
+        const npmResults = await npmDownloader.searchPackages(query);
+        results = npmResults.map((pkg) => ({
           name: pkg.name,
           version: pkg.version,
           description: pkg.metadata?.description as string,


### PR DESCRIPTION
## 요약
- CLI `search -t npm`를 기존 검색 출력 포맷으로 연결했습니다.
- npm 검색 성공/빈 결과/실패 처리와 `-l` 전달을 고정하는 CLI 테스트를 추가했습니다.
- 표준 worktree 검증 진입점(`scripts/ensure_verify_worktree.sh`, `scripts/verify-worktree.sh`)과 관련 테스트 문서를 추가했습니다.

## 배경
- npm downloader에는 검색 구현이 이미 있었지만 CLI `search` 명령에는 연결되지 않아 문서와 동작이 어긋나고 있었습니다.
- 현재 worktree-flow 검증 단계는 저장소 루트의 `scripts/verify-worktree.sh`를 표준 진입점으로 요구하지만, 이 저장소에는 해당 스크립트가 없었습니다.

## 변경 사항
- `src/cli/commands/search.ts`에 npm 분기를 추가하고 npm Registry 조회에도 `-l` 값을 전달하도록 수정했습니다.
- `src/cli/commands/search.test.ts`를 추가해 성공/빈 결과/실패와 limit 전달을 고정했습니다.
- `scripts/ensure_verify_worktree.sh`, `scripts/verify-worktree.sh`를 추가했습니다.
- `README.md`, `docs/cli.md`, `docs/testing.md`, 설계 문서를 업데이트했습니다.

## 검증
- `git diff --check` 통과
- `bash scripts/ensure_verify_worktree.sh "$PWD"` 통과
- `bash scripts/verify-worktree.sh` 실패 (`ERR_MODULE_NOT_FOUND: vitest`, worktree 로컬 의존성 없음)
- GitHub Actions: `Lint`, `Test Coverage`, `Test on macos-latest`, `Test on ubuntu-latest`, `Test on windows-latest` pass

## 문서
- `README.md`
- `docs/cli.md`
- `docs/testing.md`
- `docs/superpowers/specs/2026-04-13-cli-npm-search-design.md`
