### PR TITLE
품질 게이트 복구: lint error 0화 및 CI lint/typecheck 정렬

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -90,6 +90,13 @@ module.exports = {
       },
     },
     {
+      // CLI 출력은 사용자 인터페이스의 일부
+      files: ['src/cli/**/*.ts'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+    {
       // Electron main process
       files: ['electron/**/*.ts'],
       env: {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run TypeScript type check
-        run: npx tsc --noEmit
+      - name: Run lint
+        run: npm run lint
 
   e2e:
     name: Playwright E2E

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,26 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript type check
+        run: npx tsc --noEmit
+
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest

--- a/electron/search-handlers.ts
+++ b/electron/search-handlers.ts
@@ -315,7 +315,7 @@ export function registerSearchHandlers(): void {
           results = await searchPyPI(query, options?.indexUrl);
           results = sortByRelevance(results, query, 'pip');
           break;
-        case 'conda':
+        case 'conda': {
           // conda는 실제 Anaconda API 사용
           const condaDownloader = getCondaDownloader();
           const channel = (options?.channel || 'conda-forge') as 'conda-forge' | 'anaconda' | 'bioconda' | 'pytorch' | 'all';
@@ -327,11 +327,12 @@ export function registerSearchHandlers(): void {
           }));
           results = sortByRelevance(results, query, 'conda');
           break;
+        }
         case 'maven':
           results = await searchMaven(query);
           results = sortByRelevance(results, query, 'maven');
           break;
-        case 'npm':
+        case 'npm': {
           const npmDownloader = getNpmDownloader();
           const npmResults = await npmDownloader.searchPackages(query);
           results = npmResults.map(pkg => ({
@@ -341,7 +342,8 @@ export function registerSearchHandlers(): void {
           }));
           results = sortByRelevance(results, query, 'npm');
           break;
-        case 'docker':
+        }
+        case 'docker': {
           const dockerDownloader = getDockerDownloader();
           const dockerRegistry = options?.registry || 'docker.io';
           const dockerResults = await dockerDownloader.searchPackages(query, dockerRegistry);
@@ -352,6 +354,7 @@ export function registerSearchHandlers(): void {
             registry: dockerRegistry,
           }));
           break;
+        }
         default:
           // 미구현 타입은 빈 배열 반환
           results = [];
@@ -375,24 +378,27 @@ export function registerSearchHandlers(): void {
         case 'pip':
           versions = await getPyPIVersions(packageName, options?.indexUrl);
           break;
-        case 'conda':
+        case 'conda': {
           // conda는 실제 Anaconda API 사용
           const condaDownloaderForVersions = getCondaDownloader();
           const channel = (options?.channel || 'conda-forge') as 'conda-forge' | 'anaconda' | 'bioconda' | 'pytorch' | 'all';
           versions = await condaDownloaderForVersions.getVersions(packageName, channel);
           break;
+        }
         case 'maven':
           versions = await getMavenVersions(packageName);
           break;
-        case 'npm':
+        case 'npm': {
           const npmDownloaderForVersions = getNpmDownloader();
           versions = await npmDownloaderForVersions.getVersions(packageName);
           break;
-        case 'docker':
+        }
+        case 'docker': {
           const dockerDownloaderForVersions = getDockerDownloader();
           const dockerRegistryForVersions = options?.registry || 'docker.io';
           versions = await dockerDownloaderForVersions.getVersions(packageName, dockerRegistryForVersions);
           break;
+        }
         default:
           versions = [];
       }
@@ -440,10 +446,11 @@ export function registerSearchHandlers(): void {
         case 'pip':
           searchPromise = (downloader as PipDownloader).searchPackages(query);
           break;
-        case 'conda':
+        case 'conda': {
           const condaChannel = (options?.channel || 'conda-forge') as 'conda-forge' | 'anaconda' | 'bioconda' | 'pytorch' | 'all';
           searchPromise = (downloader as CondaDownloader).searchPackages(query, condaChannel);
           break;
+        }
         case 'maven':
           searchPromise = (downloader as MavenDownloader).searchPackages(query);
           break;
@@ -654,7 +661,7 @@ export function registerSearchHandlers(): void {
       // packageManager에 따라 적절한 resolver 선택
       let searchResults;
       switch (fullDistribution.packageManager) {
-        case 'yum':
+        case 'yum': {
           const yumResolver = getYumResolver({
             repositories: fullDistribution.defaultRepos,
             architecture,
@@ -664,8 +671,9 @@ export function registerSearchHandlers(): void {
           });
           searchResults = await yumResolver.searchPackages(query, matchType === 'exact' ? 'exact' : 'partial');
           break;
+        }
 
-        case 'apt':
+        case 'apt': {
           const aptResolver = getAptResolver({
             repositories: fullDistribution.defaultRepos,
             architecture,
@@ -675,8 +683,9 @@ export function registerSearchHandlers(): void {
           });
           searchResults = await aptResolver.searchPackages(query, matchType === 'exact' ? 'exact' : 'partial');
           break;
+        }
 
-        case 'apk':
+        case 'apk': {
           const apkResolver = getApkResolver({
             repositories: fullDistribution.defaultRepos,
             architecture,
@@ -686,6 +695,7 @@ export function registerSearchHandlers(): void {
           });
           searchResults = await apkResolver.searchPackages(query, matchType === 'exact' ? 'exact' : 'partial');
           break;
+        }
 
         default:
           throw new Error(`Unsupported package manager: ${fullDistribution.packageManager}`);

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,5 +1,5 @@
 import { autoUpdater, UpdateInfo, ProgressInfo } from 'electron-updater';
-import { BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 import { createScopedLogger } from './utils/logger';
 
 const log = createScopedLogger('Updater');
@@ -208,7 +208,7 @@ export function registerDevModeHandlers() {
  */
 export async function checkForUpdatesOnStartup() {
   // 개발 모드에서는 체크하지 않음
-  if (process.env.NODE_ENV === 'development' || !require('electron').app.isPackaged) {
+  if (process.env.NODE_ENV === 'development' || !app.isPackaged) {
     log.info('Skipping update check in development mode');
     return;
   }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -26,7 +26,7 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
 
     // 타입별 다운로더 호출
     switch (options.type) {
-      case 'pip':
+      case 'pip': {
         const pipDownloader = getPipDownloader();
         const pipResults = await pipDownloader.searchPackages(query);
         results = pipResults.map((pkg) => ({
@@ -35,8 +35,9 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
           description: pkg.metadata?.description as string,
         }));
         break;
+      }
 
-      case 'conda':
+      case 'conda': {
         const condaDownloader = getCondaDownloader();
         const condaResults = await condaDownloader.searchPackages(query);
         results = condaResults.map((pkg) => ({
@@ -45,8 +46,9 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
           description: pkg.metadata?.description as string,
         }));
         break;
+      }
 
-      case 'maven':
+      case 'maven': {
         const mavenDownloader = getMavenDownloader();
         const mavenResults = await mavenDownloader.searchPackages(query);
         results = mavenResults.map((pkg) => ({
@@ -55,8 +57,9 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
           description: pkg.metadata?.description as string,
         }));
         break;
+      }
 
-      case 'npm':
+      case 'npm': {
         const npmDownloader = getNpmDownloader();
         const npmResults = await npmDownloader.searchPackages(query, limit);
         results = npmResults.map((pkg) => ({
@@ -65,6 +68,7 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
           description: pkg.metadata?.description as string,
         }));
         break;
+      }
 
       case 'yum':
       case 'apt':
@@ -72,8 +76,9 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
         console.error(`OS 패키지 검색은 'os search' 명령어를 사용하세요.`);
         console.error(`예: depssmuggler os search ${query} --distro rocky-9`);
         process.exit(1);
+        return;
 
-      case 'docker':
+      case 'docker': {
         const dockerDownloader = getDockerDownloader();
         const dockerResults = await dockerDownloader.searchPackages(query);
         results = dockerResults.map((pkg) => ({
@@ -82,10 +87,12 @@ export async function searchCommand(query: string, options: SearchOptions): Prom
           description: pkg.metadata?.description as string,
         }));
         break;
+      }
 
       default:
         console.log(chalk.red(`지원하지 않는 패키지 타입: ${options.type}`));
         process.exit(1);
+        return;
     }
 
     // 결과 제한

--- a/src/core/downloaders/apk.ts
+++ b/src/core/downloaders/apk.ts
@@ -328,9 +328,10 @@ export class ApkMetadataParser {
           return pkg.name === query;
         case 'partial':
           return pkg.name.includes(query);
-        case 'wildcard':
+        case 'wildcard': {
           const regex = new RegExp('^' + query.replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
           return regex.test(pkg.name);
+        }
         default:
           return false;
       }

--- a/src/core/downloaders/apt.ts
+++ b/src/core/downloaders/apt.ts
@@ -391,9 +391,10 @@ export class AptMetadataParser {
           return pkg.name === query;
         case 'partial':
           return pkg.name.includes(query);
-        case 'wildcard':
+        case 'wildcard': {
           const regex = new RegExp('^' + query.replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
           return regex.test(pkg.name);
+        }
         default:
           return false;
       }

--- a/src/core/downloaders/maven.test.ts
+++ b/src/core/downloaders/maven.test.ts
@@ -428,13 +428,22 @@ describe('maven downloader utilities', () => {
         // (1.0,2.0] - 1.0 초과, 2.0 이하
         // [1.0,) - 1.0 이상
         // (,2.0] - 2.0 이하
-        const match = range.match(/^([\[\(])([^,]*),([^\]\)]*)([\]\)])$/);
-        if (!match) return null;
+        const start = range[0];
+        const end = range[range.length - 1];
+        const separatorIndex = range.indexOf(',');
+
+        if (!start || !end || separatorIndex === -1) {
+          return null;
+        }
+
+        if (!['[', '('].includes(start) || ![']', ')'].includes(end)) {
+          return null;
+        }
 
         return {
-          min: match[2] || undefined,
-          max: match[3] || undefined,
-          inclusive: [match[1] === '[', match[4] === ']'],
+          min: range.slice(1, separatorIndex) || undefined,
+          max: range.slice(separatorIndex + 1, -1) || undefined,
+          inclusive: [start === '[', end === ']'],
         };
       };
 

--- a/src/core/downloaders/npm.test.ts
+++ b/src/core/downloaders/npm.test.ts
@@ -452,7 +452,7 @@ describe('NpmDownloader 추가 테스트', () => {
 
     it('sanitizePath 로직 테스트', () => {
       // npm의 sanitizePath는 정규식으로 위험 문자 제거
-      const sanitize = (input: string) => input.replace(/[^a-zA-Z0-9._\-]/g, '_');
+      const sanitize = (input: string) => input.replace(/[^a-zA-Z0-9._-]/g, '_');
 
       expect(sanitize('lodash-4.17.21.tgz')).toBe('lodash-4.17.21.tgz');
       expect(sanitize('package@1.0.0.tgz')).toBe('package_1.0.0.tgz'); // @ 제거

--- a/src/core/downloaders/npm.ts
+++ b/src/core/downloaders/npm.ts
@@ -143,7 +143,7 @@ export class NpmDownloader implements IDownloader {
 
       // 파일명 추출 (경로 조작 방지를 위해 정규화)
       const rawFileName = path.basename(new URL(downloadUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._\-]/g);
+      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
       const filePath = path.join(destPath, fileName);
 
       // 디렉토리 생성
@@ -242,7 +242,7 @@ export class NpmDownloader implements IDownloader {
     try {
       // 파일명 추출 (경로 조작 방지를 위해 정규화)
       const rawFileName = path.basename(new URL(tarballUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._\-]/g);
+      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
       const filePath = path.join(destPath, fileName);
 
       await fs.ensureDir(destPath);

--- a/src/core/downloaders/os-shared/base-downloader.ts
+++ b/src/core/downloaders/os-shared/base-downloader.ts
@@ -226,7 +226,7 @@ export abstract class BaseOSDownloader {
     let lastTime = Date.now();
     let currentSpeed = 0;
 
-    while (true) {
+    for (;;) {
       if (this.options.abortSignal?.aborted) {
         throw this.createAbortError();
       }

--- a/src/core/downloaders/pip.ts
+++ b/src/core/downloaders/pip.ts
@@ -254,7 +254,7 @@ export class PipDownloader implements IDownloader {
 
       // 파일명 추출 (경로 조작 방지를 위해 정규화)
       const rawFileName = path.basename(new URL(downloadUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._\-]/g);
+      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
       const filePath = path.join(destPath, fileName);
 
       // 디렉토리 생성

--- a/src/core/downloaders/yum.ts
+++ b/src/core/downloaders/yum.ts
@@ -443,9 +443,10 @@ export class YumMetadataParser {
           return pkg.name === query;
         case 'partial':
           return pkg.name.includes(query);
-        case 'wildcard':
+        case 'wildcard': {
           const regex = new RegExp('^' + query.replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
           return regex.test(pkg.name);
+        }
         default:
           return false;
       }

--- a/src/core/packager/script-generator.ts
+++ b/src/core/packager/script-generator.ts
@@ -219,7 +219,7 @@ export class ScriptGenerator {
       lines.push('');
 
       for (const pkg of dockerPackages) {
-        const imageName = pkg.name.replace(/[\/]/g, '_');
+        const imageName = pkg.name.replace(/\//g, '_');
         lines.push(`    # ${pkg.name}:${pkg.version} 로드`);
         lines.push(`    log_info "${pkg.name}:${pkg.version} 로드 중..."`);
         lines.push(`    docker load -i "$PACKAGE_DIR/${imageName}_${pkg.version}.tar" || {`);
@@ -429,7 +429,7 @@ export class ScriptGenerator {
       lines.push('');
 
       for (const pkg of dockerPackages) {
-        const imageName = pkg.name.replace(/[\/]/g, '_');
+        const imageName = pkg.name.replace(/\//g, '_');
         const tarFileName = `${imageName}_${pkg.version}.tar`;
         lines.push(`    # ${pkg.name}:${pkg.version} 로드`);
         lines.push(`    Write-Info "${pkg.name}:${pkg.version} 로드 중..."`);

--- a/src/core/resolver/npm-tree-manager.ts
+++ b/src/core/resolver/npm-tree-manager.ts
@@ -157,7 +157,7 @@ export class NpmTreeManager {
     let existingVersion: string | null = null;
 
     // 루트까지 올라가며 배치 가능 여부 확인
-    while (true) {
+    for (;;) {
       const checkPath = target ? `${target}/node_modules/${name}` : `node_modules/${name}`;
       const existing = this.tree.get(checkPath);
 
@@ -288,7 +288,7 @@ export class NpmTreeManager {
   findNodePath(name: string, startPath: string | null): string | null {
     let searchPath = startPath || '';
 
-    while (true) {
+    for (;;) {
       const checkPath = searchPath ? `${searchPath}/node_modules/${name}` : `node_modules/${name}`;
       if (this.tree.has(checkPath)) {
         return checkPath;

--- a/src/core/resolver/os-resolver-utils.ts
+++ b/src/core/resolver/os-resolver-utils.ts
@@ -26,11 +26,12 @@ export function matchPackagesByQuery(
         return pkg.name === query;
       case 'partial':
         return pkg.name.includes(query);
-      case 'wildcard':
+      case 'wildcard': {
         const regex = new RegExp(
           '^' + query.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
         );
         return regex.test(pkg.name);
+      }
       default:
         return false;
     }

--- a/src/core/shared/filename-utils.ts
+++ b/src/core/shared/filename-utils.ts
@@ -7,7 +7,14 @@
  * Windows에서 금지된 파일명 문자
  * < > : " / \ | ? * 및 제어 문자 (0x00-0x1F)
  */
-const WINDOWS_FORBIDDEN_CHARS = /[<>:"/\\|?*\x00-\x1F]/g;
+const WINDOWS_FORBIDDEN_CHARS = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*']);
+
+function replaceWindowsForbiddenChars(name: string): string {
+  return Array.from(name, (char) => {
+    const code = char.charCodeAt(0);
+    return code <= 0x1f || WINDOWS_FORBIDDEN_CHARS.has(char) ? '_' : char;
+  }).join('');
+}
 
 /**
  * Windows 예약 파일명
@@ -29,16 +36,14 @@ const WINDOWS_RESERVED_NAMES = [
  * @example
  * sanitizeFilename('file<>:name') // 'file___name'
  * sanitizeFilename('CON') // '_CON'
- * sanitizeFilename('@types/node') // '_types_node'
+ * sanitizeFilename('@types/node') // '@types_node'
  */
 export function sanitizeFilename(name: string, maxLength = 200): string {
   if (!name) {
     return '_empty_';
   }
 
-  let safe = name
-    // Windows 금지 문자를 언더스코어로 변환
-    .replace(WINDOWS_FORBIDDEN_CHARS, '_')
+  let safe = replaceWindowsForbiddenChars(name)
     // 연속된 언더스코어를 하나로
     .replace(/_{2,}/g, '_')
     // 앞뒤 언더스코어 제거

--- a/src/core/shared/search-utils.ts
+++ b/src/core/shared/search-utils.ts
@@ -99,15 +99,17 @@ export type PackageType = 'pip' | 'conda' | 'maven' | 'npm' | 'docker' | 'yum' |
  */
 function extractCoreName(name: string, type: PackageType): string {
   switch (type) {
-    case 'maven':
+    case 'maven': {
       // groupId:artifactId 형식에서 artifactId 추출
       const mavenParts = name.split(':');
       return mavenParts.length > 1 ? mavenParts[1] : name;
+    }
 
-    case 'docker':
+    case 'docker': {
       // namespace/image 형식에서 image 추출
       const dockerParts = name.split('/');
       return dockerParts.length > 1 ? dockerParts[dockerParts.length - 1] : name;
+    }
 
     case 'npm':
       // @org/package 형식에서 package 추출

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -1260,6 +1260,7 @@ const SettingsPage: React.FC = () => {
               <List.Item
                 actions={[
                   <Button
+                    key={`remove-${item.url}`}
                     type="link"
                     danger
                     size="small"


### PR DESCRIPTION
## 요약
- lint error 50개를 0개로 복구했습니다.
- CI의 lint job이 `npm run lint`를 실제로 실행하도록 수정했습니다.
- 기존 PR 게이트에 있던 전체 TypeScript 검사는 별도 `typecheck` job으로 유지했습니다.
- CLI의 intentional `console`은 전역 완화 대신 `src/cli/**/*.ts` 범위 override로 정리했습니다.

## 배경
- 현재 `npm run lint`가 error급 규칙 위반 50건으로 실패하고 있었습니다.
- GitHub Actions의 lint job은 실제 lint 대신 `npx tsc --noEmit`만 실행하고 있어 품질 게이트 역할이 어긋나 있었습니다.

## 변경 사항
- `switch` case 블록 선언, 상수 조건 루프, 정규식 escape, JSX key 누락 등 error급 위반을 동작 변경 없이 정리했습니다.
- `electron/updater.ts`의 `require('electron')` 사용을 import 기반으로 교체했습니다.
- Windows 파일명 sanitize 로직을 control-regex 없이 동일 동작으로 유지하도록 정리했습니다.
- `.github/workflows/test.yml`에서 `lint` job은 `npm run lint`, `typecheck` job은 `npx tsc --noEmit`를 실행하도록 분리했습니다.

## 검증
- `npm run lint` → 통과 (`0 errors`, warnings only)
- `npx tsc --noEmit` → 통과
- `bash scripts/verify-worktree.sh` → 통과
- 추가 확인: `npx vitest run src/core/shared/filename-utils.test.ts src/core/downloaders/docker-download.test.ts` → 통과

## 문서
- 없음
- 내부 lint/CI 게이트 복구 범위라 사용자/운영 문서는 이번 변경에서 제외했습니다.
