### PR TITLE
SMTP 테스트/파일 분할/메일 전달을 다운로드 플로우에 연결

### DIFF
--- a/docs/download-history.md
+++ b/docs/download-history.md
@@ -49,6 +49,9 @@ interface HistorySettings {
   outputFormat: 'zip' | 'tar.gz';
   includeScripts: boolean;
   includeDependencies: boolean;
+  deliveryMethod: 'local' | 'email';
+  fileSplitEnabled?: boolean;
+  maxFileSizeMB?: number;
 }
 ```
 
@@ -63,6 +66,15 @@ interface DownloadHistory {
   packages: HistoryPackageItem[];
   settings: HistorySettings;
   outputPath: string;          // 실제 산출물 경로 (예: /path/to/output.zip)
+  artifactPaths?: string[];    // 실제 산출물 전체 목록
+  deliveryMethod?: 'local' | 'email';
+  deliveryResult?: {
+    emailSent: boolean;
+    emailsSent?: number;
+    attachmentsSent?: number;
+    splitApplied?: boolean;
+    error?: string;
+  };
   totalSize: number;           // 바이트 단위
   status: 'success' | 'partial' | 'failed';
   downloadedCount?: number;    // 성공한 파일 수
@@ -89,7 +101,7 @@ interface HistoryState {
 
 | 액션 | 파라미터 | 설명 |
 |------|----------|------|
-| `addHistory` | packages, settings, outputPath, totalSize, status, downloadedCount?, failedCount? | 히스토리 추가 (시작 시점 설정 스냅샷과 실제 산출물 경로 저장, 100개 초과 시 오래된 것 삭제) |
+| `addHistory` | packages, settings, outputPath, totalSize, status, downloadedCount?, failedCount?, options? | 히스토리 추가 (시작 시점 설정 스냅샷과 실제 산출물/전달 메타데이터 저장, 100개 초과 시 오래된 것 삭제) |
 | `getHistory` | id | ID로 특정 히스토리 조회 |
 | `getHistories` | - | 전체 히스토리 조회 |
 | `deleteHistory` | id | 특정 히스토리 삭제 |
@@ -191,7 +203,7 @@ history: {
 
 ### DownloadPage에서 자동 저장
 
-다운로드 완료 시 (`download:all-complete` 이벤트) 자동으로 히스토리 저장합니다. 아카이브 출력(`zip`, `tar.gz`)에서는 이벤트의 `outputPath`가 실제 생성된 압축 파일 경로를 담고, 그 값이 그대로 히스토리에 저장됩니다.
+다운로드 완료 시 (`download:all-complete` 이벤트) 자동으로 히스토리 저장합니다. 아카이브 출력(`zip`, `tar.gz`)에서는 이벤트의 `outputPath`가 대표 산출물 경로를 담고, `artifactPaths`는 실제 산출물 전체 목록을 담습니다. 이메일 전달에서는 `deliveryMethod=email`과 `deliveryResult`가 함께 저장됩니다.
 
 ```typescript
 // DownloadPage.tsx 내 download:all-complete 핸들러

--- a/docs/download-history.md
+++ b/docs/download-history.md
@@ -50,6 +50,7 @@ interface HistorySettings {
   includeScripts: boolean;
   includeDependencies: boolean;
   deliveryMethod: 'local' | 'email';
+  smtpTo?: string;
   fileSplitEnabled?: boolean;
   maxFileSizeMB?: number;
 }
@@ -195,6 +196,7 @@ history: {
 2. 확인 모달 표시
 3. 패키지들을 장바구니에 추가 (`cartStore.addItem`)
 4. 설정 복원 (`settingsStore.updateSettings`)
+   이메일 전달 히스토리면 저장된 `smtpTo`도 함께 복원
 5. 다운로드 페이지로 이동
 
 ---
@@ -203,7 +205,7 @@ history: {
 
 ### DownloadPage에서 자동 저장
 
-다운로드 완료 시 (`download:all-complete` 이벤트) 자동으로 히스토리 저장합니다. 아카이브 출력(`zip`, `tar.gz`)에서는 이벤트의 `outputPath`가 대표 산출물 경로를 담고, `artifactPaths`는 실제 산출물 전체 목록을 담습니다. 이메일 전달에서는 `deliveryMethod=email`과 `deliveryResult`가 함께 저장됩니다.
+다운로드 완료 시 (`download:all-complete` 이벤트) 자동으로 히스토리 저장합니다. 아카이브 출력(`zip`, `tar.gz`)에서는 이벤트의 `outputPath`가 대표 산출물 경로를 담고, `artifactPaths`는 실제 산출물 전체 목록을 담습니다. 이메일 전달에서는 `deliveryMethod=email`, `deliveryResult`, 그리고 재다운로드 복원용 `settings.smtpTo`가 함께 저장됩니다.
 
 ```typescript
 // DownloadPage.tsx 내 download:all-complete 핸들러

--- a/docs/download-history.md
+++ b/docs/download-history.md
@@ -196,7 +196,7 @@ history: {
 2. 확인 모달 표시
 3. 패키지들을 장바구니에 추가 (`cartStore.addItem`)
 4. 설정 복원 (`settingsStore.updateSettings`)
-   이메일 전달 히스토리면 저장된 `smtpTo`도 함께 복원
+   이메일 수신자(`smtpTo`)는 전역 설정을 바꾸지 않고 재다운로드 세션 상태로만 전달
 5. 다운로드 페이지로 이동
 
 ---

--- a/docs/electron-renderer.md
+++ b/docs/electron-renderer.md
@@ -72,6 +72,7 @@
 - `selectDirectory`
 - `saveFile`
 - `openFolder`
+- `testSmtpConnection`
 
 ### 일반 패키지
 
@@ -137,8 +138,10 @@
 
 ### 일반 패키지
 
-- `DownloadPage`는 설정 스토어의 `defaultOutputFormat`, `includeInstallScripts`를 사용합니다.
+- `DownloadPage`는 설정 스토어의 `defaultOutputFormat`, `includeInstallScripts`, `enableFileSplit`, SMTP 설정을 사용합니다.
+- 다운로드 시작 시 전달 방식 `local | email`을 선택할 수 있고, `email` 선택 시 설정 화면의 SMTP 발신자/수신자와 파일 분할 기준을 함께 전달합니다.
 - 설정 UI와 main process 모두 `zip`과 `tar.gz`를 실제 아카이브 출력 형식으로 사용합니다.
+- 이메일 전달을 선택하면 main process가 패키징 직후 SMTP 발송까지 수행하며, 첨부 크기 초과 시 `FileSplitter`를 사용해 실제 산출물을 분할합니다.
 
 ### OS 패키지
 

--- a/docs/ipc-handlers.md
+++ b/docs/ipc-handlers.md
@@ -112,6 +112,7 @@ electron/
 | `download:cancel` | 취소 |
 | `download:check-path` | 출력 폴더 상태 확인 |
 | `download:clear-path` | 출력 폴더 비우기 |
+| `test-smtp-connection` | SMTP 설정으로 연결 테스트 |
 
 일반 패키지 이벤트:
 
@@ -120,9 +121,10 @@ electron/
 | `download:status` | 전체 단계 상태 |
 | `download:progress` | 개별 패키지 진행률 |
 | `download:deps-resolved` | 다운로드 전 의존성 해결 결과 |
-| `download:all-complete` | 전체 다운로드 완료. `outputPath`는 실제 산출물 경로를 담음 (`.zip`, `.tar.gz`, 또는 취소 시 작업 디렉터리) |
+| `download:all-complete` | 전체 다운로드 완료. `outputPath`는 대표 산출물 경로를, `artifactPaths`는 실제 산출물 목록을 담음. 이메일 전달 시 `deliveryMethod`, `deliveryResult`가 함께 전달됨 |
 
 참고: `dependency:resolve`의 `options.includeDependencies`가 `false`이면 메인 프로세스는 원본 패키지 목록만 반환합니다.
+참고: `download:start`는 `deliveryMethod`, `email`, `smtp`, `fileSplit` 옵션을 받아 패키징 뒤 로컬 저장 또는 이메일 전달까지 수행합니다.
 
 #### OS 패키지 채널
 

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -224,40 +224,35 @@ const scripts = await generator.generateAllScripts({
 
 ```typescript
 interface SplitOptions {
-  inputPath: string;           // 원본 파일 경로
-  outputDir: string;           // 분할 파일 출력 디렉토리
-  chunkSize?: number;          // 분할 크기 (바이트)
+  maxSizeMB?: number;          // 분할 기준 크기 (MB)
   onProgress?: (progress: SplitProgress) => void;
+  generateMergeScripts?: boolean;
 }
 
 interface SplitProgress {
-  current: number;             // 현재 파트 번호
-  total: number;               // 총 파트 수
-  bytesWritten: number;        // 기록된 바이트
+  currentPart: number;         // 현재 파트 번호
+  totalParts: number;          // 총 파트 수
+  processedBytes: number;      // 처리된 바이트
   totalBytes: number;          // 총 바이트
+  percentage: number;
 }
 
 interface SplitResult {
-  success: boolean;
   parts: string[];             // 분할된 파일 경로 목록
   metadata: SplitMetadata;
-  metadataPath: string;
-  mergeScriptBash: string;     // Bash 병합 스크립트 경로
-  mergeScriptPowerShell: string; // PowerShell 병합 스크립트 경로
+  metadataPath?: string;       // 생성된 메타데이터 JSON 경로
+  mergeScripts?: {
+    bash?: string;             // Bash 병합 스크립트 경로
+    powershell?: string;       // PowerShell 병합 스크립트 경로
+  };
 }
 
 interface SplitMetadata {
-  originalName: string;
+  originalFileName: string;
   originalSize: number;
   checksum: string;
-  chunkSize: number;
   partCount: number;
-  parts: Array<{
-    index: number;
-    filename: string;
-    size: number;
-    checksum: string;
-  }>;
+  partSize: number;
   createdAt: string;
 }
 ```
@@ -269,7 +264,7 @@ split/
 ├── packages.zip.part.001
 ├── packages.zip.part.002
 ├── packages.zip.part.003
-├── packages.zip.metadata.json
+├── packages.zip.meta.json
 ├── merge.sh
 └── merge.ps1
 ```
@@ -281,19 +276,19 @@ import { getFileSplitter } from './core/packager/file-splitter';
 const splitter = getFileSplitter();
 
 // 분할
-const result = await splitter.splitFile({
-  inputPath: '/tmp/large-file.zip',
-  outputDir: '/tmp/split',
-  chunkSize: 10 * 1024 * 1024, // 10MB
-  onProgress: (p) => console.log(`Part ${p.current}/${p.total}`)
+const result = await splitter.splitFile('/tmp/large-file.zip', {
+  maxSizeMB: 10,
+  onProgress: (p) => console.log(`Part ${p.currentPart}/${p.totalParts}`)
 });
 
 // 병합
 const joinedPath = await splitter.joinFiles(
-  result.metadataPath,
+  result.metadataPath!,
   '/tmp/restored-file.zip'
 );
 ```
+
+현재 일반 다운로드 이메일 전달 플로우는 첨부 크기 초과 시 `splitFile()`을 호출해 생성된 파트, 메타데이터 JSON, 병합 스크립트를 그대로 메일 첨부 대상으로 사용합니다.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-13-smtp-delivery-download-flow.md
+++ b/docs/superpowers/plans/2026-04-13-smtp-delivery-download-flow.md
@@ -1,0 +1,222 @@
+# SMTP Delivery Download Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 설정 화면의 SMTP/파일 분할 값을 실제 다운로드 완료 전달 플로우에 연결해 `local | email` 전달을 지원한다.
+
+**Architecture:** 렌더러는 전달 방식과 SMTP 설정 스냅샷을 수집해 `download:start` 옵션으로 전달한다. 메인 프로세스의 다운로드 핸들러는 패키징 뒤 로컬 저장 또는 이메일 전달을 수행하고, 필요 시 `FileSplitter`로 실제 산출물을 분할한 뒤 `EmailSender`로 발송한다. 완료 이벤트와 히스토리는 대표 경로와 실제 산출물 목록, 전달 결과를 함께 저장한다.
+
+**Tech Stack:** Electron IPC, React + Zustand, TypeScript, nodemailer, fs-extra, Vitest
+
+---
+
+### Task 1: IPC/타입 계약 고정
+
+**Files:**
+- Modify: `electron/preload.ts`
+- Modify: `src/types/electron.d.ts`
+- Modify: `src/core/shared/types.ts`
+- Modify: `src/types/index.ts`
+- Test: `electron/download-handlers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+확장된 `download:all-complete` payload와 `download:start` 옵션을 사용하는 테스트를 추가한다. `deliveryMethod`, `artifactPaths`, `deliveryResult`가 없어서 실패하도록 만든다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: FAIL because delivery-related fields are not present in the current contract.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`preload`와 Electron 타입 정의에 SMTP 테스트 API, 전달 관련 `download:start` 옵션, 확장된 완료 이벤트 타입을 추가한다. 공유 타입/히스토리 타입에 `deliveryMethod`, `artifactPaths`, `deliveryResult`, `smtpTo`를 반영한다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: PASS for the new contract-level assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/preload.ts src/types/electron.d.ts src/core/shared/types.ts src/types/index.ts electron/download-handlers.test.ts
+git commit -m "feat: 전달 IPC 계약을 확장"
+```
+
+### Task 2: 설정 화면과 다운로드 화면 연결
+
+**Files:**
+- Modify: `src/renderer/stores/settings-store.ts`
+- Modify: `src/renderer/pages/SettingsPage.tsx`
+- Modify: `src/renderer/pages/DownloadPage.tsx`
+- Modify: `src/renderer/stores/history-store.ts`
+- Test: `src/renderer/pages/DownloadPage.tsx` 관련 existing tests if present, otherwise contract validation via handler tests
+
+- [ ] **Step 1: Write the failing test**
+
+설정에서 `smtpTo`를 읽고 다운로드 시작 옵션에 `deliveryMethod`, `email`, `fileSplit`가 전달된다는 시나리오를 테스트에 추가한다. 설정 UI의 SMTP 테스트 버튼이 실제 IPC를 호출한다고 가정하는 케이스도 포함한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: FAIL because renderer does not yet provide delivery/email/fileSplit settings.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`settings-store`에 `smtpTo`를 추가하고 `SettingsPage`에 수신자 입력 필드를 연결한다. `DownloadPage`에 `deliveryMethod` 상태/UI를 추가하고 시작 전 SMTP 필수값 검증과 다운로드 옵션 스냅샷을 구현한다. 히스토리 저장 함수가 확장된 설정/산출물 정보를 받을 수 있도록 맞춘다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: PASS for delivery option propagation assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stores/settings-store.ts src/renderer/pages/SettingsPage.tsx src/renderer/pages/DownloadPage.tsx src/renderer/stores/history-store.ts
+git commit -m "feat: 설정과 다운로드 화면에 이메일 전달 옵션 추가"
+```
+
+### Task 3: SMTP 테스트 IPC 구현
+
+**Files:**
+- Modify: `electron/main.ts`
+- Modify: `src/core/mailer/email-sender.ts`
+- Test: `src/core/mailer/email-sender.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`EmailSender.testConnection()`이 성공/실패 시 구조화된 결과를 반환하거나, IPC 소비에 필요한 오류 메시지를 제공한다는 테스트를 추가한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/core/mailer/email-sender.test.ts`
+Expected: FAIL because SMTP 테스트 결과가 현재 IPC contract 수준으로 노출되지 않는다.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`electron/main.ts`에 `test-smtp-connection` IPC를 등록하고, 전달된 설정으로 `EmailSender`를 생성해 `testConnection()`을 실행한다. `EmailSender`는 오류 메시지를 포함한 결과를 메인 프로세스가 사용할 수 있게 정리한다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/core/mailer/email-sender.test.ts`
+Expected: PASS for SMTP test success/failure assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/main.ts src/core/mailer/email-sender.ts src/core/mailer/email-sender.test.ts
+git commit -m "feat: SMTP 연결 테스트 IPC 구현"
+```
+
+### Task 4: 다운로드 완료 후 이메일 전달 오케스트레이션
+
+**Files:**
+- Modify: `electron/download-handlers.ts`
+- Modify: `src/core/mailer/email-sender.ts`
+- Test: `electron/download-handlers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+다음 시나리오를 `electron/download-handlers.test.ts`에 추가한다.
+
+```ts
+it('email 전달 선택 시 패키징 뒤 메일을 발송한다', async () => {
+  // deliveryMethod=email, split disabled, sendEmail called, outputPath/artifactPaths/deliveryResult returned
+});
+```
+
+추가로 `deliveryMethod=local`이면 메일러가 호출되지 않는다는 회귀 테스트를 둔다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: FAIL because the handler currently only packages and completes locally.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`download:start` 완료 단계에서 `deliveryMethod`를 읽어, `local`이면 기존 동작을 유지하고 `email`이면 메일러를 초기화해 실제 첨부 전달을 수행한다. 전달 성공 시 `artifactPaths`, `deliveryMethod`, `deliveryResult`를 포함해 완료 이벤트를 전송하고, 실패 시 생성된 로컬 산출물 정보를 포함한 실패 이벤트를 보낸다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: PASS for local/email branching tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/download-handlers.ts src/core/mailer/email-sender.ts electron/download-handlers.test.ts
+git commit -m "feat: 다운로드 완료 후 이메일 전달을 연결"
+```
+
+### Task 5: 파일 분할 기반 첨부 전달
+
+**Files:**
+- Modify: `src/core/packager/file-splitter.ts`
+- Modify: `src/core/mailer/email-sender.ts`
+- Modify: `electron/download-handlers.ts`
+- Test: `src/core/packager/file-splitter.test.ts`
+- Test: `src/core/mailer/email-sender.test.ts`
+- Test: `electron/download-handlers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+아카이브 파일이 첨부 제한을 넘고 `enableFileSplit=true`일 때 `splitFile()` 결과의 파트, 메타데이터, 병합 스크립트가 메일 첨부 목록과 완료 이벤트의 `artifactPaths`에 포함된다는 테스트를 추가한다. `enableFileSplit=false`일 때는 전달 실패 테스트를 추가한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/core/packager/file-splitter.test.ts src/core/mailer/email-sender.test.ts electron/download-handlers.test.ts`
+Expected: FAIL because no splitter orchestration exists yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+아카이브 파일 크기와 설정의 `maxFileSize`를 비교해, 필요 시 `FileSplitter.splitFile()`을 호출한다. splitter 결과에서 실제 첨부 파일 목록을 구성하는 헬퍼를 만들고, mailer 반환값에 `attachmentsSent`, `splitApplied`를 반영한다. 분할 비활성화 상태의 초과 크기는 명시적 에러로 종료한다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/core/packager/file-splitter.test.ts src/core/mailer/email-sender.test.ts electron/download-handlers.test.ts`
+Expected: PASS for split/no-split delivery cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/packager/file-splitter.ts src/core/packager/file-splitter.test.ts src/core/mailer/email-sender.ts src/core/mailer/email-sender.test.ts electron/download-handlers.ts electron/download-handlers.test.ts
+git commit -m "feat: 분할 첨부 메일 전달을 지원"
+```
+
+### Task 6: 히스토리/문서 정리와 전체 검증
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/renderer/stores/history-store.ts`
+- Modify: `docs/ipc-handlers.md`
+- Modify: `docs/electron-renderer.md`
+- Modify: `docs/download-history.md`
+- Modify: `docs/packagers.md`
+- Verify: `scripts/verify-worktree.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+히스토리 저장이 `artifactPaths`, `deliveryMethod`, `deliveryResult`를 유지한다고 가정하는 테스트 또는 기존 소비 코드 검증을 추가한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- electron/download-handlers.test.ts`
+Expected: FAIL because history/output metadata is still incomplete.
+
+- [ ] **Step 3: Write minimal implementation**
+
+히스토리 타입/스토어를 확장하고, 문서에서 새 IPC 계약과 이메일 전달/파일 분할 동작을 반영한다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/verify-worktree.sh`
+Expected: PASS if local dependencies are available; otherwise document the failure reason and rely on CI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/index.ts src/renderer/stores/history-store.ts docs/ipc-handlers.md docs/electron-renderer.md docs/download-history.md docs/packagers.md
+git commit -m "docs: 이메일 전달 완료 메타데이터를 반영"
+```

--- a/docs/superpowers/specs/2026-04-13-smtp-delivery-download-flow-design.md
+++ b/docs/superpowers/specs/2026-04-13-smtp-delivery-download-flow-design.md
@@ -1,0 +1,157 @@
+# SMTP Delivery Download Flow Design
+
+## 배경
+
+현재 다운로드 플로우는 패키징이 끝나면 로컬 산출물 경로만 반환하고 종료한다. 설정 화면에는 SMTP 서버 정보와 파일 분할 크기 설정이 있지만, SMTP 연결 테스트 IPC는 실제 구현되어 있지 않고 다운로드 완료 후 실제 메일 전달도 수행되지 않는다. 이 때문에 "메일 전달"은 UI와 타입에는 존재하지만 실제 사용자 플로우에는 연결되지 않은 상태다.
+
+## 목표
+
+- 설정 화면에서 SMTP 발신 설정과 수신자 주소를 저장하고, `testSmtpConnection`을 실제 IPC로 연결한다.
+- 다운로드 화면에서 전달 방식 `local | email`을 선택할 수 있게 하고, 선택값을 실제 다운로드 완료 흐름에 반영한다.
+- 이메일 전달 시 첨부 크기 초과를 감지해 `FileSplitter.splitFile()`로 실제 산출물을 분할한다.
+- 완료 이벤트와 히스토리가 실제 전달 산출물 경로와 전달 결과를 반영하도록 정리한다.
+- 변경 범위는 Electron preload/main/download handler, 설정/다운로드 화면, mailer/file-splitter, 관련 타입/테스트와 문서로 제한한다.
+
+## 비목표
+
+- SMTP OAuth, 템플릿 편집, 주소록 관리 같은 메일 기능 확장은 이번 범위에 포함하지 않는다.
+- 분할 파일 병합 UX를 다운로드 화면에 새로 추가하지 않는다. 기존 splitter가 생성하는 메타데이터/병합 스크립트를 그대로 사용한다.
+- 히스토리 재전송 기능은 이번 작업 범위에 포함하지 않는다. 현재 다운로드 세션의 완료 단계만 연결한다.
+
+## 접근 옵션
+
+### 옵션 1. 다운로드 핸들러가 패키징 후 전달까지 오케스트레이션
+
+- `download:start`가 다운로드, 패키징, 전달(local/email)을 순차 수행한다.
+- 완료 이벤트는 최종 전달 결과와 실제 산출물 목록을 포함한다.
+- 추천한다. 실제 산출물 경로를 알고 있는 메인 프로세스가 파일 분할과 메일 전송까지 이어서 처리하면 상태 정합성이 가장 좋다.
+
+### 옵션 2. 패키징 후 렌더러가 별도 `deliver` IPC 호출
+
+- 메인 프로세스는 패키징까지만 담당하고, 완료 후 렌더러가 전달 방식을 보고 추가 IPC를 호출한다.
+- UI가 단계별로 세분화되지만, 완료 이벤트와 히스토리 저장 타이밍이 이중화되고 실패 복구도 복잡해진다.
+
+### 옵션 3. 로컬 저장만 완료하고 히스토리에서 메일 전송
+
+- 구현은 가장 단순하지만 "현재 다운로드 플로우에 연결" 요구를 만족하지 못한다.
+- 즉시 전달 UX가 아니므로 제외한다.
+
+## 선택 설계
+
+옵션 1을 채택한다. 다운로드 화면에서 전달 방식을 미리 선택하고, 메인 프로세스의 다운로드 핸들러가 패키징 직후 `local` 또는 `email` 전달을 수행한다.
+
+## 설계
+
+### 1. 설정 모델
+
+- `SettingsState`에 `smtpTo`를 추가한다.
+- `SettingsPage`는 발신자(`smtpFrom`)와 별도로 수신자(`smtpTo`)를 입력받는다.
+- SMTP 테스트는 현재 폼 값을 그대로 사용한다. 즉 저장 전 임시 값으로도 테스트 가능해야 한다.
+- 첨부 제한은 기존 `enableFileSplit`, `maxFileSize`를 그대로 사용한다. 단위는 MB로 유지한다.
+
+### 2. 다운로드 화면 계약
+
+- `DownloadPage`에 전달 방식 상태 `deliveryMethod: 'local' | 'email'`를 추가한다.
+- 시작 전에 `deliveryMethod === 'email'`이면 SMTP 필수 항목(`smtpHost`, `smtpPort`, `smtpTo`, 인증 필요 시 `smtpUser`, `smtpPassword`)을 검사한다.
+- 다운로드 시작 시 전달 방식과 메일 설정 스냅샷을 함께 넘긴다.
+- 완료 화면과 히스토리는 전달 결과를 표시할 수 있어야 하므로 실제 산출물 목록과 전달 방식 정보를 소비한다.
+
+### 3. IPC 계약
+
+- `electron/preload.ts`와 `src/types/electron.d.ts`에 아래 계약을 추가한다.
+- `testSmtpConnection(config)`:
+  - 입력: `host`, `port`, `user`, `password`, `from`
+  - 출력: `{ success: boolean, error?: string }`
+- `download:start` options 확장:
+  - `deliveryMethod: 'local' | 'email'`
+  - `email?: { to: string; from?: string; subject?: string }`
+  - `fileSplit?: { enabled: boolean; maxSizeMB: number }`
+- `download:all-complete` payload 확장:
+  - `outputPath`: 대표 산출물 경로
+  - `artifactPaths`: 실제 전달 산출물 경로 목록
+  - `deliveryMethod`
+  - `deliveryResult?: { emailSent: boolean; emailsSent?: number; splitApplied?: boolean; error?: string }`
+
+### 4. 메인 프로세스 오케스트레이션
+
+- `electron/main.ts`에서 SMTP 테스트 IPC를 등록한다. 구현은 `EmailSender.testConnection()`을 직접 사용한다.
+- 전달 오케스트레이션은 별도 핸들러로 분리하지 않고 `electron/download-handlers.ts`에서 수행한다.
+- 흐름은 아래 순서를 따른다.
+  1. 패키지 다운로드
+  2. 필요 시 설치 스크립트 생성
+  3. `zip | tar.gz` 패키징
+  4. `deliveryMethod === 'local'`이면 종료
+  5. `deliveryMethod === 'email'`이면 첨부 가능한 산출물 목록 준비
+  6. 필요 시 `splitFile()` 실행
+  7. `EmailSender.sendEmail()` 호출
+  8. 완료 이벤트 전송
+
+### 5. 이메일 전달 규칙
+
+- 이메일 첨부의 기준 입력은 패키징 산출물 1개다. 즉 `.zip` 또는 `.tar.gz` 파일을 기본 첨부 대상으로 사용한다.
+- `enableFileSplit === true`이고 산출물 크기가 `maxFileSize`를 넘으면 `splitFile()`을 호출한다.
+- `splitFile()` 결과에서는 아래 파일들을 첨부 대상으로 포함한다.
+  - 분할 파트들
+  - 메타데이터 JSON
+  - 생성된 병합 스크립트들(있으면)
+- `EmailSender`는 전달 받은 파일 목록을 그대로 첨부 대상으로 사용한다.
+- 분할 후에도 전체 첨부 크기가 한 번에 제한을 넘으면 `EmailSender`의 기존 다중 메일 전송 로직으로 묶음 분할을 수행한다.
+- `enableFileSplit === false`이고 산출물 크기가 제한을 넘으면 파일 분할을 수행하지 않고 메일 전달 실패로 처리한다. 사용자는 설정을 켜거나 로컬 전달을 선택해야 한다.
+
+### 6. Mailer 정리
+
+- `EmailSender`는 "메일 묶음 분할"과 "파일 분할"을 명확히 구분해야 한다.
+- 파일 분할은 외부에서 수행하고, mailer는 전달 받은 첨부 파일 배열을 메일 단위로 나누는 역할만 맡는다.
+- 반환 타입은 최소한 아래 정보를 제공해야 한다.
+  - `success`
+  - `messageId`
+  - `emailsSent`
+  - `attachmentsSent`
+  - `splitApplied`
+  - `error`
+
+### 7. 히스토리/완료 이벤트
+
+- 히스토리에는 기존 `outputPath` 외에 `artifactPaths`, `deliveryMethod`, `deliveryResult`를 저장한다.
+- `outputPath`는 대표 경로로 유지한다.
+  - 로컬 전달: 아카이브 파일 경로
+  - 이메일 전달 + 분할 없음: 아카이브 파일 경로
+  - 이메일 전달 + 분할 있음: 첫 번째 분할 산출물 경로
+- `HistoryPage`의 기존 "폴더 열기" 동작은 대표 경로 기준으로 유지한다.
+
+## 오류 처리
+
+- SMTP 테스트 실패는 저장과 별개로 즉시 에러 메시지를 반환한다.
+- 이메일 전달 선택 시 SMTP 설정이 불완전하면 다운로드 시작 전에 차단한다.
+- 패키징 성공 후 메일 전달이 실패하면 전체 작업은 실패로 간주한다.
+  - 이유: 사용자가 선택한 전달 방식이 완료되지 않았기 때문이다.
+  - 단, 로컬 아카이브 자체는 이미 생성되어 있으므로 `artifactPaths`와 `outputPath`는 반환해 사용자가 수동 복구할 수 있게 한다.
+- 분할 도중 실패하면 메일 전송을 시도하지 않는다.
+
+## 테스트 전략
+
+### 우선 실패시킬 테스트
+
+- `electron/download-handlers.test.ts`
+  - `deliveryMethod=local`이면 기존처럼 메일러/분할기를 호출하지 않는다.
+  - `deliveryMethod=email`이면 SMTP 설정으로 메일러를 초기화하고 발송한다.
+  - 파일 크기 초과 + 파일 분할 활성화 시 `splitFile()`이 호출되고 분할 산출물이 완료 이벤트에 반영된다.
+  - 파일 크기 초과 + 파일 분할 비활성화 시 실패 이벤트를 보낸다.
+- `src/core/mailer/email-sender.test.ts`
+  - `testConnection()`의 성공/실패 결과를 IPC 소비에 맞는 구조로 유지한다.
+  - 전달된 첨부 파일 목록 기준으로 `attachmentsSent`, `splitApplied`, `emailsSent`가 반환된다.
+- `src/core/packager/file-splitter.test.ts`
+  - 분할 결과가 대표 파일 외 메타데이터/병합 스크립트까지 소비 가능하도록 검증한다.
+
+### 검증
+
+- 저장소 표준 테스트 엔트리(`scripts/verify-worktree.sh`)로 전체 단위 테스트를 실행한다.
+- 로컬 의존성이 없으면 CI 결과를 최종 근거로 사용한다.
+
+## 문서 영향
+
+- `docs/ipc-handlers.md`
+- `docs/electron-renderer.md`
+- `docs/download-history.md`
+- `docs/packagers.md`
+- 필요 시 설정 화면/메일 전달 관련 운영 문서

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -686,6 +686,10 @@ describe('registerDownloadHandlers', () => {
       }
     );
 
+    await waitForExpectation(() => {
+      expect(downloadFileMock).toHaveBeenCalled();
+    });
+
     await downloadCancelHandler({});
     resolveDownload();
 

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -626,6 +626,84 @@ describe('registerDownloadHandlers', () => {
     });
   });
 
+  it('다운로드 완료 직후 취소되면 패키징과 메일 전달 없이 cancelled 완료 이벤트로 끝나야 함', async () => {
+    let resolveDownload!: () => void;
+    downloadFileMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        })
+    );
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+    const downloadCancelHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:cancel'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+    expect(downloadCancelHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'cancelled-before-packaging-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 10,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+          },
+        },
+      }
+    );
+
+    await downloadCancelHandler({});
+    resolveDownload();
+
+    await waitForExpectation(() => {
+      expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
+      expect(initializeEmailSenderMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          cancelled: true,
+          outputPath: outputDir,
+        })
+      );
+    });
+  });
+
   it('첨부 제한 초과이고 파일 분할이 켜져 있으면 splitFile 결과를 첨부와 완료 이벤트에 반영해야 함', async () => {
     createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
       await fs.ensureDir(path.dirname(outputPath));

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -644,6 +644,71 @@ describe('registerDownloadHandlers', () => {
     });
   });
 
+  it('발신자 후보가 없으면 이메일 전달을 시작하지 않고 명시적으로 실패해야 함', async () => {
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'missing-from-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 10,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(initializeEmailSenderMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: `${outputDir}.tar.gz`,
+          deliveryMethod: 'email',
+          deliveryResult: expect.objectContaining({
+            emailSent: false,
+            error: '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.',
+          }),
+        })
+      );
+    });
+  });
+
   it('첨부 제한 초과인데 파일 분할이 꺼져 있으면 메일 전달 실패로 처리해야 함', async () => {
     createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
       await fs.ensureDir(path.dirname(outputPath));

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -441,11 +441,15 @@ describe('registerDownloadHandlers', () => {
     );
 
     await waitForExpectation(() => {
-      expect(webContentsSend).toHaveBeenCalledWith('download:all-complete', {
-        success: false,
-        outputPath: outputDir,
-        error: 'archive failed',
-      });
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: outputDir,
+          error: 'archive failed',
+          results: [expect.objectContaining({ id: 'pip-requests-2.28.0', success: true })],
+        })
+      );
     });
     expect(webContentsSend).not.toHaveBeenCalledWith('download:all-complete', {
       success: true,
@@ -490,11 +494,15 @@ describe('registerDownloadHandlers', () => {
     );
 
     await waitForExpectation(() => {
-      expect(webContentsSend).toHaveBeenCalledWith('download:all-complete', {
-        success: false,
-        outputPath: outputDir,
-        error: '지원하지 않는 출력 형식입니다: archive',
-      });
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: outputDir,
+          error: '지원하지 않는 출력 형식입니다: archive',
+          results: [expect.objectContaining({ id: 'pip-requests-2.28.0', success: true })],
+        })
+      );
     });
     expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
   });
@@ -1104,7 +1112,7 @@ describe('registerDownloadHandlers', () => {
       expect.any(Map),
       expect.objectContaining({
         packageManager: 'yum',
-        outputPath: `${osOutputDir}/repository`,
+        outputPath: path.join(osOutputDir, 'repository'),
       })
     );
     expect(webContentsSend).toHaveBeenCalledWith(

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -552,6 +552,80 @@ describe('registerDownloadHandlers', () => {
     });
   });
 
+  it('성공한 패키지가 하나도 없으면 패키징과 메일 전달 없이 실패해야 함', async () => {
+    downloadFileMock.mockRejectedValue(new Error('network failed'));
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'all-failed-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: true,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 10,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(generateInstallScriptsMock).not.toHaveBeenCalled();
+      expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
+      expect(initializeEmailSenderMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: outputDir,
+          deliveryMethod: 'email',
+          error: '다운로드에 성공한 패키지가 없습니다.',
+          results: [
+            {
+              id: 'pip-requests-2.28.0',
+              success: false,
+              error: 'network failed',
+            },
+          ],
+        })
+      );
+    });
+  });
+
   it('첨부 제한 초과이고 파일 분할이 켜져 있으면 splitFile 결과를 첨부와 완료 이벤트에 반영해야 함', async () => {
     createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
       await fs.ensureDir(path.dirname(outputPath));

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -457,6 +457,101 @@ describe('registerDownloadHandlers', () => {
     });
   });
 
+  it('부분 성공 다운로드에서는 실제 성공한 패키지만 메일 메타데이터와 스크립트에 반영해야 함', async () => {
+    downloadFileMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('network failed'));
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'partial-email-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+          {
+            id: 'pip-urllib3-2.1.0',
+            type: 'pip',
+            name: 'urllib3',
+            version: '2.1.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: true,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 10,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+            password: 'secret',
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(generateInstallScriptsMock).toHaveBeenCalledWith(
+        outputDir,
+        [
+          expect.objectContaining({
+            id: 'pip-requests-2.28.0',
+            name: 'requests',
+          }),
+        ]
+      );
+      expect(createArchiveFromDirectoryMock).toHaveBeenCalledWith(
+        outputDir,
+        `${outputDir}.tar.gz`,
+        [
+          expect.objectContaining({
+            name: 'requests',
+            version: '2.28.0',
+          }),
+        ],
+        expect.any(Object)
+      );
+      expect(sendEmailMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: 'DepsSmuggler 패키지 전달 (1개 패키지)',
+          body: expect.stringContaining('다운로드 실패한 1개 패키지는 이번 전달에서 제외되었습니다.'),
+          packages: [
+            expect.objectContaining({
+              name: 'requests',
+              version: '2.28.0',
+            }),
+          ],
+        })
+      );
+    });
+  });
+
   it('첨부 제한 초과이고 파일 분할이 켜져 있으면 splitFile 결과를 첨부와 완료 이벤트에 반영해야 함', async () => {
     createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
       await fs.ensureDir(path.dirname(outputPath));

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
 import { registerDownloadHandlers } from './download-handlers';
 
 const {
@@ -9,6 +12,10 @@ const {
   generateInstallScriptsMock,
   createZipArchiveMock,
   createArchiveFromDirectoryMock,
+  initializeEmailSenderMock,
+  sendEmailMock,
+  getFileSplitterMock,
+  splitFileMock,
 } = vi.hoisted(() => ({
   ipcHandle: vi.fn(),
   webContentsSend: vi.fn(),
@@ -17,6 +24,10 @@ const {
   generateInstallScriptsMock: vi.fn(),
   createZipArchiveMock: vi.fn(),
   createArchiveFromDirectoryMock: vi.fn(),
+  initializeEmailSenderMock: vi.fn(),
+  sendEmailMock: vi.fn(),
+  getFileSplitterMock: vi.fn(),
+  splitFileMock: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -63,6 +74,14 @@ vi.mock('../src/core/packager/archive-packager', () => ({
   })),
 }));
 
+vi.mock('../src/core/mailer/email-sender', () => ({
+  initializeEmailSender: initializeEmailSenderMock,
+}));
+
+vi.mock('../src/core/packager/file-splitter', () => ({
+  getFileSplitter: getFileSplitterMock,
+}));
+
 const waitForExpectation = async (assertion: () => void, timeoutMs = 2000): Promise<void> => {
   const startTime = Date.now();
   let lastError: unknown;
@@ -81,8 +100,11 @@ const waitForExpectation = async (assertion: () => void, timeoutMs = 2000): Prom
 };
 
 describe('registerDownloadHandlers', () => {
+  let tempDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    tempDir = path.join(os.tmpdir(), `download-handler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 
     getPyPIDownloadUrlMock.mockResolvedValue({
       url: 'https://example.com/requests-2.28.0.whl',
@@ -91,7 +113,44 @@ describe('registerDownloadHandlers', () => {
     downloadFileMock.mockResolvedValue(undefined);
     generateInstallScriptsMock.mockResolvedValue(undefined);
     createZipArchiveMock.mockResolvedValue(undefined);
-    createArchiveFromDirectoryMock.mockImplementation(async (_sourceDir: string, outputPath: string) => outputPath);
+    createArchiveFromDirectoryMock.mockImplementation(async (_sourceDir: string, outputPath: string) => {
+      await fs.ensureDir(path.dirname(outputPath));
+      await fs.writeFile(outputPath, Buffer.alloc(1024));
+      return outputPath;
+    });
+    sendEmailMock.mockResolvedValue({
+      success: true,
+      messageId: 'mail-1',
+      emailsSent: 1,
+      attachmentsSent: 1,
+      splitApplied: false,
+    });
+    initializeEmailSenderMock.mockReturnValue({
+      sendEmail: sendEmailMock,
+      testConnection: vi.fn(),
+    });
+    splitFileMock.mockResolvedValue({
+      parts: [
+        path.join(tempDir, 'bundle.tar.gz.part001'),
+        path.join(tempDir, 'bundle.tar.gz.part002'),
+      ],
+      metadataPath: path.join(tempDir, 'bundle.tar.gz.meta.json'),
+      metadata: {
+        originalFileName: 'bundle.tar.gz',
+        originalSize: 2048,
+        partCount: 2,
+        partSize: 1024,
+        checksum: 'abc',
+        createdAt: new Date().toISOString(),
+      },
+      mergeScripts: {
+        bash: path.join(tempDir, 'merge.sh'),
+        powershell: path.join(tempDir, 'merge.ps1'),
+      },
+    });
+    getFileSplitterMock.mockReturnValue({
+      splitFile: splitFileMock,
+    });
   });
 
   it('tar.gz 선택 시 공통 아카이브 패키저를 사용하고 실제 산출물 경로를 완료 이벤트에 담아야 함', async () => {
@@ -148,17 +207,23 @@ describe('registerDownloadHandlers', () => {
     });
 
     await waitForExpectation(() => {
-      expect(webContentsSend).toHaveBeenCalledWith('download:all-complete', {
-        success: true,
-        outputPath: expectedArchivePath,
-        results: [
-          {
-            id: 'pip-requests-2.28.0',
-            success: true,
-          },
-        ],
-      });
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: true,
+          outputPath: expectedArchivePath,
+          artifactPaths: [expectedArchivePath],
+          deliveryMethod: 'local',
+          results: [
+            {
+              id: 'pip-requests-2.28.0',
+              success: true,
+            },
+          ],
+        })
+      );
     });
+    expect(initializeEmailSenderMock).not.toHaveBeenCalled();
   });
 
   it('zip 선택 시에도 완료 이벤트가 디렉터리가 아닌 실제 아카이브 파일 경로를 반영해야 함', async () => {
@@ -198,17 +263,23 @@ describe('registerDownloadHandlers', () => {
     );
 
     await waitForExpectation(() => {
-      expect(webContentsSend).toHaveBeenCalledWith('download:all-complete', {
-        success: true,
-        outputPath: expectedArchivePath,
-        results: [
-          {
-            id: 'pip-requests-2.28.0',
-            success: true,
-          },
-        ],
-      });
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: true,
+          outputPath: expectedArchivePath,
+          artifactPaths: [expectedArchivePath],
+          deliveryMethod: 'local',
+          results: [
+            {
+              id: 'pip-requests-2.28.0',
+              success: true,
+            },
+          ],
+        })
+      );
     });
+    expect(initializeEmailSenderMock).not.toHaveBeenCalled();
   });
 
   it('아카이브 생성이 실패하면 성공 완료 이벤트 대신 실패 이벤트를 보내야 함', async () => {
@@ -305,5 +376,246 @@ describe('registerDownloadHandlers', () => {
       });
     });
     expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
+  });
+
+  it('email 전달 선택 시 패키징 뒤 메일을 발송하고 완료 이벤트에 전달 메타데이터를 담아야 함', async () => {
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'email-output');
+    const expectedArchivePath = `${outputDir}.tar.gz`;
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+            from: 'sender@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 10,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+            password: 'secret',
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(initializeEmailSenderMock).toHaveBeenCalled();
+      expect(sendEmailMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'offline@example.com',
+          attachments: [expectedArchivePath],
+        })
+      );
+    });
+
+    await waitForExpectation(() => {
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: true,
+          outputPath: expectedArchivePath,
+          artifactPaths: [expectedArchivePath],
+          deliveryMethod: 'email',
+          deliveryResult: expect.objectContaining({
+            emailSent: true,
+            emailsSent: 1,
+            splitApplied: false,
+          }),
+        })
+      );
+    });
+  });
+
+  it('첨부 제한 초과이고 파일 분할이 켜져 있으면 splitFile 결과를 첨부와 완료 이벤트에 반영해야 함', async () => {
+    createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
+      await fs.ensureDir(path.dirname(outputPath));
+      await fs.writeFile(outputPath, Buffer.alloc(4 * 1024));
+      return outputPath;
+    });
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'split-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: true,
+            maxSizeMB: 0.001,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+            password: 'secret',
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(splitFileMock).toHaveBeenCalled();
+      expect(sendEmailMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            path.join(tempDir, 'bundle.tar.gz.part001'),
+            path.join(tempDir, 'bundle.tar.gz.part002'),
+            path.join(tempDir, 'bundle.tar.gz.meta.json'),
+            path.join(tempDir, 'merge.sh'),
+            path.join(tempDir, 'merge.ps1'),
+          ]),
+        })
+      );
+    });
+
+    await waitForExpectation(() => {
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: true,
+          outputPath: path.join(tempDir, 'bundle.tar.gz.part001'),
+          artifactPaths: expect.arrayContaining([
+            path.join(tempDir, 'bundle.tar.gz.part001'),
+            path.join(tempDir, 'bundle.tar.gz.part002'),
+            path.join(tempDir, 'bundle.tar.gz.meta.json'),
+            path.join(tempDir, 'merge.sh'),
+            path.join(tempDir, 'merge.ps1'),
+          ]),
+          deliveryMethod: 'email',
+          deliveryResult: expect.objectContaining({
+            splitApplied: true,
+          }),
+        })
+      );
+    });
+  });
+
+  it('첨부 제한 초과인데 파일 분할이 꺼져 있으면 메일 전달 실패로 처리해야 함', async () => {
+    createArchiveFromDirectoryMock.mockImplementationOnce(async (_sourceDir: string, outputPath: string) => {
+      await fs.ensureDir(path.dirname(outputPath));
+      await fs.writeFile(outputPath, Buffer.alloc(4 * 1024));
+      return outputPath;
+    });
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = path.join(tempDir, 'split-disabled-output');
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+          deliveryMethod: 'email',
+          email: {
+            to: 'offline@example.com',
+          },
+          fileSplit: {
+            enabled: false,
+            maxSizeMB: 0.001,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 587,
+            user: 'sender@example.com',
+            password: 'secret',
+          },
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(splitFileMock).not.toHaveBeenCalled();
+      expect(sendEmailMock).not.toHaveBeenCalled();
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: `${outputDir}.tar.gz`,
+          artifactPaths: [`${outputDir}.tar.gz`],
+          deliveryMethod: 'email',
+        })
+      );
+    });
   });
 });

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -507,6 +507,59 @@ describe('registerDownloadHandlers', () => {
     expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
   });
 
+  it('설치 스크립트 생성 실패도 results를 포함한 실패 완료 이벤트로 내려보내야 함', async () => {
+    generateInstallScriptsMock.mockImplementationOnce(() => {
+      throw new Error('script generation failed');
+    });
+
+    registerDownloadHandlers(() => ({
+      webContents: {
+        send: webContentsSend,
+      },
+    }) as never);
+
+    const downloadStartHandler = ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'download:start'
+    )?.[1];
+
+    expect(downloadStartHandler).toBeTypeOf('function');
+
+    const outputDir = '/tmp/depssmuggler-gui-output-script-failure';
+
+    await downloadStartHandler(
+      {},
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.28.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.28.0',
+          },
+        ],
+        options: {
+          outputDir,
+          outputFormat: 'zip',
+          includeScripts: true,
+          concurrency: 1,
+        },
+      }
+    );
+
+    await waitForExpectation(() => {
+      expect(webContentsSend).toHaveBeenCalledWith(
+        'download:all-complete',
+        expect.objectContaining({
+          success: false,
+          outputPath: outputDir,
+          error: 'script generation failed',
+          results: [expect.objectContaining({ id: 'pip-requests-2.28.0', success: true })],
+        })
+      );
+    });
+    expect(createArchiveFromDirectoryMock).not.toHaveBeenCalled();
+  });
+
   it('email 전달 선택 시 패키징 뒤 메일을 발송하고 완료 이벤트에 전달 메타데이터를 담아야 함', async () => {
     registerDownloadHandlers(() => ({
       webContents: {
@@ -1137,11 +1190,11 @@ describe('registerDownloadHandlers', () => {
         generatedOutputs: expect.arrayContaining([
           expect.objectContaining({
             type: 'archive',
-            path: `${osOutputDir}/os-packages.zip`,
+            path: path.join(osOutputDir, 'os-packages.zip'),
           }),
           expect.objectContaining({
             type: 'repository',
-            path: `${osOutputDir}/repository`,
+            path: path.join(osOutputDir, 'repository'),
           }),
         ]),
         warnings: [],

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -749,7 +749,19 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
 
           // 설치 스크립트 생성 (의존성 포함)
           if (includeScripts) {
-            generateInstallScripts(outputDir, deliveredPackages);
+            try {
+              generateInstallScripts(outputDir, deliveredPackages);
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              log.error('Failed to generate install scripts:', error);
+              mainWindow?.webContents.send('download:all-complete', {
+                success: false,
+                outputPath: outputDir,
+                error: errorMessage,
+                results,
+              });
+              return;
+            }
           }
 
           if (!isSupportedOutputFormat) {

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -446,6 +446,28 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
       Promise.all(downloadPromises).then(async (downloadResults) => {
         // 취소된 항목 제외하고 결과 수집
         const results = downloadResults.filter(r => r.error !== 'cancelled');
+        const emitCancelledCompletion = (
+          currentOutputPath: string,
+          currentArtifactPaths?: string[]
+        ): void => {
+          mainWindow?.webContents.send('download:all-complete', {
+            success: false,
+            cancelled: true,
+            outputPath: currentOutputPath,
+            artifactPaths: currentArtifactPaths,
+          });
+        };
+        const shouldStopForCancellation = (
+          currentOutputPath: string,
+          currentArtifactPaths?: string[]
+        ): boolean => {
+          if (!downloadCancelled) {
+            return false;
+          }
+
+          emitCancelledCompletion(currentOutputPath, currentArtifactPaths);
+          return true;
+        };
 
         if (!downloadCancelled) {
           let finalOutputPath = outputDir;
@@ -500,6 +522,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             return;
           }
 
+          if (shouldStopForCancellation(finalOutputPath, artifactPaths)) {
+            return;
+          }
+
           if (isSupportedOutputFormat) {
             try {
               const archivePath = `${outputDir}.${outputFormat === 'zip' ? 'zip' : 'tar.gz'}`;
@@ -533,6 +559,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
               });
               return;
             }
+          }
+
+          if (shouldStopForCancellation(finalOutputPath, artifactPaths)) {
+            return;
           }
 
           if (deliveryMethod === 'email') {
@@ -584,6 +614,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             });
 
             try {
+              if (shouldStopForCancellation(finalOutputPath, artifactPaths)) {
+                return;
+              }
+
               const archiveStat = await fse.stat(finalOutputPath);
 
               if (archiveStat.size > maxAttachmentSizeBytes) {
@@ -613,6 +647,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                 artifactPaths = attachments;
                 finalOutputPath = attachments[0] || finalOutputPath;
                 splitApplied = true;
+              }
+
+              if (shouldStopForCancellation(finalOutputPath, attachments)) {
+                return;
               }
 
               const emailSender = initializeEmailSender(
@@ -647,6 +685,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                 attachments,
                 packages: packageInfos,
               });
+
+              if (shouldStopForCancellation(finalOutputPath, attachments)) {
+                return;
+              }
 
               if (!emailSendResult.success) {
                 const errorMessage = emailSendResult.error || '이메일 전달에 실패했습니다';
@@ -690,6 +732,10 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
               });
               return;
             }
+          }
+
+          if (shouldStopForCancellation(finalOutputPath, artifactPaths.length > 0 ? artifactPaths : [finalOutputPath])) {
+            return;
           }
 
           // 전체 완료 이벤트 전송

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -757,6 +757,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
               success: false,
               outputPath: outputDir,
               error: `지원하지 않는 출력 형식입니다: ${String(outputFormat)}`,
+              results,
             });
             return;
           }
@@ -795,6 +796,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                 success: false,
                 outputPath: outputDir,
                 error: errorMessage,
+                results,
               });
               return;
             }
@@ -822,6 +824,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                   error: errorMessage,
                 },
                 error: errorMessage,
+                results,
               });
               return;
             }
@@ -839,6 +842,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                   error: errorMessage,
                 },
                 error: errorMessage,
+                results,
               });
               return;
             }
@@ -873,6 +877,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                       error: errorMessage,
                     },
                     error: errorMessage,
+                    results,
                   });
                   return;
                 }
@@ -940,6 +945,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                     error: errorMessage,
                   },
                   error: errorMessage,
+                  results,
                 });
                 return;
               }
@@ -964,6 +970,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                   error: errorMessage,
                 },
                 error: errorMessage,
+                results,
               });
               return;
             }

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -28,6 +28,8 @@ import {
   getApkResolver,
 } from '../src/core';
 import { getArchivePackager } from '../src/core/packager/archive-packager';
+import { getFileSplitter } from '../src/core/packager/file-splitter';
+import { initializeEmailSender } from '../src/core/mailer/email-sender';
 import type { PackageInfo } from '../src/types';
 import type {
   OSPackageInfo,
@@ -77,6 +79,22 @@ function sendProgressThrottled(
       ...data,
     });
   }
+}
+
+function collectSplitArtifacts(splitResult: {
+  parts: string[];
+  metadataPath?: string;
+  mergeScripts?: {
+    bash?: string;
+    powershell?: string;
+  };
+}): string[] {
+  return [
+    ...splitResult.parts,
+    splitResult.metadataPath,
+    splitResult.mergeScripts?.bash,
+    splitResult.mergeScripts?.powershell,
+  ].filter((value): value is string => Boolean(value));
 }
 
 // 다운로드 상태
@@ -431,6 +449,24 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
 
         if (!downloadCancelled) {
           let finalOutputPath = outputDir;
+          let artifactPaths: string[] = [];
+          const deliveryMethod = options.deliveryMethod || 'local';
+          const packageInfos: PackageInfo[] = allPackages.map((pkg) => ({
+            type: pkg.type as PackageInfo['type'],
+            name: pkg.name,
+            version: pkg.version,
+            arch: pkg.architecture as PackageInfo['arch'],
+            metadata: pkg.metadata,
+          }));
+          let deliveryResult:
+            | {
+                emailSent: boolean;
+                emailsSent?: number;
+                attachmentsSent?: number;
+                splitApplied?: boolean;
+                error?: string;
+              }
+            | undefined;
           const isSupportedOutputFormat = outputFormat === 'zip' || outputFormat === 'tar.gz';
 
           // 설치 스크립트 생성 (의존성 포함)
@@ -451,13 +487,6 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             try {
               const archivePath = `${outputDir}.${outputFormat === 'zip' ? 'zip' : 'tar.gz'}`;
               const archivePackager = getArchivePackager();
-              const packageInfos: PackageInfo[] = allPackages.map((pkg) => ({
-                type: pkg.type as PackageInfo['type'],
-                name: pkg.name,
-                version: pkg.version,
-                arch: pkg.architecture as PackageInfo['arch'],
-                metadata: pkg.metadata,
-              }));
 
               mainWindow?.webContents.send('download:status', {
                 phase: 'packaging',
@@ -474,6 +503,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                   includeReadme: true,
                 }
               );
+              artifactPaths = [finalOutputPath];
 
               log.info(`Created ${outputFormat} archive: ${finalOutputPath}`);
             } catch (error) {
@@ -488,10 +518,145 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             }
           }
 
+          if (deliveryMethod === 'email') {
+            const smtpOptions = options.smtp;
+            const emailOptions = options.email;
+
+            if (!smtpOptions?.host || !smtpOptions.port || !emailOptions?.to) {
+              const errorMessage = '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다';
+              mainWindow?.webContents.send('download:all-complete', {
+                success: false,
+                outputPath: finalOutputPath,
+                artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+                deliveryMethod,
+                deliveryResult: {
+                  emailSent: false,
+                  splitApplied: false,
+                  error: errorMessage,
+                },
+                error: errorMessage,
+              });
+              return;
+            }
+
+            const maxAttachmentSizeBytes = (options.fileSplit?.maxSizeMB ?? 25) * 1024 * 1024;
+            let attachments = artifactPaths.length > 0 ? [...artifactPaths] : [finalOutputPath];
+            let splitApplied = false;
+
+            mainWindow?.webContents.send('download:status', {
+              phase: 'packaging',
+              message: '이메일 전달 준비 중...',
+            });
+
+            try {
+              const archiveStat = await fse.stat(finalOutputPath);
+
+              if (archiveStat.size > maxAttachmentSizeBytes) {
+                if (!options.fileSplit?.enabled) {
+                  const errorMessage = '첨부 파일 크기가 제한을 초과했습니다. 파일 분할을 활성화하세요.';
+                  mainWindow?.webContents.send('download:all-complete', {
+                    success: false,
+                    outputPath: finalOutputPath,
+                    artifactPaths: [finalOutputPath],
+                    deliveryMethod,
+                    deliveryResult: {
+                      emailSent: false,
+                      splitApplied: false,
+                      error: errorMessage,
+                    },
+                    error: errorMessage,
+                  });
+                  return;
+                }
+
+                const splitter = getFileSplitter();
+                const splitResult = await splitter.splitFile(finalOutputPath, {
+                  maxSizeMB: options.fileSplit.maxSizeMB,
+                  generateMergeScripts: true,
+                });
+                attachments = collectSplitArtifacts(splitResult);
+                artifactPaths = attachments;
+                finalOutputPath = attachments[0] || finalOutputPath;
+                splitApplied = true;
+              }
+
+              const emailSender = initializeEmailSender(
+                {
+                  host: smtpOptions.host,
+                  port: smtpOptions.port,
+                  secure: smtpOptions.secure ?? smtpOptions.port === 465,
+                  auth: smtpOptions.user
+                    ? {
+                        user: smtpOptions.user,
+                        pass: smtpOptions.password || '',
+                      }
+                    : undefined,
+                  from: emailOptions.from || smtpOptions.from,
+                },
+                maxAttachmentSizeBytes
+              );
+
+              const emailSendResult = await emailSender.sendEmail({
+                to: emailOptions.to,
+                subject: emailOptions.subject || `DepsSmuggler 패키지 전달 (${packageInfos.length}개 패키지)`,
+                body: splitApplied
+                  ? '첨부 용량 제한에 맞춰 파일을 분할해 전달했습니다.'
+                  : '다운로드된 패키지 아카이브를 전달합니다.',
+                attachments,
+                packages: packageInfos,
+              });
+
+              if (!emailSendResult.success) {
+                const errorMessage = emailSendResult.error || '이메일 전달에 실패했습니다';
+                mainWindow?.webContents.send('download:all-complete', {
+                  success: false,
+                  outputPath: finalOutputPath,
+                  artifactPaths: attachments,
+                  deliveryMethod,
+                  deliveryResult: {
+                    emailSent: false,
+                    emailsSent: emailSendResult.emailsSent,
+                    attachmentsSent: emailSendResult.attachmentsSent,
+                    splitApplied,
+                    error: errorMessage,
+                  },
+                  error: errorMessage,
+                });
+                return;
+              }
+
+              deliveryResult = {
+                emailSent: true,
+                emailsSent: emailSendResult.emailsSent,
+                attachmentsSent: emailSendResult.attachmentsSent,
+                splitApplied,
+              };
+              artifactPaths = attachments;
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              mainWindow?.webContents.send('download:all-complete', {
+                success: false,
+                outputPath: finalOutputPath,
+                artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+                deliveryMethod,
+                deliveryResult: {
+                  emailSent: false,
+                  splitApplied,
+                  error: errorMessage,
+                },
+                error: errorMessage,
+              });
+              return;
+            }
+          }
+
           // 전체 완료 이벤트 전송
           mainWindow?.webContents.send('download:all-complete', {
             success: true,
             outputPath: finalOutputPath,
+            artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+            deliveryMethod,
+            deliveryResult,
             results,
           });
         } else {

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -474,6 +474,18 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             | undefined;
           const isSupportedOutputFormat = outputFormat === 'zip' || outputFormat === 'tar.gz';
 
+          if (successfulPackageIds.size === 0) {
+            const errorMessage = '다운로드에 성공한 패키지가 없습니다.';
+            mainWindow?.webContents.send('download:all-complete', {
+              success: false,
+              outputPath: outputDir,
+              deliveryMethod,
+              error: errorMessage,
+              results,
+            });
+            return;
+          }
+
           // 설치 스크립트 생성 (의존성 포함)
           if (includeScripts) {
             generateInstallScripts(outputDir, deliveredPackages);

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -686,10 +686,6 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                 packages: packageInfos,
               });
 
-              if (shouldStopForCancellation(finalOutputPath, attachments)) {
-                return;
-              }
-
               if (!emailSendResult.success) {
                 const errorMessage = emailSendResult.error || '이메일 전달에 실패했습니다';
                 mainWindow?.webContents.send('download:all-complete', {
@@ -734,7 +730,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
             }
           }
 
-          if (shouldStopForCancellation(finalOutputPath, artifactPaths.length > 0 ? artifactPaths : [finalOutputPath])) {
+          if (!deliveryResult?.emailSent && shouldStopForCancellation(finalOutputPath, artifactPaths.length > 0 ? artifactPaths : [finalOutputPath])) {
             return;
           }
 

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -451,13 +451,18 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
           let finalOutputPath = outputDir;
           let artifactPaths: string[] = [];
           const deliveryMethod = options.deliveryMethod || 'local';
-          const packageInfos: PackageInfo[] = allPackages.map((pkg) => ({
+          const successfulPackageIds = new Set(
+            results.filter((result) => result.success).map((result) => result.id)
+          );
+          const deliveredPackages = allPackages.filter((pkg) => successfulPackageIds.has(pkg.id));
+          const packageInfos: PackageInfo[] = deliveredPackages.map((pkg) => ({
             type: pkg.type as PackageInfo['type'],
             name: pkg.name,
             version: pkg.version,
             arch: pkg.architecture as PackageInfo['arch'],
             metadata: pkg.metadata,
           }));
+          const failedDownloadCount = results.filter((result) => !result.success).length;
           let deliveryResult:
             | {
                 emailSent: boolean;
@@ -471,7 +476,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
 
           // 설치 스크립트 생성 (의존성 포함)
           if (includeScripts) {
-            generateInstallScripts(outputDir, allPackages);
+            generateInstallScripts(outputDir, deliveredPackages);
           }
 
           if (!isSupportedOutputFormat) {
@@ -599,9 +604,16 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
               const emailSendResult = await emailSender.sendEmail({
                 to: emailOptions.to,
                 subject: emailOptions.subject || `DepsSmuggler 패키지 전달 (${packageInfos.length}개 패키지)`,
-                body: splitApplied
-                  ? '첨부 용량 제한에 맞춰 파일을 분할해 전달했습니다.'
-                  : '다운로드된 패키지 아카이브를 전달합니다.',
+                body: [
+                  splitApplied
+                    ? '첨부 용량 제한에 맞춰 파일을 분할해 전달했습니다.'
+                    : '다운로드된 패키지 아카이브를 전달합니다.',
+                  failedDownloadCount > 0
+                    ? `다운로드 실패한 ${failedDownloadCount}개 패키지는 이번 전달에서 제외되었습니다.`
+                    : '',
+                ]
+                  .filter(Boolean)
+                  .join('\n'),
                 attachments,
                 packages: packageInfos,
               });

--- a/electron/download-handlers.ts
+++ b/electron/download-handlers.ts
@@ -526,9 +526,27 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
           if (deliveryMethod === 'email') {
             const smtpOptions = options.smtp;
             const emailOptions = options.email;
+            const effectiveFrom = emailOptions?.from || smtpOptions?.from || smtpOptions?.user;
 
             if (!smtpOptions?.host || !smtpOptions.port || !emailOptions?.to) {
               const errorMessage = '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다';
+              mainWindow?.webContents.send('download:all-complete', {
+                success: false,
+                outputPath: finalOutputPath,
+                artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+                deliveryMethod,
+                deliveryResult: {
+                  emailSent: false,
+                  splitApplied: false,
+                  error: errorMessage,
+                },
+                error: errorMessage,
+              });
+              return;
+            }
+
+            if (!effectiveFrom) {
+              const errorMessage = '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.';
               mainWindow?.webContents.send('download:all-complete', {
                 success: false,
                 outputPath: finalOutputPath,
@@ -596,7 +614,7 @@ export function registerDownloadHandlers(windowGetter: () => BrowserWindow | nul
                         pass: smtpOptions.password || '',
                       }
                     : undefined,
-                  from: emailOptions.from || smtpOptions.from,
+                  from: effectiveFrom,
                 },
                 maxAttachmentSizeBytes
               );

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,7 @@ if (process.env.DEPSSMUGGLER_STRICT_SSL !== 'true') {
 }
 import { createScopedLogger } from './utils/logger';
 import { logger as coreLogger } from '../src/utils/logger';
+import { EmailSender } from '../src/core/mailer/email-sender';
 
 // 스코프별 로거 생성
 const log = createScopedLogger('Main');
@@ -247,6 +248,43 @@ ipcMain.handle('open-folder', async (_, targetPath: string) => {
   }
 
   await shell.openPath(targetPath);
+});
+
+ipcMain.handle('test-smtp-connection', async (_, config: {
+  host: string;
+  port: number;
+  user?: string;
+  password?: string;
+  from?: string;
+}) => {
+  try {
+    const emailSender = new EmailSender({
+      host: config.host,
+      port: config.port,
+      secure: config.port === 465,
+      auth: config.user
+        ? {
+            user: config.user,
+            pass: config.password || '',
+          }
+        : undefined,
+      from: config.from,
+    });
+
+    const success = await emailSender.testConnection();
+    emailSender.close();
+
+    if (!success) {
+      return { success: false, error: 'SMTP 연결 테스트 실패' };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 });
 
 // 파일 저장 다이얼로그

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -257,8 +257,9 @@ ipcMain.handle('test-smtp-connection', async (_, config: {
   password?: string;
   from?: string;
 }) => {
+  let emailSender: EmailSender | null = null;
   try {
-    const emailSender = new EmailSender({
+    emailSender = new EmailSender({
       host: config.host,
       port: config.port,
       secure: config.port === 465,
@@ -271,19 +272,15 @@ ipcMain.handle('test-smtp-connection', async (_, config: {
       from: config.from,
     });
 
-    const success = await emailSender.testConnection();
-    emailSender.close();
-
-    if (!success) {
-      return { success: false, error: 'SMTP 연결 테스트 실패' };
-    }
-
+    await emailSender.testConnection();
     return { success: true };
   } catch (error) {
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),
     };
+  } finally {
+    emailSender?.close();
   }
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,10 +18,48 @@ const electronAPI = {
     ipcRenderer.invoke('save-file', defaultPath),
   openFolder: (folderPath: string): Promise<void> =>
     ipcRenderer.invoke('open-folder', folderPath),
+  testSmtpConnection: (config: {
+    host: string;
+    port: number;
+    user?: string;
+    password?: string;
+    from?: string;
+  }): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('test-smtp-connection', config),
 
   // 다운로드 관련
   download: {
-    start: (data: { packages: unknown[]; options: unknown }): Promise<void> =>
+    start: (data: {
+      packages: unknown[];
+      options: {
+        outputDir: string;
+        outputFormat: 'zip' | 'tar.gz';
+        includeScripts: boolean;
+        targetOS?: string;
+        architecture?: string;
+        includeDependencies?: boolean;
+        pythonVersion?: string;
+        concurrency?: number;
+        deliveryMethod?: 'local' | 'email';
+        email?: {
+          to: string;
+          from?: string;
+          subject?: string;
+        };
+        fileSplit?: {
+          enabled: boolean;
+          maxSizeMB: number;
+        };
+        smtp?: {
+          host: string;
+          port: number;
+          user?: string;
+          password?: string;
+          from?: string;
+          secure?: boolean;
+        };
+      };
+    }): Promise<void> =>
       ipcRenderer.invoke('download:start', data),
     pause: (): Promise<void> => ipcRenderer.invoke('download:pause'),
     resume: (): Promise<void> => ipcRenderer.invoke('download:resume'),
@@ -67,6 +105,15 @@ const electronAPI = {
     onAllComplete: (callback: (data: {
       success: boolean;
       outputPath: string;
+      artifactPaths?: string[];
+      deliveryMethod?: 'local' | 'email';
+      deliveryResult?: {
+        emailSent: boolean;
+        emailsSent?: number;
+        attachmentsSent?: number;
+        splitApplied?: boolean;
+        error?: string;
+      };
       cancelled?: boolean;
       error?: string;
       results?: Array<{ id: string; success: boolean; error?: string }>;
@@ -75,6 +122,15 @@ const electronAPI = {
         callback(data as {
           success: boolean;
           outputPath: string;
+          artifactPaths?: string[];
+          deliveryMethod?: 'local' | 'email';
+          deliveryResult?: {
+            emailSent: boolean;
+            emailsSent?: number;
+            attachmentsSent?: number;
+            splitApplied?: boolean;
+            error?: string;
+          };
           cancelled?: boolean;
           error?: string;
           results?: Array<{ id: string; success: boolean; error?: string }>;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -16,6 +16,8 @@ export interface Config {
   smtpPort?: number;
   smtpUser?: string;
   smtpPassword?: string; // 암호화되어 저장됨
+  smtpFrom?: string;
+  smtpTo?: string;
 
   // 기타 설정
   defaultOutputFormat: 'archive' | 'mirror' | 'withScript';

--- a/src/core/mailer/email-sender.test.ts
+++ b/src/core/mailer/email-sender.test.ts
@@ -220,6 +220,34 @@ describe('EmailSender', () => {
       expect(result.emailsSent).toBeGreaterThan(1);
       expect(result.attachmentsSent).toBe(2);
     });
+
+    it('분할 발송 중 일부 파트가 실패해도 누적 발송 메타데이터를 반환해야 함', async () => {
+      sender.setMaxAttachmentSize(1024); // 1KB
+
+      const file1 = path.join(tempDir, 'part1.txt');
+      const file2 = path.join(tempDir, 'part2.txt');
+      await fs.writeFile(file1, 'a'.repeat(600));
+      await fs.writeFile(file2, 'b'.repeat(600));
+
+      const mockTransporter = nodemailer.createTransport({} as nodemailer.TransportOptions);
+      vi.mocked(mockTransporter.sendMail)
+        .mockResolvedValueOnce({ messageId: 'split-part-1' } as never)
+        .mockRejectedValueOnce(new Error('split send failed'));
+
+      const options: EmailOptions = {
+        to: 'recipient@example.com',
+        subject: 'Large Files',
+        body: 'Please see attachments.',
+        attachments: [file1, file2],
+      };
+
+      const result = await sender.sendEmail(options);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('split send failed');
+      expect(result.emailsSent).toBe(1);
+      expect(result.attachmentsSent).toBe(1);
+    });
   });
 
   describe('updateConfig', () => {

--- a/src/core/mailer/email-sender.test.ts
+++ b/src/core/mailer/email-sender.test.ts
@@ -79,12 +79,11 @@ describe('EmailSender', () => {
       });
     });
 
-    it('연결 테스트 실패 시 false를 반환해야 함', async () => {
+    it('연결 테스트 실패 시 원본 오류를 던져야 함', async () => {
       const mockTransporter = nodemailer.createTransport({} as nodemailer.TransportOptions);
       vi.mocked(mockTransporter.verify).mockRejectedValueOnce(new Error('Connection failed'));
 
-      const result = await sender.testConnection();
-      expect(result).toBe(false);
+      await expect(sender.testConnection()).rejects.toThrow('Connection failed');
     });
   });
 

--- a/src/core/mailer/email-sender.test.ts
+++ b/src/core/mailer/email-sender.test.ts
@@ -101,6 +101,8 @@ describe('EmailSender', () => {
       expect(result.success).toBe(true);
       expect(result.messageId).toBe('test-message-id');
       expect(result.emailsSent).toBe(1);
+      expect(result.attachmentsSent).toBe(0);
+      expect(result.splitApplied).toBe(false);
     });
 
     it('여러 수신자에게 이메일을 발송해야 함', async () => {
@@ -113,6 +115,7 @@ describe('EmailSender', () => {
       const result = await sender.sendEmail(options);
 
       expect(result.success).toBe(true);
+      expect(result.attachmentsSent).toBe(0);
       expect(result.emailsSent).toBe(1);
     });
 
@@ -126,6 +129,7 @@ describe('EmailSender', () => {
       const result = await sender.sendEmail(options);
 
       expect(result.success).toBe(true);
+      expect(result.attachmentsSent).toBe(0);
     });
 
     it('첨부파일과 함께 이메일을 발송해야 함', async () => {
@@ -143,6 +147,7 @@ describe('EmailSender', () => {
       const result = await sender.sendEmail(options);
 
       expect(result.success).toBe(true);
+      expect(result.attachmentsSent).toBe(1);
     });
 
     it('패키지 정보와 함께 이메일을 발송해야 함', async () => {
@@ -214,6 +219,7 @@ describe('EmailSender', () => {
 
       expect(result.success).toBe(true);
       expect(result.emailsSent).toBeGreaterThan(1);
+      expect(result.attachmentsSent).toBe(2);
     });
   });
 
@@ -473,6 +479,26 @@ describe('발신자 주소', () => {
 
     const result = await sender.sendEmail(options);
     expect(result.success).toBe(true);
+
+    sender.close();
+  });
+
+  it('auth 없이도 from 주소로 발송 설정을 구성할 수 있어야 함', async () => {
+    const sender = new EmailSender({
+      host: 'smtp.example.com',
+      port: 25,
+      secure: false,
+      from: 'sender@example.com',
+    });
+
+    const result = await sender.sendEmail({
+      to: 'recipient@example.com',
+      subject: 'No Auth',
+      body: 'Test',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.attachmentsSent).toBe(0);
 
     sender.close();
   });

--- a/src/core/mailer/email-sender.ts
+++ b/src/core/mailer/email-sender.ts
@@ -78,7 +78,7 @@ export class EmailSender {
       return true;
     } catch (error) {
       logger.error('SMTP 연결 테스트 실패', { error });
-      return false;
+      throw error;
     }
   }
 

--- a/src/core/mailer/email-sender.ts
+++ b/src/core/mailer/email-sender.ts
@@ -13,7 +13,7 @@ export interface SmtpConfig {
   host: string;
   port: number;
   secure: boolean; // true for 465, false for other ports
-  auth: {
+  auth?: {
     user: string;
     pass: string;
   };
@@ -34,6 +34,8 @@ export interface SendResult {
   messageId?: string;
   error?: string;
   emailsSent?: number;
+  attachmentsSent?: number;
+  splitApplied?: boolean;
 }
 
 const DEFAULT_MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10MB
@@ -61,7 +63,7 @@ export class EmailSender {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
-      auth: this.config.auth,
+      ...(this.config.auth ? { auth: this.config.auth } : {}),
     });
   }
 
@@ -110,7 +112,7 @@ export class EmailSender {
 
       // 단일 메일 발송
       const mailOptions: nodemailer.SendMailOptions = {
-        from: this.config.from || this.config.auth.user,
+        from: this.config.from || this.config.auth?.user,
         to: Array.isArray(to) ? to.join(', ') : to,
         subject,
         text: body,
@@ -126,6 +128,8 @@ export class EmailSender {
         success: true,
         messageId: info.messageId,
         emailsSent: 1,
+        attachmentsSent: mailAttachments?.length || 0,
+        splitApplied: false,
       };
     } catch (error) {
       const errorMessage = (error as Error).message;
@@ -148,6 +152,7 @@ export class EmailSender {
     const { to, subject, body, packages = [] } = options;
     const groups = await this.groupAttachmentsBySize(attachments);
     let emailsSent = 0;
+    let attachmentsSent = 0;
     const messageIds: string[] = [];
 
     for (let i = 0; i < groups.length; i++) {
@@ -160,7 +165,7 @@ export class EmailSender {
       const mailAttachments = await this.prepareAttachments(group);
 
       const mailOptions: nodemailer.SendMailOptions = {
-        from: this.config.from || this.config.auth.user,
+        from: this.config.from || this.config.auth?.user,
         to: Array.isArray(to) ? to.join(', ') : to,
         subject: partSubject,
         html: partBody,
@@ -170,6 +175,7 @@ export class EmailSender {
       const info = await this.transporter!.sendMail(mailOptions);
       messageIds.push(info.messageId);
       emailsSent++;
+      attachmentsSent += mailAttachments?.length || 0;
 
       logger.info(`분할 이메일 발송 (${i + 1}/${groups.length})`, {
         messageId: info.messageId,
@@ -180,6 +186,8 @@ export class EmailSender {
       success: true,
       messageId: messageIds.join(', '),
       emailsSent,
+      attachmentsSent,
+      splitApplied: false,
     };
   }
 

--- a/src/core/mailer/email-sender.ts
+++ b/src/core/mailer/email-sender.ts
@@ -172,14 +172,31 @@ export class EmailSender {
         attachments: mailAttachments,
       };
 
-      const info = await this.transporter!.sendMail(mailOptions);
-      messageIds.push(info.messageId);
-      emailsSent++;
-      attachmentsSent += mailAttachments?.length || 0;
+      try {
+        const info = await this.transporter!.sendMail(mailOptions);
+        messageIds.push(info.messageId);
+        emailsSent++;
+        attachmentsSent += mailAttachments?.length || 0;
 
-      logger.info(`분할 이메일 발송 (${i + 1}/${groups.length})`, {
-        messageId: info.messageId,
-      });
+        logger.info(`분할 이메일 발송 (${i + 1}/${groups.length})`, {
+          messageId: info.messageId,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`분할 이메일 발송 실패 (${i + 1}/${groups.length})`, {
+          error: errorMessage,
+          emailsSent,
+          attachmentsSent,
+        });
+        return {
+          success: false,
+          messageId: messageIds.join(', '),
+          error: errorMessage,
+          emailsSent,
+          attachmentsSent,
+          splitApplied: false,
+        };
+      }
     }
 
     return {

--- a/src/core/packager/file-splitter.test.ts
+++ b/src/core/packager/file-splitter.test.ts
@@ -120,6 +120,7 @@ describe('FileSplitter', () => {
       expect(result.parts.length).toBe(1);
       expect(result.metadata.partCount).toBe(1);
       expect(result.metadata.originalFileName).toBe('small.txt');
+      expect(result.metadataPath).toBeUndefined();
     });
 
     it('큰 파일을 여러 파트로 분할해야 함', async () => {
@@ -134,6 +135,7 @@ describe('FileSplitter', () => {
       expect(result.parts.length).toBe(3);
       expect(result.metadata.partCount).toBe(3);
       expect(result.metadata.checksum).toBeDefined();
+      expect(result.metadataPath).toBe(path.join(tempDir, 'large.bin.meta.json'));
     });
 
     it('진행률 콜백이 호출되어야 함', async () => {
@@ -171,6 +173,7 @@ describe('FileSplitter', () => {
       });
 
       expect(result.mergeScripts).toBeDefined();
+      expect(result.metadataPath).toBe(path.join(tempDir, 'script-test.bin.meta.json'));
       if (result.mergeScripts) {
         expect(result.mergeScripts.bash).toBeDefined();
         expect(result.mergeScripts.powershell).toBeDefined();

--- a/src/core/packager/file-splitter.ts
+++ b/src/core/packager/file-splitter.ts
@@ -26,6 +26,7 @@ export interface SplitProgress {
 export interface SplitResult {
   parts: string[];
   metadata: SplitMetadata;
+  metadataPath?: string;
   mergeScripts?: {
     bash?: string;
     powershell?: string;
@@ -104,6 +105,7 @@ export class FileSplitter {
           checksum,
           createdAt: new Date().toISOString(),
         },
+        metadataPath: undefined,
       };
     }
 
@@ -203,6 +205,7 @@ export class FileSplitter {
         const result: SplitResult = {
           parts,
           metadata,
+          metadataPath,
         };
 
         // 병합 스크립트 생성

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -38,6 +38,24 @@ export interface DownloadOptions {
   includeDependencies?: boolean;
   pythonVersion?: string;
   concurrency?: number;
+  deliveryMethod?: 'local' | 'email';
+  email?: {
+    to: string;
+    from?: string;
+    subject?: string;
+  };
+  fileSplit?: {
+    enabled: boolean;
+    maxSizeMB: number;
+  };
+  smtp?: {
+    host: string;
+    port: number;
+    user?: string;
+    password?: string;
+    from?: string;
+    secure?: boolean;
+  };
 }
 
 export interface DownloadUrlResult {

--- a/src/renderer/components/os/OSDownloadProgress.tsx
+++ b/src/renderer/components/os/OSDownloadProgress.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import type { OSDownloadProgress } from '../../../core/downloaders/os-shared/types';
+import type { OSDownloadProgress as OSDownloadProgressData } from '../../../core/downloaders/os-shared/types';
 
 interface OSDownloadProgressProps {
-  progress: OSDownloadProgress | null;
+  progress: OSDownloadProgressData | null;
   packageCount: number;
   outputDir: string;
 }
 
-const phaseLabels: Record<OSDownloadProgress['phase'], string> = {
+const phaseLabels: Record<OSDownloadProgressData['phase'], string> = {
   resolving: '의존성 확인',
   downloading: '다운로드',
   verifying: '검증',

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Card,
   Button,
@@ -146,6 +146,7 @@ function createPendingDownloadItems(items: PendingDownloadSource[]): DownloadIte
 
 const DownloadPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const cartItems = useCartStore((state) => state.items);
   const clearCart = useCartStore((state) => state.clearCart);
   const {
@@ -237,6 +238,16 @@ const DownloadPage: React.FC = () => {
     }
 
   }, [cartItems, downloadItems.length, setItems, clearLogs]);
+
+  useEffect(() => {
+    const restoredDeliveryMethod = (
+      location.state as { deliveryMethod?: 'local' | 'email' } | null
+    )?.deliveryMethod;
+
+    if (restoredDeliveryMethod) {
+      setDeliveryMethod(restoredDeliveryMethod);
+    }
+  }, [location.state]);
 
   useEffect(() => {
     const includeDependenciesChanged =

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -69,6 +69,10 @@ import type {
   OSDownloadProgress as OSDownloadProgressData,
   PackageDependency,
 } from '../../core/downloaders/os-shared/types';
+import {
+  buildHistorySettings,
+  getEmailDeliveryValidationError,
+} from './download-delivery-utils';
 
 const { Title, Text, Paragraph } = Typography;
 const { Panel } = Collapse;
@@ -769,14 +773,15 @@ const DownloadPage: React.FC = () => {
         metadata: item.metadata,
       }));
 
-      const historySettings = historySettingsSnapshotRef.current ?? {
+      const historySettings = historySettingsSnapshotRef.current ?? buildHistorySettings({
         outputFormat,
         includeScripts: includeInstallScripts,
         includeDependencies,
         deliveryMethod,
+        smtpTo,
         fileSplitEnabled: enableFileSplit,
         maxFileSizeMB: maxFileSize,
-      };
+      });
 
       const resultMap = new Map((data.results || []).map((result) => [result.id, result.success]));
       let completedCount = 0;
@@ -1341,13 +1346,13 @@ const DownloadPage: React.FC = () => {
         : item.metadata,
     }));
 
-    const historySettings: HistorySettings = {
+    const historySettings = buildHistorySettings({
       outputFormat: result.outputOptions.archiveFormat || 'zip',
       includeScripts: result.outputOptions.generateScripts,
       includeDependencies,
       deliveryMethod: 'local',
       osOutputOptions: result.outputOptions,
-    };
+    });
 
     const failedCount = result.failed.length + result.unresolved.length;
     const downloadedCount = result.success.length;
@@ -1510,11 +1515,18 @@ const DownloadPage: React.FC = () => {
       return;
     }
 
-    if (deliveryMethod === 'email') {
-      if (!smtpHost || !smtpPort || !smtpTo || !(smtpFrom || smtpUser)) {
-        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버, 수신자, 발신자 또는 로그인 사용자를 입력하세요');
-        return;
-      }
+    const emailDeliveryValidationError = getEmailDeliveryValidationError({
+      deliveryMethod,
+      smtpHost,
+      smtpPort,
+      smtpTo,
+      smtpFrom,
+      smtpUser,
+    });
+
+    if (emailDeliveryValidationError) {
+      message.warning(emailDeliveryValidationError);
+      return;
     }
 
     if (includeDependencies && !depsResolved) {
@@ -1545,14 +1557,15 @@ const DownloadPage: React.FC = () => {
     window.electronAPI?.log?.('info', `[TIMING] Proceeding with download at ${Date.now() - handleStartTime}ms`);
     // 히스토리 저장용 장바구니 스냅샷 저장
     cartSnapshotRef.current = [...cartItems];
-    historySettingsSnapshotRef.current = {
+    historySettingsSnapshotRef.current = buildHistorySettings({
       outputFormat,
       includeScripts: includeInstallScripts,
       includeDependencies,
       deliveryMethod,
+      smtpTo,
       fileSplitEnabled: enableFileSplit,
       maxFileSizeMB: maxFileSize,
-    };
+    });
     setCompletedOutputPath('');
     setCompletedArtifactPaths([]);
     setCompletedDeliveryResult(undefined);
@@ -1686,6 +1699,20 @@ const DownloadPage: React.FC = () => {
   const executeRetryDownload = async (item: DownloadItem) => {
     if (!window.electronAPI?.download?.start) {
       addLog('error', '다운로드 API를 사용할 수 없습니다');
+      return;
+    }
+
+    const emailDeliveryValidationError = getEmailDeliveryValidationError({
+      deliveryMethod,
+      smtpHost,
+      smtpPort,
+      smtpTo,
+      smtpFrom,
+      smtpUser,
+    });
+
+    if (emailDeliveryValidationError) {
+      message.warning(emailDeliveryValidationError);
       return;
     }
 

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -1074,8 +1074,8 @@ const DownloadPage: React.FC = () => {
     }
 
     if (deliveryMethod === 'email') {
-      if (!smtpHost || !smtpPort || !smtpTo) {
-        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버와 수신자를 입력하세요');
+      if (!smtpHost || !smtpPort || !smtpTo || !(smtpFrom || smtpUser)) {
+        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버, 수신자, 발신자 또는 로그인 사용자를 입력하세요');
         return;
       }
     }

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -506,6 +506,18 @@ const DownloadPage: React.FC = () => {
     const unsubAllComplete = window.electronAPI.download.onAllComplete?.((data) => {
       if (!data.success) {
         setIsDownloading(false);
+        setIsPaused(false);
+
+        if (data.cancelled) {
+          setPackagingStatus('idle');
+          setPackagingProgress(0);
+          setCompletedOutputPath('');
+          setCompletedArtifactPaths([]);
+          setCompletedDeliveryResult(undefined);
+          setCompletedError('');
+          return;
+        }
+
         setPackagingStatus('failed');
         setPackagingProgress(0);
         setCompletedOutputPath(data.outputPath || '');
@@ -513,11 +525,9 @@ const DownloadPage: React.FC = () => {
         setCompletedDeliveryResult(data.deliveryResult);
         setCompletedError(data.error || data.deliveryResult?.error || '');
 
-        if (!data.cancelled) {
-          const errorMessage = data.error || '패키징 중 오류가 발생했습니다';
-          scheduleLogBatch('error', '다운로드/패키징 실패', errorMessage);
-          message.error(errorMessage);
-        }
+        const errorMessage = data.error || '패키징 중 오류가 발생했습니다';
+        scheduleLogBatch('error', '다운로드/패키징 실패', errorMessage);
+        message.error(errorMessage);
 
         return;
       }

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -1030,8 +1030,8 @@ const DownloadPage: React.FC = () => {
     }
 
     if (deliveryMethod === 'email') {
-      if (!smtpHost || !smtpPort || !smtpFrom || !smtpTo) {
-        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버, 발신자, 수신자를 입력하세요');
+      if (!smtpHost || !smtpPort || !smtpTo) {
+        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버와 수신자를 입력하세요');
         return;
       }
     }
@@ -1121,7 +1121,7 @@ const DownloadPage: React.FC = () => {
         email: deliveryMethod === 'email'
           ? {
               to: smtpTo,
-              from: smtpFrom,
+              from: smtpFrom || smtpUser,
             }
           : undefined,
         fileSplit: {
@@ -1134,7 +1134,7 @@ const DownloadPage: React.FC = () => {
               port: smtpPort,
               user: smtpUser,
               password: smtpPassword,
-              from: smtpFrom,
+              from: smtpFrom || smtpUser,
             }
           : undefined,
       };
@@ -1238,7 +1238,7 @@ const DownloadPage: React.FC = () => {
         email: deliveryMethod === 'email'
           ? {
               to: smtpTo,
-              from: smtpFrom,
+              from: smtpFrom || smtpUser,
             }
           : undefined,
         fileSplit: {
@@ -1251,7 +1251,7 @@ const DownloadPage: React.FC = () => {
               port: smtpPort,
               user: smtpUser,
               password: smtpPassword,
-              from: smtpFrom,
+              from: smtpFrom || smtpUser,
             }
           : undefined,
       };
@@ -1466,13 +1466,17 @@ const DownloadPage: React.FC = () => {
   }
 
   // 완료 화면
-  if (packagingStatus === 'completed' && allCompleted) {
+  if (packagingStatus === 'completed') {
     return (
       <div>
         <Result
-          status="success"
-          title="다운로드 완료"
-          subTitle={`${completedCount}개 패키지가 성공적으로 다운로드되었습니다`}
+          status={failedCount > 0 ? 'warning' : 'success'}
+          title={failedCount > 0 ? '부분 완료' : '다운로드 완료'}
+          subTitle={
+            failedCount > 0
+              ? `${completedCount}개 패키지가 완료되었고 ${failedCount}개는 실패했습니다. 생성된 산출물을 확인하세요.`
+              : `${completedCount}개 패키지가 성공적으로 다운로드되었습니다`
+          }
           extra={[
             <Button
               type="primary"

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -59,7 +59,7 @@ import type {
   HistorySettings,
   HistoryStatus,
 } from '../../types';
-import type { DependencyAPI } from '../../types/electron';
+import type { AllCompleteData, DependencyAPI } from '../../types/electron';
 
 const { Title, Text, Paragraph } = Typography;
 const { Panel } = Collapse;
@@ -502,6 +502,78 @@ const DownloadPage: React.FC = () => {
       }
     });
 
+    const persistHistoryEntry = (data: AllCompleteData, forcedStatus?: HistoryStatus) => {
+      const finalItems = useDownloadStore.getState().items;
+
+      const historyPackages: HistoryPackageItem[] = cartSnapshotRef.current.map((item) => ({
+        type: item.type,
+        name: item.name,
+        version: item.version,
+        arch: item.arch,
+        languageVersion: item.languageVersion,
+        metadata: item.metadata,
+      }));
+
+      const historySettings = historySettingsSnapshotRef.current ?? {
+        outputFormat,
+        includeScripts: includeInstallScripts,
+        includeDependencies,
+        deliveryMethod,
+        fileSplitEnabled: enableFileSplit,
+        maxFileSizeMB: maxFileSize,
+      };
+
+      const resultMap = new Map((data.results || []).map((result) => [result.id, result.success]));
+      let completedCount = 0;
+      let failedCount = 0;
+
+      finalItems.forEach((item) => {
+        const result = resultMap.get(item.id);
+        if (typeof result === 'boolean') {
+          if (result) {
+            completedCount += 1;
+          } else {
+            failedCount += 1;
+          }
+          return;
+        }
+
+        if (item.status === 'completed') {
+          completedCount += 1;
+        } else if (item.status === 'failed') {
+          failedCount += 1;
+        }
+      });
+
+      const totalCount = finalItems.length || data.results?.length || 0;
+      let historyStatus = forcedStatus || 'success';
+
+      if (!forcedStatus) {
+        if (failedCount === totalCount && totalCount > 0) {
+          historyStatus = 'failed';
+        } else if (failedCount > 0) {
+          historyStatus = 'partial';
+        }
+      }
+
+      const totalSize = finalItems.reduce((sum, item) => sum + (item.totalBytes || 0), 0);
+
+      addHistory(
+        historyPackages,
+        historySettings,
+        data.outputPath,
+        totalSize,
+        historyStatus,
+        completedCount,
+        failedCount,
+        {
+          artifactPaths: data.artifactPaths,
+          deliveryMethod: data.deliveryMethod || historySettings.deliveryMethod,
+          deliveryResult: data.deliveryResult,
+        }
+      );
+    };
+
     // 전체 다운로드 완료 리스너
     const unsubAllComplete = window.electronAPI.download.onAllComplete?.((data) => {
       if (!data.success) {
@@ -528,6 +600,7 @@ const DownloadPage: React.FC = () => {
         const errorMessage = data.error || '패키징 중 오류가 발생했습니다';
         scheduleLogBatch('error', '다운로드/패키징 실패', errorMessage);
         message.error(errorMessage);
+        persistHistoryEntry(data, 'failed');
 
         return;
       }
@@ -554,62 +627,12 @@ const DownloadPage: React.FC = () => {
         : '다운로드 및 패키징이 완료되었습니다';
       scheduleLogBatch('success', '다운로드 및 패키징 완료', `다운로드 경로: ${data.outputPath}`);
       message.success(completionMessage);
-
-      // 히스토리 저장
-      const finalItems = useDownloadStore.getState().items;
-
-      // 패키지 정보 변환 (다운로드 시작 시 저장된 스냅샷 사용)
-      const historyPackages: HistoryPackageItem[] = cartSnapshotRef.current.map((item) => ({
-        type: item.type,
-        name: item.name,
-        version: item.version,
-        arch: item.arch,
-        languageVersion: item.languageVersion,
-        metadata: item.metadata,
-      }));
-
-      // 설정 정보
-      const historySettings = historySettingsSnapshotRef.current ?? {
-        outputFormat,
-        includeScripts: includeInstallScripts,
-        includeDependencies,
-        deliveryMethod,
-        fileSplitEnabled: enableFileSplit,
-        maxFileSizeMB: maxFileSize,
-      };
-
-      // 상태 계산
-      const completedCount = finalItems.filter((i) => i.status === 'completed').length;
-      const failedCount = finalItems.filter((i) => i.status === 'failed').length;
-      const totalCount = finalItems.length;
-
-      let historyStatus: HistoryStatus = 'success';
-      if (failedCount === totalCount) {
-        historyStatus = 'failed';
-      } else if (failedCount > 0) {
-        historyStatus = 'partial';
-      }
-
-      // 총 크기 계산
-      const totalSize = finalItems.reduce((sum, item) => sum + (item.totalBytes || 0), 0);
-
-      // 히스토리 저장
-      addHistory(
-        historyPackages,
-        historySettings,
-        data.outputPath,
-        totalSize,
-        historyStatus,
-        completedCount,
-        failedCount,
-        {
-          artifactPaths: data.artifactPaths || [data.outputPath],
-          deliveryMethod: data.deliveryMethod || historySettings.deliveryMethod,
-          deliveryResult: data.deliveryResult,
-        }
-      );
+      persistHistoryEntry(data);
 
       // 실패 없이 모두 완료되면 장바구니 자동 비우기
+      const finalItems = useDownloadStore.getState().items;
+      const failedCount = (data.results || []).filter((result) => !result.success).length
+        || finalItems.filter((item) => item.status === 'failed').length;
       if (failedCount === 0) {
         clearCart();
       }

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -206,6 +206,7 @@ const DownloadPage: React.FC = () => {
   const [completedOutputPath, setCompletedOutputPath] = useState('');
   const [completedArtifactPaths, setCompletedArtifactPaths] = useState<string[]>([]);
   const [completedDeliveryResult, setCompletedDeliveryResult] = useState<HistoryDeliveryResult | undefined>();
+  const [completedError, setCompletedError] = useState('');
   // 의존성 확인 관련 상태
   const [isResolvingDeps, setIsResolvingDeps] = useState(false);
   const downloadCancelledRef = useRef(false);
@@ -499,6 +500,7 @@ const DownloadPage: React.FC = () => {
         setCompletedOutputPath(data.outputPath || '');
         setCompletedArtifactPaths(data.artifactPaths || []);
         setCompletedDeliveryResult(data.deliveryResult);
+        setCompletedError(data.error || data.deliveryResult?.error || '');
 
         if (!data.cancelled) {
           const errorMessage = data.error || '패키징 중 오류가 발생했습니다';
@@ -525,6 +527,7 @@ const DownloadPage: React.FC = () => {
       setCompletedOutputPath(data.outputPath);
       setCompletedArtifactPaths(data.artifactPaths || [data.outputPath]);
       setCompletedDeliveryResult(data.deliveryResult);
+      setCompletedError('');
       const completionMessage = data.deliveryMethod === 'email'
         ? '다운로드, 패키징 및 이메일 전달이 완료되었습니다'
         : '다운로드 및 패키징이 완료되었습니다';
@@ -1072,6 +1075,7 @@ const DownloadPage: React.FC = () => {
     setCompletedOutputPath('');
     setCompletedArtifactPaths([]);
     setCompletedDeliveryResult(undefined);
+    setCompletedError('');
 
     addLog('info', '다운로드 시작', `총 ${downloadItems.length}개 패키지`);
 
@@ -1268,6 +1272,7 @@ const DownloadPage: React.FC = () => {
     setCompletedOutputPath('');
     setCompletedArtifactPaths([]);
     setCompletedDeliveryResult(undefined);
+    setCompletedError('');
     setDeliveryMethod('local');
     navigate('/');
   };
@@ -1399,7 +1404,10 @@ const DownloadPage: React.FC = () => {
   const allCompleted =
     downloadItems.length > 0 &&
     downloadItems.every((item) => ['completed', 'skipped'].includes(item.status));
-  const hasAnyCompleted = completedCount > 0;
+  const hasRecoverableArtifacts =
+    Boolean(completedOutputPath) ||
+    completedArtifactPaths.length > 0 ||
+    Boolean(completedDeliveryResult?.error);
 
   // 전체 다운로드 속도 (이동 평균 기반)
   const totalSpeed = calculateOverallSpeed();
@@ -1577,6 +1585,167 @@ const DownloadPage: React.FC = () => {
         </Card>
 
         {/* 로그 */}
+        <Card
+          size="small"
+          title={
+            <Space>
+              <span>로그</span>
+              <Tag>{logs.length}개</Tag>
+            </Space>
+          }
+          style={{ marginTop: 24 }}
+          styles={{ body: { padding: 0 } }}
+        >
+          <div
+            style={{
+              height: 200,
+              overflow: 'auto',
+              backgroundColor: '#1a1a1a',
+              padding: '8px 12px',
+              fontFamily: 'monospace',
+              fontSize: 12,
+            }}
+          >
+            {logs.length === 0 ? (
+              <Text type="secondary" style={{ color: '#666' }}>로그가 없습니다</Text>
+            ) : (
+              logs.map((log, index) => (
+                <div key={index} style={{ marginBottom: 4, display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                  <span style={{ flexShrink: 0 }}>{logIcons[log.level]}</span>
+                  <Text style={{ color: '#888', flexShrink: 0, minWidth: 70 }}>
+                    {new Date(log.timestamp).toLocaleTimeString()}
+                  </Text>
+                  <Text style={{ color: log.level === 'error' ? '#ff4d4f' : log.level === 'warn' ? '#faad14' : '#d9d9d9' }}>
+                    {log.message}
+                    {log.details && <span style={{ color: '#888' }}> - {log.details}</span>}
+                  </Text>
+                </div>
+              ))
+            )}
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (packagingStatus === 'failed' && hasRecoverableArtifacts) {
+    return (
+      <div>
+        <Result
+          status="error"
+          title={completedArtifactPaths.length > 0 ? '전달 실패' : '다운로드 실패'}
+          subTitle={
+            completedArtifactPaths.length > 0
+              ? '로컬 산출물은 생성되었습니다. 경로를 확인해 수동 전달을 진행할 수 있습니다.'
+              : '패키징 또는 전달 중 오류가 발생했습니다.'
+          }
+          extra={[
+            <Button
+              type="primary"
+              key="open"
+              icon={<FolderOpenOutlined />}
+              onClick={handleOpenFolder}
+            >
+              다운로드 폴더 열기
+            </Button>,
+            <Button key="done" icon={<ReloadOutlined />} onClick={handleComplete}>
+              새 다운로드
+            </Button>,
+          ]}
+        />
+
+        <Card title="실패 결과" style={{ marginTop: 24 }}>
+          <Alert
+            type="error"
+            showIcon
+            message="전달 실패 상세"
+            description={completedError || completedDeliveryResult?.error || '상세 오류를 확인할 수 없습니다.'}
+            style={{ marginBottom: 16 }}
+          />
+
+          <Row gutter={24}>
+            <Col span={6}>
+              <Statistic
+                title="완료"
+                value={completedCount}
+                suffix="개"
+                valueStyle={{ color: '#52c41a' }}
+                prefix={<CheckCircleOutlined />}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="실패"
+                value={failedCount}
+                suffix="개"
+                valueStyle={{ color: '#ff4d4f' }}
+                prefix={<CloseCircleOutlined />}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="건너뜀"
+                value={skippedCount}
+                suffix="개"
+                valueStyle={{ color: skippedCount > 0 ? '#faad14' : undefined }}
+                prefix={<ForwardOutlined />}
+              />
+            </Col>
+            <Col span={6}>
+              <Statistic
+                title="출력 형식"
+                value={outputFormat.toUpperCase()}
+                prefix={<FileZipOutlined />}
+              />
+            </Col>
+          </Row>
+
+          <Divider />
+
+          <div>
+            <Text strong>대표 경로:</Text>
+            <Paragraph copyable style={{ marginTop: 8 }}>
+              {completedOutputPath || outputDir}
+            </Paragraph>
+          </div>
+
+          <Divider />
+
+          <div>
+            <Text strong>전달 방식:</Text>
+            <Paragraph style={{ marginTop: 8 }}>
+              {deliveryMethod === 'email' ? '이메일 전달' : '로컬 저장'}
+            </Paragraph>
+          </div>
+
+          {completedArtifactPaths.length > 0 && (
+            <>
+              <Divider />
+              <div>
+                <Text strong>복구 가능한 산출물:</Text>
+                <div style={{ marginTop: 8 }}>
+                  {completedArtifactPaths.map((artifactPath) => (
+                    <Paragraph key={artifactPath} copyable style={{ marginBottom: 4 }}>
+                      {artifactPath}
+                    </Paragraph>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </Card>
+
+        <Card title="다운로드된 패키지" style={{ marginTop: 24 }}>
+          <Table
+            dataSource={downloadItems}
+            columns={columns}
+            rowKey="id"
+            pagination={false}
+            size="small"
+            scroll={{ y: 300 }}
+          />
+        </Card>
+
         <Card
           size="small"
           title={

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -357,9 +357,14 @@ const DownloadPage: React.FC = () => {
   const [completedDeliveryResult, setCompletedDeliveryResult] = useState<HistoryDeliveryResult | undefined>();
   const [completedError, setCompletedError] = useState('');
   const historyDownloadState = (
-    location.state as { deliveryMethod?: 'local' | 'email'; osOutputOptions?: OSPackageOutputOptions } | null
+    location.state as {
+      deliveryMethod?: 'local' | 'email';
+      emailRecipient?: string;
+      osOutputOptions?: OSPackageOutputOptions;
+    } | null
   );
   const historyOSOutputOptions = historyDownloadState?.osOutputOptions;
+  const effectiveSmtpTo = historyDownloadState?.emailRecipient || smtpTo;
   const osCartItems = useMemo(() => cartItems.filter(isOSCartItem), [cartItems]);
   const hasOnlyOSPackages = cartItems.length > 0 && osCartItems.length === cartItems.length;
   const osPackageManagers = useMemo(
@@ -434,6 +439,7 @@ const DownloadPage: React.FC = () => {
   // 히스토리 저장용 장바구니 데이터 (다운로드 시작 시 스냅샷)
   const cartSnapshotRef = useRef<typeof cartItems>([]);
   const historySettingsSnapshotRef = useRef<HistorySettings | null>(null);
+  const historyTrackedItemIdsRef = useRef<Set<string> | null>(null);
   // 배치 업데이트용 pending 상태 저장
   const pendingUpdatesRef = useRef<Map<string, Partial<DownloadItem>>>(new Map());
   const pendingLogsRef = useRef<Array<{ level: 'info' | 'warn' | 'error' | 'success'; message: string; details?: string }>>([]);
@@ -763,6 +769,10 @@ const DownloadPage: React.FC = () => {
 
     const persistHistoryEntry = (data: AllCompleteData, forcedStatus?: HistoryStatus) => {
       const finalItems = useDownloadStore.getState().items;
+      const trackedItemIds = historyTrackedItemIdsRef.current;
+      const relevantItems = trackedItemIds && trackedItemIds.size > 0
+        ? finalItems.filter((item) => trackedItemIds.has(item.id))
+        : finalItems;
 
       const historyPackages: HistoryPackageItem[] = cartSnapshotRef.current.map((item) => ({
         type: item.type,
@@ -778,7 +788,7 @@ const DownloadPage: React.FC = () => {
         includeScripts: includeInstallScripts,
         includeDependencies,
         deliveryMethod,
-        smtpTo,
+        smtpTo: effectiveSmtpTo,
         fileSplitEnabled: enableFileSplit,
         maxFileSizeMB: maxFileSize,
       });
@@ -787,7 +797,7 @@ const DownloadPage: React.FC = () => {
       let completedCount = 0;
       let failedCount = 0;
 
-      finalItems.forEach((item) => {
+      relevantItems.forEach((item) => {
         const result = resultMap.get(item.id);
         if (typeof result === 'boolean') {
           if (result) {
@@ -805,7 +815,7 @@ const DownloadPage: React.FC = () => {
         }
       });
 
-      const totalCount = finalItems.length || data.results?.length || 0;
+      const totalCount = relevantItems.length || data.results?.length || 0;
       let historyStatus = forcedStatus || 'success';
 
       if (!forcedStatus) {
@@ -816,7 +826,7 @@ const DownloadPage: React.FC = () => {
         }
       }
 
-      const totalSize = finalItems.reduce((sum, item) => sum + (item.totalBytes || 0), 0);
+      const totalSize = relevantItems.reduce((sum, item) => sum + (item.totalBytes || 0), 0);
 
       addHistory(
         historyPackages,
@@ -1519,7 +1529,7 @@ const DownloadPage: React.FC = () => {
       deliveryMethod,
       smtpHost,
       smtpPort,
-      smtpTo,
+      smtpTo: effectiveSmtpTo,
       smtpFrom,
       smtpUser,
     });
@@ -1557,12 +1567,13 @@ const DownloadPage: React.FC = () => {
     window.electronAPI?.log?.('info', `[TIMING] Proceeding with download at ${Date.now() - handleStartTime}ms`);
     // 히스토리 저장용 장바구니 스냅샷 저장
     cartSnapshotRef.current = [...cartItems];
+    historyTrackedItemIdsRef.current = new Set(downloadItems.map((item) => item.id));
     historySettingsSnapshotRef.current = buildHistorySettings({
       outputFormat,
       includeScripts: includeInstallScripts,
       includeDependencies,
       deliveryMethod,
-      smtpTo,
+      smtpTo: effectiveSmtpTo,
       fileSplitEnabled: enableFileSplit,
       maxFileSizeMB: maxFileSize,
     });
@@ -1614,7 +1625,7 @@ const DownloadPage: React.FC = () => {
         deliveryMethod,
         email: deliveryMethod === 'email'
           ? {
-              to: smtpTo,
+              to: effectiveSmtpTo,
               from: smtpFrom || smtpUser,
             }
           : undefined,
@@ -1706,7 +1717,7 @@ const DownloadPage: React.FC = () => {
       deliveryMethod,
       smtpHost,
       smtpPort,
-      smtpTo,
+      smtpTo: effectiveSmtpTo,
       smtpFrom,
       smtpUser,
     });
@@ -1715,6 +1726,32 @@ const DownloadPage: React.FC = () => {
       message.warning(emailDeliveryValidationError);
       return;
     }
+
+    cartSnapshotRef.current = [{
+      id: item.id,
+      type: item.type as CartItem['type'],
+      name: item.name,
+      version: item.version,
+      arch: item.arch as CartItem['arch'],
+      metadata: item.metadata,
+      addedAt: Date.now(),
+      downloadUrl: item.downloadUrl,
+      repository: item.repository as CartItem['repository'],
+      location: item.location,
+      indexUrl: item.indexUrl,
+      extras: item.extras,
+      classifier: item.classifier,
+    }];
+    historyTrackedItemIdsRef.current = new Set([item.id]);
+    historySettingsSnapshotRef.current = buildHistorySettings({
+      outputFormat,
+      includeScripts: includeInstallScripts,
+      includeDependencies: false,
+      deliveryMethod,
+      smtpTo: effectiveSmtpTo,
+      fileSplitEnabled: enableFileSplit,
+      maxFileSizeMB: maxFileSize,
+    });
 
     // 상태를 pending → downloading으로 변경
     retryItem(item.id);
@@ -1745,7 +1782,7 @@ const DownloadPage: React.FC = () => {
         deliveryMethod,
         email: deliveryMethod === 'email'
           ? {
-              to: smtpTo,
+              to: effectiveSmtpTo,
               from: smtpFrom || smtpUser,
             }
           : undefined,
@@ -1782,6 +1819,7 @@ const DownloadPage: React.FC = () => {
     setCompletedDeliveryResult(undefined);
     setCompletedError('');
     setDeliveryMethod('local');
+    historyTrackedItemIdsRef.current = null;
     setOSProgress(null);
     setOSResult(null);
     setOSDownloadError(null);
@@ -2477,8 +2515,8 @@ const DownloadPage: React.FC = () => {
               style={{ marginTop: 12 }}
               message="설정 화면의 SMTP 발신자/수신자와 파일 분할 값을 사용합니다."
               description={
-                smtpTo
-                  ? `현재 수신자: ${smtpTo}`
+                effectiveSmtpTo
+                  ? `현재 수신자: ${effectiveSmtpTo}`
                   : '수신자가 비어 있습니다. 설정 화면에서 SMTP 수신자를 먼저 입력하세요.'
               }
             />

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -190,14 +190,40 @@ function toOSPackageInfo(item: CartItem): OSPackageInfo | null {
     return null;
   }
 
+  const architectureMap: Partial<Record<NonNullable<CartItem['arch']>, OSPackageInfo['architecture']>> = {
+    x86_64: 'x86_64',
+    amd64: 'amd64',
+    arm64: 'arm64',
+    aarch64: 'aarch64',
+    i386: 'i386',
+    i686: 'i686',
+    noarch: 'noarch',
+    all: 'all',
+    'arm/v7': 'armv7',
+    '386': 'i386',
+  };
+  const architecture = architectureMap[item.arch];
+  if (!architecture) {
+    return null;
+  }
+
+  const repository: OSPackageInfo['repository'] = {
+    id: item.repository.baseUrl,
+    name: item.repository.name || item.repository.baseUrl,
+    baseUrl: item.repository.baseUrl,
+    enabled: true,
+    gpgCheck: true,
+    isOfficial: false,
+  };
+
   return {
     name: item.name,
     version: item.version,
-    architecture: item.arch,
+    architecture,
     size: 0,
     checksum: { type: 'sha256', value: '' },
     location: item.location,
-    repository: item.repository,
+    repository,
     dependencies: [],
     description: typeof item.metadata?.description === 'string' ? item.metadata.description : undefined,
     summary: typeof item.metadata?.description === 'string' ? item.metadata.description : undefined,
@@ -1319,6 +1345,7 @@ const DownloadPage: React.FC = () => {
       outputFormat: result.outputOptions.archiveFormat || 'zip',
       includeScripts: result.outputOptions.generateScripts,
       includeDependencies,
+      deliveryMethod: 'local',
       osOutputOptions: result.outputOptions,
     };
 
@@ -2711,7 +2738,7 @@ const DownloadPage: React.FC = () => {
               </Button>
             </>
           )}
-          {(allCompleted || packagingStatus === 'completed') && (
+          {allCompleted && (
             <Button
               type="primary"
               icon={<CheckCircleOutlined />}

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -53,7 +53,12 @@ import {
 } from '../stores/download-store';
 import { useSettingsStore } from '../stores/settings-store';
 import { useHistoryStore } from '../stores/history-store';
-import type { HistoryPackageItem, HistorySettings, HistoryStatus } from '../../types';
+import type {
+  HistoryDeliveryResult,
+  HistoryPackageItem,
+  HistorySettings,
+  HistoryStatus,
+} from '../../types';
 import type { DependencyAPI } from '../../types/electron';
 
 const { Title, Text, Paragraph } = Typography;
@@ -143,7 +148,27 @@ const DownloadPage: React.FC = () => {
   const navigate = useNavigate();
   const cartItems = useCartStore((state) => state.items);
   const clearCart = useCartStore((state) => state.clearCart);
-  const { defaultTargetOS, defaultArchitecture, includeDependencies, languageVersions, cudaVersion, concurrentDownloads, defaultDownloadPath, downloadRenderInterval, yumDistribution, aptDistribution, apkDistribution } = useSettingsStore();
+  const {
+    defaultTargetOS,
+    defaultArchitecture,
+    includeDependencies,
+    languageVersions,
+    cudaVersion,
+    concurrentDownloads,
+    defaultDownloadPath,
+    downloadRenderInterval,
+    yumDistribution,
+    aptDistribution,
+    apkDistribution,
+    enableFileSplit,
+    maxFileSize,
+    smtpHost,
+    smtpPort,
+    smtpUser,
+    smtpPassword,
+    smtpFrom,
+    smtpTo,
+  } = useSettingsStore();
   const {
     items: downloadItems,
     isDownloading,
@@ -177,6 +202,10 @@ const DownloadPage: React.FC = () => {
   const { addHistory } = useHistoryStore();
 
   const [outputDir, setOutputDir] = useState(outputPath || defaultDownloadPath || '');
+  const [deliveryMethod, setDeliveryMethod] = useState<'local' | 'email'>('local');
+  const [completedOutputPath, setCompletedOutputPath] = useState('');
+  const [completedArtifactPaths, setCompletedArtifactPaths] = useState<string[]>([]);
+  const [completedDeliveryResult, setCompletedDeliveryResult] = useState<HistoryDeliveryResult | undefined>();
   // 의존성 확인 관련 상태
   const [isResolvingDeps, setIsResolvingDeps] = useState(false);
   const downloadCancelledRef = useRef(false);
@@ -467,6 +496,9 @@ const DownloadPage: React.FC = () => {
         setIsDownloading(false);
         setPackagingStatus('failed');
         setPackagingProgress(0);
+        setCompletedOutputPath(data.outputPath || '');
+        setCompletedArtifactPaths(data.artifactPaths || []);
+        setCompletedDeliveryResult(data.deliveryResult);
 
         if (!data.cancelled) {
           const errorMessage = data.error || '패키징 중 오류가 발생했습니다';
@@ -490,8 +522,14 @@ const DownloadPage: React.FC = () => {
       setIsDownloading(false);
       setPackagingStatus('completed');
       setPackagingProgress(100);
+      setCompletedOutputPath(data.outputPath);
+      setCompletedArtifactPaths(data.artifactPaths || [data.outputPath]);
+      setCompletedDeliveryResult(data.deliveryResult);
+      const completionMessage = data.deliveryMethod === 'email'
+        ? '다운로드, 패키징 및 이메일 전달이 완료되었습니다'
+        : '다운로드 및 패키징이 완료되었습니다';
       scheduleLogBatch('success', '다운로드 및 패키징 완료', `다운로드 경로: ${data.outputPath}`);
-      message.success('다운로드 및 패키징이 완료되었습니다');
+      message.success(completionMessage);
 
       // 히스토리 저장
       const finalItems = useDownloadStore.getState().items;
@@ -511,6 +549,9 @@ const DownloadPage: React.FC = () => {
         outputFormat,
         includeScripts: includeInstallScripts,
         includeDependencies,
+        deliveryMethod,
+        fileSplitEnabled: enableFileSplit,
+        maxFileSizeMB: maxFileSize,
       };
 
       // 상태 계산
@@ -536,7 +577,12 @@ const DownloadPage: React.FC = () => {
         totalSize,
         historyStatus,
         completedCount,
-        failedCount
+        failedCount,
+        {
+          artifactPaths: data.artifactPaths || [data.outputPath],
+          deliveryMethod: data.deliveryMethod || historySettings.deliveryMethod,
+          deliveryResult: data.deliveryResult,
+        }
       );
 
       // 실패 없이 모두 완료되면 장바구니 자동 비우기
@@ -559,7 +605,24 @@ const DownloadPage: React.FC = () => {
       pendingLogsRef.current = [];
     };
     // downloadItems 대신 downloadItemsRef를 사용하므로 dependency에서 제거
-  }, [updateItem, updateItemsBatch, addLog, addLogsBatch, setItems, setIsDownloading, setPackagingStatus, setPackagingProgress, addHistory, clearCart]);
+  }, [
+    updateItem,
+    updateItemsBatch,
+    addLog,
+    addLogsBatch,
+    setItems,
+    setIsDownloading,
+    setPackagingStatus,
+    setPackagingProgress,
+    addHistory,
+    clearCart,
+    outputFormat,
+    includeInstallScripts,
+    includeDependencies,
+    deliveryMethod,
+    enableFileSplit,
+    maxFileSize,
+  ]);
 
   // downloadItems 변경 시 ref 동기화 (IPC 이벤트 핸들러에서 최신 상태 참조용)
   // updateItem 호출 후에도 ref가 최신 상태를 유지하도록 함
@@ -963,6 +1026,13 @@ const DownloadPage: React.FC = () => {
       return;
     }
 
+    if (deliveryMethod === 'email') {
+      if (!smtpHost || !smtpPort || !smtpFrom || !smtpTo) {
+        message.warning('이메일 전달을 사용하려면 설정에서 SMTP 서버, 발신자, 수신자를 입력하세요');
+        return;
+      }
+    }
+
     if (includeDependencies && !depsResolved) {
       message.warning('먼저 의존성 확인을 진행하세요');
       return;
@@ -995,7 +1065,13 @@ const DownloadPage: React.FC = () => {
       outputFormat,
       includeScripts: includeInstallScripts,
       includeDependencies,
+      deliveryMethod,
+      fileSplitEnabled: enableFileSplit,
+      maxFileSizeMB: maxFileSize,
     };
+    setCompletedOutputPath('');
+    setCompletedArtifactPaths([]);
+    setCompletedDeliveryResult(undefined);
 
     addLog('info', '다운로드 시작', `총 ${downloadItems.length}개 패키지`);
 
@@ -1037,6 +1113,26 @@ const DownloadPage: React.FC = () => {
         includeDependencies,
         pythonVersion: languageVersions.python,
         concurrency: concurrentDownloads,
+        deliveryMethod,
+        email: deliveryMethod === 'email'
+          ? {
+              to: smtpTo,
+              from: smtpFrom,
+            }
+          : undefined,
+        fileSplit: {
+          enabled: enableFileSplit,
+          maxSizeMB: maxFileSize,
+        },
+        smtp: deliveryMethod === 'email'
+          ? {
+              host: smtpHost,
+              port: smtpPort,
+              user: smtpUser,
+              password: smtpPassword,
+              from: smtpFrom,
+            }
+          : undefined,
       };
 
       window.electronAPI?.log?.('info', `[TIMING] Calling download.start IPC at ${Date.now() - handleStartTime}ms`);
@@ -1134,6 +1230,26 @@ const DownloadPage: React.FC = () => {
         includeDependencies: false, // 재시도 시 의존성 해결 불필요
         pythonVersion: languageVersions.python,
         concurrency: 1, // 단일 패키지이므로 1
+        deliveryMethod,
+        email: deliveryMethod === 'email'
+          ? {
+              to: smtpTo,
+              from: smtpFrom,
+            }
+          : undefined,
+        fileSplit: {
+          enabled: enableFileSplit,
+          maxSizeMB: maxFileSize,
+        },
+        smtp: deliveryMethod === 'email'
+          ? {
+              host: smtpHost,
+              port: smtpPort,
+              user: smtpUser,
+              password: smtpPassword,
+              from: smtpFrom,
+            }
+          : undefined,
       };
 
       await window.electronAPI.download.start({ packages, options });
@@ -1149,17 +1265,22 @@ const DownloadPage: React.FC = () => {
     reset();
     setDepsResolved(false);
     dependencyResolutionBypassedRef.current = false;
+    setCompletedOutputPath('');
+    setCompletedArtifactPaths([]);
+    setCompletedDeliveryResult(undefined);
+    setDeliveryMethod('local');
     navigate('/');
   };
 
   // 다운로드 폴더 열기 (Finder/Explorer)
   const handleOpenFolder = async () => {
+    const targetPath = completedOutputPath || outputDir;
     if (window.electronAPI?.openFolder) {
-      await window.electronAPI.openFolder(outputDir);
+      await window.electronAPI.openFolder(targetPath);
     } else {
-      message.info(`폴더 열기: ${outputDir}`);
+      message.info(`폴더 열기: ${targetPath}`);
     }
-    addLog('info', `다운로드 폴더 열기: ${outputDir}`);
+    addLog('info', `다운로드 폴더 열기: ${targetPath}`);
   };
 
   // 테이블 컬럼
@@ -1402,9 +1523,45 @@ const DownloadPage: React.FC = () => {
           <div>
             <Text strong>다운로드 경로:</Text>
             <Paragraph copyable style={{ marginTop: 8 }}>
-              {outputDir}
+              {completedOutputPath || outputDir}
             </Paragraph>
           </div>
+
+          <Divider />
+
+          <div>
+            <Text strong>전달 방식:</Text>
+            <Paragraph style={{ marginTop: 8 }}>
+              {deliveryMethod === 'email' ? '이메일 전달' : '로컬 저장'}
+            </Paragraph>
+          </div>
+
+          {completedArtifactPaths.length > 0 && (
+            <div>
+              <Text strong>실제 산출물:</Text>
+              <div style={{ marginTop: 8 }}>
+                {completedArtifactPaths.map((artifactPath) => (
+                  <Paragraph key={artifactPath} copyable style={{ marginBottom: 4 }}>
+                    {artifactPath}
+                  </Paragraph>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {completedDeliveryResult?.emailSent && (
+            <Alert
+              type="success"
+              showIcon
+              style={{ marginTop: 16 }}
+              message={`이메일 전달 완료 (${completedDeliveryResult.emailsSent || 1}건)`}
+              description={
+                completedDeliveryResult.splitApplied
+                  ? '첨부 제한을 넘겨 분할 파일로 전달했습니다.'
+                  : '아카이브 파일을 그대로 첨부해 전달했습니다.'
+              }
+            />
+          )}
         </Card>
 
         {/* 다운로드된 패키지 목록 */}
@@ -1486,6 +1643,34 @@ const DownloadPage: React.FC = () => {
               선택
             </Button>
           </Space.Compact>
+        </div>
+
+        <div>
+          <Text strong>전달 방식</Text>
+          <Radio.Group
+            value={deliveryMethod}
+            onChange={(event) => setDeliveryMethod(event.target.value)}
+            disabled={isDownloading}
+            style={{ display: 'block', marginTop: 8 }}
+          >
+            <Space direction="vertical">
+              <Radio value="local">로컬 저장만</Radio>
+              <Radio value="email">이메일로 전달</Radio>
+            </Space>
+          </Radio.Group>
+          {deliveryMethod === 'email' && (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginTop: 12 }}
+              message="설정 화면의 SMTP 발신자/수신자와 파일 분할 값을 사용합니다."
+              description={
+                smtpTo
+                  ? `현재 수신자: ${smtpTo}`
+                  : '수신자가 비어 있습니다. 설정 화면에서 SMTP 수신자를 먼저 입력하세요.'
+              }
+            />
+          )}
         </div>
 
       </Card>

--- a/src/renderer/pages/HistoryPage.tsx
+++ b/src/renderer/pages/HistoryPage.tsx
@@ -33,7 +33,7 @@ import { useHistoryStore, DownloadHistory, HistoryStatus } from '../stores/histo
 import { useCartStore, PackageType } from '../stores/cart-store';
 import { useSettingsStore } from '../stores/settings-store';
 
-const { Title, Text } = Typography;
+const { Title, Text, Paragraph } = Typography;
 
 // 패키지 타입별 색상
 const typeColors: Record<PackageType, string> = {
@@ -74,6 +74,20 @@ const formatDate = (isoString: string): string => {
     minute: '2-digit',
   }).format(date);
 };
+
+const getArtifactPaths = (history: DownloadHistory): string[] =>
+  history.artifactPaths && history.artifactPaths.length > 0
+    ? history.artifactPaths
+    : [history.outputPath];
+
+const getPrimaryArtifactPath = (history: DownloadHistory): string =>
+  getArtifactPaths(history)[0] || history.outputPath;
+
+const getDeliveryMethod = (history: DownloadHistory): 'local' | 'email' =>
+  history.deliveryMethod || history.settings.deliveryMethod || 'local';
+
+const getDeliveryLabel = (history: DownloadHistory): string =>
+  getDeliveryMethod(history) === 'email' ? '이메일' : '로컬';
 
 const HistoryPage: React.FC = () => {
   const navigate = useNavigate();
@@ -271,6 +285,52 @@ const HistoryPage: React.FC = () => {
       render: (format: string) => <Tag>{format.toUpperCase()}</Tag>,
     },
     {
+      title: '전달',
+      key: 'delivery',
+      width: 180,
+      render: (_, record) => (
+        <Space direction="vertical" size={2}>
+          <Tag color={getDeliveryMethod(record) === 'email' ? 'blue' : 'default'}>
+            {getDeliveryLabel(record)}
+          </Tag>
+          {getDeliveryMethod(record) === 'email' && (
+            <Text
+              type={record.deliveryResult?.emailSent ? 'secondary' : record.deliveryResult?.error ? 'danger' : undefined}
+              style={{ fontSize: 12 }}
+            >
+              {record.deliveryResult?.emailSent
+                ? `${record.deliveryResult.emailsSent || 1}건 발송${record.deliveryResult.splitApplied ? ' · 분할 전달' : ''}`
+                : record.deliveryResult?.error || '결과 정보 없음'}
+            </Text>
+          )}
+        </Space>
+      ),
+    },
+    {
+      title: '산출물',
+      key: 'artifacts',
+      width: 280,
+      render: (_, record) => {
+        const artifactPaths = getArtifactPaths(record);
+        const primaryArtifactPath = artifactPaths[0];
+
+        return (
+          <Space direction="vertical" size={2} style={{ width: '100%' }}>
+            <Tooltip title={primaryArtifactPath}>
+              <Text ellipsis style={{ maxWidth: 240 }}>
+                {primaryArtifactPath}
+              </Text>
+            </Tooltip>
+            {artifactPaths.length > 1 && (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                +{artifactPaths.length - 1}개 추가 산출물
+              </Text>
+            )}
+          </Space>
+        );
+      },
+    },
+    {
       title: '작업',
       key: 'actions',
       width: 200,
@@ -287,7 +347,7 @@ const HistoryPage: React.FC = () => {
             <Button
               type="text"
               icon={<FolderOpenOutlined />}
-              onClick={() => handleOpenFolder(record.outputPath)}
+              onClick={() => handleOpenFolder(getPrimaryArtifactPath(record))}
             />
           </Tooltip>
           <Tooltip title="재다운로드">
@@ -446,16 +506,30 @@ const HistoryPage: React.FC = () => {
             <Descriptions.Item label="출력 형식">
               {selectedHistory.settings.outputFormat.toUpperCase()}
             </Descriptions.Item>
+            <Descriptions.Item label="전달 방식">
+              <Tag color={getDeliveryMethod(selectedHistory) === 'email' ? 'blue' : 'default'}>
+                {getDeliveryLabel(selectedHistory)}
+              </Tag>
+            </Descriptions.Item>
             <Descriptions.Item label="설치 스크립트">
               {selectedHistory.settings.includeScripts ? '포함' : '미포함'}
             </Descriptions.Item>
             <Descriptions.Item label="의존성 포함">
               {selectedHistory.settings.includeDependencies ? '예' : '아니오'}
             </Descriptions.Item>
-            <Descriptions.Item label="출력 경로" span={2}>
+            <Descriptions.Item label="대표 경로" span={2}>
               <Text copyable style={{ wordBreak: 'break-all' }}>
-                {selectedHistory.outputPath}
+                {getPrimaryArtifactPath(selectedHistory)}
               </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="산출물 경로" span={2}>
+              <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                {getArtifactPaths(selectedHistory).map((artifactPath) => (
+                  <Paragraph key={artifactPath} copyable style={{ marginBottom: 0, wordBreak: 'break-all' }}>
+                    {artifactPath}
+                  </Paragraph>
+                ))}
+              </Space>
             </Descriptions.Item>
             <Descriptions.Item label="패키지 목록" span={2}>
               <Space wrap size={[4, 8]}>
@@ -475,6 +549,20 @@ const HistoryPage: React.FC = () => {
             {selectedHistory.failedCount !== undefined && (
               <Descriptions.Item label="다운로드 실패">
                 {selectedHistory.failedCount}개
+              </Descriptions.Item>
+            )}
+            {getDeliveryMethod(selectedHistory) === 'email' && (
+              <Descriptions.Item label="메일 전달 결과" span={2}>
+                <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                  <Text type={selectedHistory.deliveryResult?.emailSent ? undefined : selectedHistory.deliveryResult?.error ? 'danger' : undefined}>
+                    {selectedHistory.deliveryResult?.emailSent
+                      ? `성공 (${selectedHistory.deliveryResult.emailsSent || 1}건 발송, ${selectedHistory.deliveryResult.attachmentsSent ?? getArtifactPaths(selectedHistory).length}개 첨부)`
+                      : selectedHistory.deliveryResult?.error || '결과 정보 없음'}
+                  </Text>
+                  {selectedHistory.deliveryResult?.splitApplied && (
+                    <Text type="secondary">첨부 제한을 넘겨 분할 파일로 전달했습니다.</Text>
+                  )}
+                </Space>
               </Descriptions.Item>
             )}
           </Descriptions>

--- a/src/renderer/pages/HistoryPage.tsx
+++ b/src/renderer/pages/HistoryPage.tsx
@@ -160,6 +160,7 @@ const HistoryPage: React.FC = () => {
         navigate('/download', {
           state: {
             deliveryMethod: getDeliveryMethod(history),
+            emailRecipient: getHistoryRecipient(history),
             osOutputOptions: history.settings.osOutputOptions,
           },
         });

--- a/src/renderer/pages/HistoryPage.tsx
+++ b/src/renderer/pages/HistoryPage.tsx
@@ -130,7 +130,7 @@ const HistoryPage: React.FC = () => {
   const handleRedownload = useCallback((history: DownloadHistory) => {
     Modal.confirm({
       title: '재다운로드',
-      content: `${history.packages.length}개 패키지를 장바구니에 추가하고 다운로드 페이지로 이동하시겠습니까?`,
+      content: `${history.packages.length}개 패키지를 장바구니에 추가하고 다운로드 페이지로 이동합니다. 전달 방식은 ${getDeliveryLabel(history)}로 복원됩니다.`,
       okText: '확인',
       cancelText: '취소',
       onOk: () => {
@@ -160,7 +160,11 @@ const HistoryPage: React.FC = () => {
         });
 
         message.success(`${history.packages.length}개 패키지가 장바구니에 추가되었습니다.`);
-        navigate('/download');
+        navigate('/download', {
+          state: {
+            deliveryMethod: getDeliveryMethod(history),
+          },
+        });
       },
     });
   }, [addItem, updateSettings, navigate]);

--- a/src/renderer/pages/HistoryPage.tsx
+++ b/src/renderer/pages/HistoryPage.tsx
@@ -137,6 +137,12 @@ const HistoryPage: React.FC = () => {
           defaultOutputFormat: history.settings.outputFormat,
           includeInstallScripts: history.settings.includeScripts,
           includeDependencies: history.settings.includeDependencies,
+          ...(typeof history.settings.fileSplitEnabled === 'boolean'
+            ? { enableFileSplit: history.settings.fileSplitEnabled }
+            : {}),
+          ...(typeof history.settings.maxFileSizeMB === 'number'
+            ? { maxFileSize: history.settings.maxFileSizeMB }
+            : {}),
         });
 
         message.success(`${history.packages.length}개 패키지가 장바구니에 추가되었습니다.`);

--- a/src/renderer/pages/HistoryPage.tsx
+++ b/src/renderer/pages/HistoryPage.tsx
@@ -32,6 +32,7 @@ import {
 import { useHistoryStore, DownloadHistory, HistoryStatus } from '../stores/history-store';
 import { useCartStore, PackageType } from '../stores/cart-store';
 import { useSettingsStore } from '../stores/settings-store';
+import { buildHistoryRestoreSettings } from './download-delivery-utils';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -89,6 +90,8 @@ const getDeliveryMethod = (history: DownloadHistory): 'local' | 'email' =>
 const getDeliveryLabel = (history: DownloadHistory): string =>
   getDeliveryMethod(history) === 'email' ? '이메일' : '로컬';
 
+const getHistoryRecipient = (history: DownloadHistory): string | undefined => history.settings.smtpTo;
+
 const HistoryPage: React.FC = () => {
   const navigate = useNavigate();
   const { histories, deleteHistory, clearAll } = useHistoryStore();
@@ -130,7 +133,11 @@ const HistoryPage: React.FC = () => {
   const handleRedownload = useCallback((history: DownloadHistory) => {
     Modal.confirm({
       title: '재다운로드',
-      content: `${history.packages.length}개 패키지를 장바구니에 추가하고 다운로드 페이지로 이동합니다. 전달 방식은 ${getDeliveryLabel(history)}로 복원됩니다.`,
+      content: `${history.packages.length}개 패키지를 장바구니에 추가하고 다운로드 페이지로 이동합니다. 전달 방식은 ${
+        getDeliveryMethod(history) === 'email' && getHistoryRecipient(history)
+          ? `이메일(${getHistoryRecipient(history)})`
+          : getDeliveryLabel(history)
+      }로 복원됩니다.`,
       okText: '확인',
       cancelText: '취소',
       onOk: () => {
@@ -147,17 +154,7 @@ const HistoryPage: React.FC = () => {
         });
 
         // 설정 복원
-        updateSettings({
-          defaultOutputFormat: history.settings.outputFormat,
-          includeInstallScripts: history.settings.includeScripts,
-          includeDependencies: history.settings.includeDependencies,
-          ...(typeof history.settings.fileSplitEnabled === 'boolean'
-            ? { enableFileSplit: history.settings.fileSplitEnabled }
-            : {}),
-          ...(typeof history.settings.maxFileSizeMB === 'number'
-            ? { maxFileSize: history.settings.maxFileSizeMB }
-            : {}),
-        });
+        updateSettings(buildHistoryRestoreSettings(history.settings));
 
         message.success(`${history.packages.length}개 패키지가 장바구니에 추가되었습니다.`);
         navigate('/download', {
@@ -516,6 +513,11 @@ const HistoryPage: React.FC = () => {
                 {getDeliveryLabel(selectedHistory)}
               </Tag>
             </Descriptions.Item>
+            {getDeliveryMethod(selectedHistory) === 'email' && selectedHistory.settings.smtpTo && (
+              <Descriptions.Item label="수신자">
+                <Text copyable>{selectedHistory.settings.smtpTo}</Text>
+              </Descriptions.Item>
+            )}
             <Descriptions.Item label="설치 스크립트">
               {selectedHistory.settings.includeScripts ? '포함' : '미포함'}
             </Descriptions.Item>

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -72,6 +72,7 @@ const SettingsPage: React.FC = () => {
     smtpUser,
     smtpPassword,
     smtpFrom,
+    smtpTo,
     languageVersions,
     defaultTargetOS,
     defaultArchitecture,
@@ -247,6 +248,7 @@ const SettingsPage: React.FC = () => {
           port: number;
           user?: string;
           password?: string;
+          from?: string;
         }) => Promise<boolean | { success?: boolean; error?: string }>;
       } | undefined)?.testSmtpConnection;
 
@@ -256,6 +258,7 @@ const SettingsPage: React.FC = () => {
           port: values.smtpPort,
           user: values.smtpUser,
           password: values.smtpPassword,
+          from: values.smtpFrom,
         });
         const success = typeof result === 'boolean' ? result : Boolean(result?.success);
         setSmtpTestResult(success ? 'success' : 'failed');
@@ -404,6 +407,7 @@ const SettingsPage: React.FC = () => {
       smtpUser,
       smtpPassword,
       smtpFrom,
+      smtpTo,
       languageVersions,
       defaultTargetOS,
       defaultArchitecture,
@@ -455,6 +459,7 @@ const SettingsPage: React.FC = () => {
     smtpUser,
     smtpPassword,
     smtpFrom,
+    smtpTo,
     languageVersions,
     defaultTargetOS,
     defaultArchitecture,
@@ -1742,6 +1747,14 @@ const SettingsPage: React.FC = () => {
             <Col span={12}>
               <Form.Item name="smtpPassword" label="비밀번호" style={{ marginBottom: 8 }}>
                 <Input.Password size="small" placeholder="••••••••" />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Row gutter={8}>
+            <Col span={24}>
+              <Form.Item name="smtpTo" label="수신자" style={{ marginBottom: 8 }}>
+                <Input size="small" placeholder="offline@example.com" />
               </Form.Item>
             </Col>
           </Row>

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -265,7 +265,7 @@ const SettingsPage: React.FC = () => {
         if (success) {
           message.success('SMTP 연결 테스트 성공');
         } else {
-          message.error('SMTP 연결 테스트 실패');
+          message.error(typeof result === 'boolean' ? 'SMTP 연결 테스트 실패' : result?.error || 'SMTP 연결 테스트 실패');
         }
       } else if (!window.electronAPI) {
         // 브라우저 개발 환경 시뮬레이션
@@ -278,7 +278,7 @@ const SettingsPage: React.FC = () => {
       }
     } catch (error) {
       setSmtpTestResult('failed');
-      message.error('SMTP 연결 테스트 실패');
+      message.error(error instanceof Error ? error.message : 'SMTP 연결 테스트 실패');
     } finally {
       setTestingSmtp(false);
     }

--- a/src/renderer/pages/download-delivery-utils.test.ts
+++ b/src/renderer/pages/download-delivery-utils.test.ts
@@ -25,7 +25,7 @@ describe('download-delivery-utils', () => {
     });
   });
 
-  it('히스토리 재다운로드 시 저장된 수신자를 설정으로 복원해야 함', () => {
+  it('히스토리 재다운로드 시 전역 설정에는 수신자를 복원하지 않아야 함', () => {
     const updates = buildHistoryRestoreSettings({
       outputFormat: 'zip',
       includeScripts: false,
@@ -42,8 +42,8 @@ describe('download-delivery-utils', () => {
       includeDependencies: false,
       enableFileSplit: true,
       maxFileSize: 10,
-      smtpTo: 'restore@example.com',
     });
+    expect(updates).not.toHaveProperty('smtpTo');
   });
 
   it('이메일 전달은 시작 전에 SMTP 수신자 누락을 차단해야 함', () => {

--- a/src/renderer/pages/download-delivery-utils.test.ts
+++ b/src/renderer/pages/download-delivery-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHistoryRestoreSettings,
+  buildHistorySettings,
+  getEmailDeliveryValidationError,
+} from './download-delivery-utils';
+
+describe('download-delivery-utils', () => {
+  it('이메일 전달 히스토리에 수신자를 저장해야 함', () => {
+    const historySettings = buildHistorySettings({
+      outputFormat: 'tar.gz',
+      includeScripts: true,
+      includeDependencies: true,
+      deliveryMethod: 'email',
+      fileSplitEnabled: true,
+      maxFileSizeMB: 25,
+      smtpTo: 'airgap@example.com',
+    });
+
+    expect(historySettings).toMatchObject({
+      deliveryMethod: 'email',
+      smtpTo: 'airgap@example.com',
+      fileSplitEnabled: true,
+      maxFileSizeMB: 25,
+    });
+  });
+
+  it('히스토리 재다운로드 시 저장된 수신자를 설정으로 복원해야 함', () => {
+    const updates = buildHistoryRestoreSettings({
+      outputFormat: 'zip',
+      includeScripts: false,
+      includeDependencies: false,
+      deliveryMethod: 'email',
+      fileSplitEnabled: true,
+      maxFileSizeMB: 10,
+      smtpTo: 'restore@example.com',
+    });
+
+    expect(updates).toMatchObject({
+      defaultOutputFormat: 'zip',
+      includeInstallScripts: false,
+      includeDependencies: false,
+      enableFileSplit: true,
+      maxFileSize: 10,
+      smtpTo: 'restore@example.com',
+    });
+  });
+
+  it('이메일 전달은 시작 전에 SMTP 수신자 누락을 차단해야 함', () => {
+    expect(getEmailDeliveryValidationError({
+      deliveryMethod: 'email',
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpTo: '',
+      smtpFrom: 'sender@example.com',
+      smtpUser: '',
+    })).toBe('이메일 전달을 사용하려면 설정에서 SMTP 서버, 수신자, 발신자 또는 로그인 사용자를 입력하세요');
+  });
+
+  it('로컬 전달은 SMTP 설정 없이도 통과해야 함', () => {
+    expect(getEmailDeliveryValidationError({
+      deliveryMethod: 'local',
+      smtpHost: '',
+      smtpPort: 587,
+      smtpTo: '',
+      smtpFrom: '',
+      smtpUser: '',
+    })).toBeNull();
+  });
+});

--- a/src/renderer/pages/download-delivery-utils.ts
+++ b/src/renderer/pages/download-delivery-utils.ts
@@ -1,0 +1,80 @@
+import type { OSPackageOutputOptions } from '../../core/downloaders/os-shared/types';
+import type { DeliveryMethod, HistorySettings } from '../../types';
+
+export const EMAIL_DELIVERY_VALIDATION_MESSAGE =
+  '이메일 전달을 사용하려면 설정에서 SMTP 서버, 수신자, 발신자 또는 로그인 사용자를 입력하세요';
+
+interface BuildHistorySettingsInput {
+  outputFormat: HistorySettings['outputFormat'];
+  includeScripts: boolean;
+  includeDependencies: boolean;
+  deliveryMethod: DeliveryMethod;
+  smtpTo?: string;
+  fileSplitEnabled?: boolean;
+  maxFileSizeMB?: number;
+  osOutputOptions?: OSPackageOutputOptions;
+}
+
+export interface HistoryRestoreSettings {
+  defaultOutputFormat: HistorySettings['outputFormat'];
+  includeInstallScripts: boolean;
+  includeDependencies: boolean;
+  enableFileSplit?: boolean;
+  maxFileSize?: number;
+  smtpTo?: string;
+}
+
+interface EmailDeliveryValidationInput {
+  deliveryMethod: DeliveryMethod;
+  smtpHost: string;
+  smtpPort: number;
+  smtpTo: string;
+  smtpFrom: string;
+  smtpUser: string;
+}
+
+export function buildHistorySettings(input: BuildHistorySettingsInput): HistorySettings {
+  return {
+    outputFormat: input.outputFormat,
+    includeScripts: input.includeScripts,
+    includeDependencies: input.includeDependencies,
+    deliveryMethod: input.deliveryMethod,
+    ...(input.deliveryMethod === 'email' && input.smtpTo ? { smtpTo: input.smtpTo } : {}),
+    ...(typeof input.fileSplitEnabled === 'boolean'
+      ? { fileSplitEnabled: input.fileSplitEnabled }
+      : {}),
+    ...(typeof input.maxFileSizeMB === 'number'
+      ? { maxFileSizeMB: input.maxFileSizeMB }
+      : {}),
+    ...(input.osOutputOptions ? { osOutputOptions: input.osOutputOptions } : {}),
+  };
+}
+
+export function buildHistoryRestoreSettings(settings: HistorySettings): HistoryRestoreSettings {
+  return {
+    defaultOutputFormat: settings.outputFormat,
+    includeInstallScripts: settings.includeScripts,
+    includeDependencies: settings.includeDependencies,
+    ...(typeof settings.fileSplitEnabled === 'boolean'
+      ? { enableFileSplit: settings.fileSplitEnabled }
+      : {}),
+    ...(typeof settings.maxFileSizeMB === 'number'
+      ? { maxFileSize: settings.maxFileSizeMB }
+      : {}),
+    ...(settings.deliveryMethod === 'email' && settings.smtpTo ? { smtpTo: settings.smtpTo } : {}),
+  };
+}
+
+export function getEmailDeliveryValidationError(
+  input: EmailDeliveryValidationInput
+): string | null {
+  if (input.deliveryMethod !== 'email') {
+    return null;
+  }
+
+  if (!input.smtpHost || !input.smtpPort || !input.smtpTo || !(input.smtpFrom || input.smtpUser)) {
+    return EMAIL_DELIVERY_VALIDATION_MESSAGE;
+  }
+
+  return null;
+}

--- a/src/renderer/pages/download-delivery-utils.ts
+++ b/src/renderer/pages/download-delivery-utils.ts
@@ -21,7 +21,6 @@ export interface HistoryRestoreSettings {
   includeDependencies: boolean;
   enableFileSplit?: boolean;
   maxFileSize?: number;
-  smtpTo?: string;
 }
 
 interface EmailDeliveryValidationInput {
@@ -61,7 +60,6 @@ export function buildHistoryRestoreSettings(settings: HistorySettings): HistoryR
     ...(typeof settings.maxFileSizeMB === 'number'
       ? { maxFileSize: settings.maxFileSizeMB }
       : {}),
-    ...(settings.deliveryMethod === 'email' && settings.smtpTo ? { smtpTo: settings.smtpTo } : {}),
   };
 }
 

--- a/src/renderer/stores/history-store.ts
+++ b/src/renderer/stores/history-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type {
   DownloadHistory,
+  HistoryDeliveryResult,
   HistoryPackageItem,
   HistorySettings,
   HistoryStatus,
@@ -27,7 +28,12 @@ interface HistoryState {
     totalSize: number,
     status: HistoryStatus,
     downloadedCount?: number,
-    failedCount?: number
+    failedCount?: number,
+    options?: {
+      artifactPaths?: string[];
+      deliveryMethod?: 'local' | 'email';
+      deliveryResult?: HistoryDeliveryResult;
+    }
   ) => string;
 
   // ID로 히스토리 조회
@@ -55,7 +61,8 @@ export const useHistoryStore = create<HistoryState>()(
         totalSize,
         status,
         downloadedCount,
-        failedCount
+        failedCount,
+        options
       ) => {
         const id = generateId();
         const newHistory: DownloadHistory = {
@@ -64,6 +71,9 @@ export const useHistoryStore = create<HistoryState>()(
           packages,
           settings,
           outputPath,
+          artifactPaths: options?.artifactPaths,
+          deliveryMethod: options?.deliveryMethod ?? settings.deliveryMethod,
+          deliveryResult: options?.deliveryResult,
           totalSize,
           status,
           downloadedCount,

--- a/src/renderer/stores/settings-store.ts
+++ b/src/renderer/stores/settings-store.ts
@@ -66,6 +66,7 @@ interface SettingsState {
   smtpUser: string;
   smtpPassword: string;
   smtpFrom: string;
+  smtpTo: string;
 
   // 언어 버전 설정
   languageVersions: LanguageVersions;
@@ -138,6 +139,7 @@ const defaultSettings = {
   smtpUser: '',
   smtpPassword: '',
   smtpFrom: '',
+  smtpTo: '',
 
   languageVersions: {
     python: '3.11',

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -15,6 +15,15 @@ export interface DepsResolvedData {
 export interface AllCompleteData {
   success: boolean;
   outputPath: string;
+  artifactPaths?: string[];
+  deliveryMethod?: 'local' | 'email';
+  deliveryResult?: {
+    emailSent: boolean;
+    emailsSent?: number;
+    attachmentsSent?: number;
+    splitApplied?: boolean;
+    error?: string;
+  };
   cancelled?: boolean;
   error?: string;
   results?: Array<{
@@ -24,8 +33,50 @@ export interface AllCompleteData {
   }>;
 }
 
+export interface DownloadStartOptions {
+  outputDir: string;
+  outputFormat: 'zip' | 'tar.gz';
+  includeScripts: boolean;
+  targetOS?: string;
+  architecture?: string;
+  includeDependencies?: boolean;
+  pythonVersion?: string;
+  concurrency?: number;
+  deliveryMethod?: 'local' | 'email';
+  email?: {
+    to: string;
+    from?: string;
+    subject?: string;
+  };
+  fileSplit?: {
+    enabled: boolean;
+    maxSizeMB: number;
+  };
+  smtp?: {
+    host: string;
+    port: number;
+    user?: string;
+    password?: string;
+    from?: string;
+    secure?: boolean;
+  };
+}
+
+export interface SmtpConnectionConfig {
+  host: string;
+  port: number;
+  user?: string;
+  password?: string;
+  from?: string;
+}
+
+export interface SmtpConnectionResult {
+  success: boolean;
+  error?: string;
+}
+
 export interface DownloadAPI {
-  start: (data: { packages: unknown[]; options: unknown }) => Promise<void>;
+  start: (data: { packages: unknown[]; options: DownloadStartOptions }) => Promise<void>;
   pause: () => Promise<void>;
   resume: () => Promise<void>;
   cancel: () => Promise<void>;
@@ -237,6 +288,7 @@ export interface ElectronAPI {
   selectDirectory: () => Promise<string | null>;
   saveFile: (defaultPath: string) => Promise<string | null>;
   openFolder: (folderPath: string) => Promise<void>;
+  testSmtpConnection?: (config: SmtpConnectionConfig) => Promise<SmtpConnectionResult>;
   download: DownloadAPI;
   config: ConfigAPI;
   cache: CacheAPI;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -314,6 +314,8 @@ export interface HistorySettings {
   includeDependencies: boolean;
   /** 전달 방식 */
   deliveryMethod: DeliveryMethod;
+  /** 이메일 전달 재실행용 수신자 */
+  smtpTo?: string;
   /** 파일 분할 활성화 여부 */
   fileSplitEnabled?: boolean;
   /** 파일 분할 기준 크기 (MB) */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -312,6 +312,20 @@ export interface HistorySettings {
   includeScripts: boolean;
   /** 의존성 포함 여부 */
   includeDependencies: boolean;
+  /** 전달 방식 */
+  deliveryMethod: DeliveryMethod;
+  /** 파일 분할 활성화 여부 */
+  fileSplitEnabled?: boolean;
+  /** 파일 분할 기준 크기 (MB) */
+  maxFileSizeMB?: number;
+}
+
+export interface HistoryDeliveryResult {
+  emailSent: boolean;
+  emailsSent?: number;
+  attachmentsSent?: number;
+  splitApplied?: boolean;
+  error?: string;
 }
 
 /** 다운로드 히스토리 상태 */
@@ -329,6 +343,12 @@ export interface DownloadHistory {
   settings: HistorySettings;
   /** 출력 파일/폴더 경로 */
   outputPath: string;
+  /** 실제 산출물 경로 목록 */
+  artifactPaths?: string[];
+  /** 전달 방식 */
+  deliveryMethod?: DeliveryMethod;
+  /** 전달 결과 */
+  deliveryResult?: HistoryDeliveryResult;
   /** 총 다운로드 크기 (바이트) */
   totalSize: number;
   /** 다운로드 상태 */


### PR DESCRIPTION
## 요약
- 다운로드 완료 후 `local | email` 전달 방식을 선택할 수 있도록 연결했습니다.
- SMTP 연결 테스트 IPC를 실제 구현하고, 설정 화면의 SMTP/수신자/파일 분할 값을 메인 프로세스 전달 로직에 반영했습니다.
- 첨부 크기 초과 시 `FileSplitter`로 실제 산출물을 분할하고, 완료 이벤트/히스토리에 전달 결과와 산출물 목록을 저장하도록 정리했습니다.

## 배경
- 기존 GUI는 SMTP 설정과 파일 분할 옵션 UI는 있었지만 실제 테스트 IPC와 메일 전달 흐름은 연결되어 있지 않았습니다.
- 다운로드 완료 이벤트와 히스토리는 로컬 산출물 경로만 가정하고 있어 이메일 전달 및 분할 산출물 메타데이터를 반영하지 못했습니다.

## 변경 사항
- `electron/main.ts`, `electron/preload.ts`, `src/types/electron.d.ts`
  - `test-smtp-connection` IPC와 preload API를 추가했습니다.
  - `download:start`/`download:all-complete` 계약에 전달 방식, 산출물 목록, 전달 결과를 확장했습니다.
- `src/renderer/pages/SettingsPage.tsx`, `src/renderer/stores/settings-store.ts`
  - SMTP 수신자(`smtpTo`) 설정을 추가하고, 연결 테스트가 실제 IPC를 사용하도록 연결했습니다.
- `src/renderer/pages/DownloadPage.tsx`, `src/renderer/stores/history-store.ts`, `src/types/index.ts`, `src/renderer/pages/HistoryPage.tsx`
  - 다운로드 화면에서 `local | email` 전달 방식을 선택할 수 있게 했습니다.
  - 히스토리에 전달 방식, 산출물 목록, 전달 결과를 저장하도록 확장했습니다.
  - 재다운로드 시 파일 분할 설정 복원이 가능하도록 보정했습니다.
- `electron/download-handlers.ts`, `src/core/mailer/email-sender.ts`, `src/core/packager/file-splitter.ts`
  - 패키징 뒤 이메일 전달 오케스트레이션을 추가했습니다.
  - 첨부 제한 초과 시 `splitFile()`을 호출하고, 분할 결과 파일들을 메일 첨부 대상으로 사용합니다.
  - 메일러 반환값에 첨부 수/메일 수를 포함하도록 보강했습니다.
- 테스트/문서
  - `electron/download-handlers.test.ts`, `src/core/mailer/email-sender.test.ts`, `src/core/packager/file-splitter.test.ts`를 확장했습니다.
  - `docs/ipc-handlers.md`, `docs/electron-renderer.md`, `docs/download-history.md`, `docs/packagers.md`를 갱신했습니다.

## 검증
- `git diff --check` 통과
- `npm test -- electron/download-handlers.test.ts` 실행 시도
  - 실패: 로컬 환경에 `vitest` 패키지가 없어 `ERR_MODULE_NOT_FOUND` 발생
- `bash scripts/verify-worktree.sh` 실행 시도
  - 실패: 동일하게 로컬 환경에 `vitest` 패키지가 없어 검증 스크립트가 시작 단계에서 중단
- 실제 테스트 통과 여부는 PR CI로 확인 예정입니다.

## 문서
- `docs/ipc-handlers.md`
- `docs/electron-renderer.md`
- `docs/download-history.md`
- `docs/packagers.md`
- `docs/superpowers/plans/2026-04-13-smtp-delivery-download-flow.md`
