### PR TITLE
WizardPage 검색 흐름 리팩터링

### DIFF
--- a/docs/documentation-status.md
+++ b/docs/documentation-status.md
@@ -45,7 +45,7 @@
 - GUI 지원 범위가 README보다 넓었습니다. 실제 UI는 `npm`, `apt`, `apk`, 다운로드 히스토리, 설정, 자동 업데이트를 포함합니다.
 - CLI 문서는 일부 영역이 실제 구현보다 넓거나 좁게 적혀 있었습니다. 현재는 `os download/cache`가 CLI backend 기준으로 동작하며, 남은 차이는 주로 `npm` 일반 CLI 쪽입니다.
 - IPC 문서는 존재하지 않는 `os-package-handlers.ts`를 기준으로 설명하고 있었습니다.
-- Electron/Renderer 문서는 오래된 경로명과 채널 구성을 일부 포함하고 있었습니다.
+- Electron/Renderer 문서는 오래된 경로명과 채널 구성을 일부 포함하고 있었고, 2026-04-14 기준으로 `WizardPage` 검색 흐름의 모듈 분리(`src/renderer/pages/wizard-page/*`)까지 반영했습니다.
 - 테스트 문서는 고정된 테스트 개수와 오래된 파일명을 기준으로 설명하고 있었습니다.
 
 ## 유지보수 원칙

--- a/docs/electron-renderer.md
+++ b/docs/electron-renderer.md
@@ -7,7 +7,7 @@
 현재 확인된 예시는 다음과 같습니다.
 
 - `src/renderer/pages/CartPage.tsx`는 일부 최신 버전 조회를 `/api/pypi`, `/api/maven`, `/api/npm`으로 직접 호출합니다.
-- `src/renderer/pages/WizardPage.tsx`는 npm 검색, Docker 검색/태그 조회에서 IPC 우선 후 HTTP 폴백을 유지합니다.
+- `src/renderer/pages/WizardPage.tsx`는 화면 조합과 store/router wiring에 집중하고, 검색/버전조회 로직은 `src/renderer/pages/wizard-page/*` 모듈로 분리되었습니다.
 
 ## 현재 화면 구조
 
@@ -43,6 +43,23 @@
 - `ecr`
 - `quay.io`
 - `custom`
+
+## WizardPage 검색 모듈 경계
+
+`/wizard` 경로의 검색 관련 책임은 다음처럼 분리됩니다.
+
+- `src/renderer/pages/WizardPage.tsx`
+  - 스텝 UI 조합, settings/cart store 연결, 검색 훅 바인딩
+- `src/renderer/pages/wizard-page/query-params.ts`
+  - `type` query param 해석 및 소비
+- `src/renderer/pages/wizard-page/os-context.ts`
+  - `yum/apt/apk` 배포판/아키텍처 계산과 `osContext` snapshot 처리
+- `src/renderer/pages/wizard-page/search-service.ts`
+  - package type별 검색 전략, Electron IPC 우선, HTTP fallback
+- `src/renderer/pages/wizard-page/version-service.ts`
+  - 버전 조회 전략, Docker tag 조회, Maven classifier 부가 조회
+- `src/renderer/pages/wizard-page/useWizardSearchFlow.ts`
+  - 검색 입력/제안/선택/버전조회 오케스트레이션
 
 ## Electron main process
 
@@ -131,10 +148,11 @@
 ### OS 패키지 흐름
 
 1. `WizardPage`에서 `yum`, `apt`, `apk` 중 하나 선택
-2. 배포판과 아키텍처를 `os:getAllDistributions`, `os:search`로 조회
-3. 필요 시 `os:resolveDependencies`로 전용 트리 계산
-4. OS 패키지만 담긴 장바구니는 `/download`에서 전용 OS 다운로드 화면으로 전환되며, `src/renderer/components/os/*`의 출력 옵션/진행률/결과 컴포넌트를 사용합니다.
-5. 실제 다운로드는 `os:download:start` IPC로 실행되고, 일반 패키지 경로 `download:start`와 분리되어 유지됩니다.
+2. 배포판과 아키텍처는 settings store와 `wizard-page/os-context.ts` helper를 통해 선택/적용됩니다.
+3. 검색은 `wizard-page/search-service.ts`가 `os:search` IPC를 통해 수행합니다.
+4. 필요 시 `os:resolveDependencies`로 전용 트리 계산
+5. OS 패키지만 담긴 장바구니는 `/download`에서 전용 OS 다운로드 화면으로 전환되며, `src/renderer/components/os/*`의 출력 옵션/진행률/결과 컴포넌트를 사용합니다.
+6. 실제 다운로드는 `os:download:start` IPC로 실행되고, 일반 패키지 경로 `download:start`와 분리되어 유지됩니다.
 
 ## 출력과 패키징
 

--- a/docs/superpowers/plans/2026-04-14-wizard-page-search-refactor.md
+++ b/docs/superpowers/plans/2026-04-14-wizard-page-search-refactor.md
@@ -1,0 +1,238 @@
+# WizardPage Search Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `WizardPage`에서 검색/버전조회/OS 배포판 분기 로직을 훅과 서비스로 분리해 페이지 본체를 화면 조합 중심으로 축소한다.
+
+**Architecture:** `src/renderer/pages/wizard-page/` 아래에 순수 헬퍼(`query-params`, `os-context`), 테스트 가능한 서비스(`search-service`, `version-service`), 오케스트레이션 훅(`useWizardSearchFlow`)을 추가한다. `WizardPage.tsx`는 router/store 값을 읽고 훅 반환값을 UI에 바인딩하는 역할만 유지한다.
+
+**Tech Stack:** React 19, TypeScript, Zustand, React Router, Vitest
+
+---
+
+### Task 1: Query Param / OS Context 순수 모듈 추출
+
+**Files:**
+- Create: `src/renderer/pages/wizard-page/types.ts`
+- Create: `src/renderer/pages/wizard-page/query-params.ts`
+- Create: `src/renderer/pages/wizard-page/query-params.test.ts`
+- Create: `src/renderer/pages/wizard-page/os-context.ts`
+- Create: `src/renderer/pages/wizard-page/os-context.test.ts`
+- Modify: `src/renderer/pages/WizardPage.tsx`
+
+- [ ] **Step 1: Query param/OS context 실패 테스트 작성**
+
+테스트 대상:
+- 유효한 `type` query param은 category/package type/step을 계산한다.
+- 무효한 `type`은 무시한다.
+- `yum/apt/apk`별 distribution payload와 effective architecture를 계산한다.
+
+- [ ] **Step 2: 테스트를 실행해 실패를 확인**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/query-params.test.ts src/renderer/pages/wizard-page/os-context.test.ts
+```
+
+Expected: 새 모듈 미존재 또는 구현 누락으로 FAIL
+
+- [ ] **Step 3: 최소 구현 추가**
+
+구현 내용:
+- `types.ts`에 `SearchResult`, search/version context 타입 정의
+- `query-params.ts`에 `resolveWizardTypeParam` 계열 순수 함수 추가
+- `os-context.ts`에 OS distribution payload, cart snapshot, effective architecture 계산 함수 추가
+
+- [ ] **Step 4: 테스트 재실행**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/query-params.test.ts src/renderer/pages/wizard-page/os-context.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/renderer/pages/wizard-page/types.ts src/renderer/pages/wizard-page/query-params.ts src/renderer/pages/wizard-page/query-params.test.ts src/renderer/pages/wizard-page/os-context.ts src/renderer/pages/wizard-page/os-context.test.ts src/renderer/pages/WizardPage.tsx
+git commit -m "refactor: extract WizardPage query param helpers"
+```
+
+### Task 2: 검색 서비스 추출
+
+**Files:**
+- Create: `src/renderer/pages/wizard-page/search-service.ts`
+- Create: `src/renderer/pages/wizard-page/search-service.test.ts`
+- Modify: `src/renderer/pages/WizardPage.tsx`
+
+- [ ] **Step 1: 검색 서비스 실패 테스트 작성**
+
+테스트 대상:
+- package type별 전략 선택
+- Electron IPC 우선 사용
+- IPC 미존재 시 HTTP fallback
+- OS 검색 결과를 `SearchResult`로 매핑
+- pip/conda/docker 옵션 전달
+
+- [ ] **Step 2: 테스트를 실행해 실패를 확인**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/search-service.test.ts
+```
+
+Expected: 모듈 미존재 또는 계약 불일치로 FAIL
+
+- [ ] **Step 3: 최소 구현 추가**
+
+구현 내용:
+- `createSearchService` 또는 동등한 계약으로 의존성 주입 가능하게 구성
+- suggestion/full search 둘 다 같은 전략 계층을 사용
+- OS 검색 분기와 Electron/HTTP fallback을 내부에서 캡슐화
+
+- [ ] **Step 4: 테스트 재실행**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/search-service.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/renderer/pages/wizard-page/search-service.ts src/renderer/pages/wizard-page/search-service.test.ts src/renderer/pages/WizardPage.tsx
+git commit -m "refactor: extract WizardPage search service"
+```
+
+### Task 3: 버전 조회 서비스 추출
+
+**Files:**
+- Create: `src/renderer/pages/wizard-page/version-service.ts`
+- Create: `src/renderer/pages/wizard-page/version-service.test.ts`
+- Modify: `src/renderer/pages/WizardPage.tsx`
+
+- [ ] **Step 1: 버전 조회 서비스 실패 테스트 작성**
+
+테스트 대상:
+- Electron `search.versions` 우선
+- PyPI/Maven/Docker fallback
+- OS 검색 결과의 버전 배열 재사용
+- Maven classifier 부가 조회 결과 조립
+
+- [ ] **Step 2: 테스트를 실행해 실패를 확인**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/version-service.test.ts
+```
+
+Expected: 모듈 미존재 또는 구현 누락으로 FAIL
+
+- [ ] **Step 3: 최소 구현 추가**
+
+구현 내용:
+- `loadPackageVersionDetails` 계약으로 package type별 버전 로딩 전략 분리
+- `usedIndexUrl`, classifier 관련 반환값 포함
+- 버전 배열이 없는 경우 단일 버전 fallback 처리
+
+- [ ] **Step 4: 테스트 재실행**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/version-service.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/renderer/pages/wizard-page/version-service.ts src/renderer/pages/wizard-page/version-service.test.ts src/renderer/pages/WizardPage.tsx
+git commit -m "refactor: extract WizardPage version service"
+```
+
+### Task 4: 오케스트레이션 훅으로 상태 이관
+
+**Files:**
+- Create: `src/renderer/pages/wizard-page/useWizardSearchFlow.ts`
+- Create: `src/renderer/pages/wizard-page/useWizardSearchFlow.test.tsx`
+- Modify: `src/renderer/pages/WizardPage.tsx`
+
+- [ ] **Step 1: 훅 실패 테스트 작성**
+
+테스트 대상:
+- 입력 변경 시 디바운스 검색 호출
+- 패키지 선택 시 버전 단계로 이동
+- reset 동작
+- 서비스 반환값이 UI 상태로 반영됨
+
+- [ ] **Step 2: 테스트를 실행해 실패를 확인**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/useWizardSearchFlow.test.tsx
+```
+
+Expected: 훅 미존재 또는 동작 불일치로 FAIL
+
+- [ ] **Step 3: 최소 구현 추가**
+
+구현 내용:
+- 검색 관련 state/action을 훅으로 이동
+- service 호출, 디바운스 타이머, 선택/초기화 로직을 훅에 집중
+- `WizardPage.tsx`는 훅 API를 소비하도록 변경
+
+- [ ] **Step 4: 테스트 재실행**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/useWizardSearchFlow.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/renderer/pages/wizard-page/useWizardSearchFlow.ts src/renderer/pages/wizard-page/useWizardSearchFlow.test.tsx src/renderer/pages/WizardPage.tsx
+git commit -m "refactor: move WizardPage search flow into hook"
+```
+
+### Task 5: 페이지 정리 및 문서/검증
+
+**Files:**
+- Modify: `src/renderer/pages/WizardPage.tsx`
+- Modify: `docs/electron-renderer.md`
+- Modify: `docs/documentation-status.md`
+
+- [ ] **Step 1: `WizardPage.tsx` 정리**
+
+구현 내용:
+- 페이지에 남은 search/version/query-param/OS helper inline 구현 제거
+- 화면 조합, 섹션 렌더링, store/router wiring만 유지
+
+- [ ] **Step 2: 문서 업데이트**
+
+반영 내용:
+- renderer search flow 책임 분리
+- 새 모듈 위치와 역할
+
+- [ ] **Step 3: 전체 관련 검증 실행**
+
+Run:
+```bash
+npx vitest run src/renderer/pages/wizard-page/query-params.test.ts src/renderer/pages/wizard-page/os-context.test.ts src/renderer/pages/wizard-page/search-service.test.ts src/renderer/pages/wizard-page/version-service.test.ts src/renderer/pages/wizard-page/useWizardSearchFlow.test.tsx
+npx tsc --noEmit --pretty false
+```
+
+Expected: PASS
+
+- [ ] **Step 4: 최종 커밋**
+
+```bash
+git add src/renderer/pages/WizardPage.tsx src/renderer/pages/wizard-page docs/electron-renderer.md docs/documentation-status.md
+git commit -m "refactor: split WizardPage search flow"
+```

--- a/docs/superpowers/specs/2026-04-14-wizard-page-search-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-14-wizard-page-search-refactor-design.md
@@ -1,0 +1,191 @@
+# WizardPage 검색 리팩터링 설계
+
+## 배경
+
+`src/renderer/pages/WizardPage.tsx`는 현재 다음 책임을 한 파일에서 동시에 수행한다.
+
+- URL query param(`type`) 해석 및 소비
+- package type별 검색 전략 분기
+- Electron IPC 우선, HTTP fallback 처리
+- OS 패키지 검색/배포판 선택/아키텍처 분기
+- 버전 조회와 Maven classifier 부가 조회
+- 검색 결과 선택과 step 전이
+
+이 구조는 검색 계약을 UI와 분리해 테스트하기 어렵고, OS 검색 경로와 일반 패키지 검색 경로의 중복도 크다.
+
+## 목표
+
+- `WizardPage` 본체에는 화면 조합과 props 바인딩만 남긴다.
+- 검색/버전조회 계약은 테스트 가능한 함수와 훅으로 분리한다.
+- package type별 검색 전략, Electron/HTTP fallback, query param 동기화, OS 검색 분기를 별도 모듈로 이동한다.
+- 기존 UI 동작과 사용자 흐름은 유지한다.
+
+## 비목표
+
+- Wizard step 구조 자체의 재설계
+- Cart/Download 흐름의 동작 변경
+- Settings 저장 구조 변경
+- OS 검색 전용 컴포넌트(`OSPackageSearch`)와의 광범위한 통합 리팩터링
+
+## 제안 구조
+
+### 1. 오케스트레이션 훅
+
+새 훅 `src/renderer/pages/wizard-page/useWizardSearchFlow.ts`를 도입한다.
+
+역할:
+
+- 검색 입력 상태와 디바운스
+- 검색 실행과 검색 결과 상태
+- 패키지 선택 후 버전 조회
+- step 전이 (`검색 -> 버전`)
+- 선택 취소/검색 초기화
+- 장바구니 추가에 필요한 계산값 조립
+
+`WizardPage`는 이 훅이 반환하는 상태와 액션만 사용한다.
+
+### 2. 검색 서비스
+
+`src/renderer/pages/wizard-page/search-service.ts`
+
+역할:
+
+- package type별 검색 전략 선택
+- Electron IPC 우선 사용
+- IPC 미사용 시 HTTP endpoint fallback
+- OS 패키지 검색 결과를 `SearchResult` UI 모델로 변환
+
+핵심 API 예시:
+
+```ts
+searchPackagesByType(context, query): Promise<SearchResult[]>
+searchSuggestionsByType(context, query): Promise<SearchResult[]>
+```
+
+서비스는 `fetch`, `electronAPI`를 외부 주입 가능하게 구성해 테스트 시 mock하기 쉽게 만든다.
+
+### 3. 버전 조회 서비스
+
+`src/renderer/pages/wizard-page/version-service.ts`
+
+역할:
+
+- package type별 버전 조회 전략 캡슐화
+- Docker tag 조회, PyPI/Maven 버전 조회, Electron `search.versions` 우선 처리
+- Maven classifier 관련 부가 데이터 조회
+- OS 패키지는 검색 결과에 이미 포함된 버전 목록을 재사용
+
+핵심 API 예시:
+
+```ts
+loadPackageVersions(context, record): Promise<VersionSelectionResult>
+```
+
+### 4. Query Param 모듈
+
+`src/renderer/pages/wizard-page/query-params.ts`
+
+역할:
+
+- `type` query param 해석
+- 유효한 `PackageType`인지 검증
+- category, packageType, initialStep 계산
+- 파라미터 소비 후 URL 정리 여부 결정
+
+이 모듈은 React 없이 순수 함수로 유지한다.
+
+### 5. OS Context 모듈
+
+`src/renderer/pages/wizard-page/os-context.ts`
+
+역할:
+
+- `yum/apt/apk`별 배포판/아키텍처 선택 정보 계산
+- 검색용 OS distribution payload 생성
+- 장바구니용 `osContext` snapshot 생성
+- package type별 effective architecture 계산
+
+이 모듈은 기존 `WizardPage` 내부 switch들을 대체한다.
+
+### 6. 타입 모듈
+
+`src/renderer/pages/wizard-page/types.ts`
+
+역할:
+
+- `SearchResult`
+- search context / version context
+- classifier 조회 결과
+- UI 훅과 서비스 사이의 공용 계약 정의
+
+## 데이터 흐름
+
+1. `WizardPage`가 settings/cart store와 router hook에서 필요한 값을 읽는다.
+2. `useWizardSearchFlow`에 packageType, settings-derived context, store action을 전달한다.
+3. 훅은 `search-service`를 통해 suggestion/full search를 수행한다.
+4. 검색 결과 선택 시 `version-service`로 버전/부가 메타데이터를 조회한다.
+5. OS package type은 `os-context`를 통해 distribution payload를 만들고 동일한 service 계약으로 실행한다.
+6. query param 초기화는 `query-params`의 순수 함수 결과를 기반으로 페이지 초기 effect에서 처리한다.
+
+## 기존 동작 유지 규칙
+
+- package type별 검색 결과 형식은 현재 UI가 기대하는 구조를 유지한다.
+- OS 검색은 여전히 배포판/아키텍처 설정을 사용한다.
+- Electron IPC가 있으면 우선 사용하고, 없는 환경에서만 HTTP fallback을 탄다.
+- pip custom index, docker custom registry, conda channel, Maven classifier 동작을 유지한다.
+- step 흐름은 `카테고리 -> 패키지 타입 -> 검색 -> 버전`을 유지한다.
+
+## 테스트 전략
+
+### 단위 테스트
+
+- `query-params.test.ts`
+  - 유효한 `type` 파라미터 해석
+  - 무효한 `type` 무시
+  - 카테고리/step 계산
+
+- `os-context.test.ts`
+  - package type별 distribution/architecture 선택
+  - 장바구니용 `osContext` 생성
+  - effective architecture 계산
+
+- `search-service.test.ts`
+  - package type별 전략 선택
+  - Electron IPC 우선
+  - HTTP fallback
+  - OS 검색 결과 매핑
+  - pip/docker/conda 옵션 전달
+
+- `version-service.test.ts`
+  - Electron `search.versions` 우선
+  - PyPI/Maven/Docker fallback
+  - OS 버전 목록 재사용
+  - Maven classifier 조회 결과 조립
+
+### 통합 수준 검증
+
+- `useWizardSearchFlow`는 필요한 핵심 시나리오만 얇게 검증한다.
+- 복잡한 분기 대부분은 순수 함수/service 테스트로 커버한다.
+
+## 구현 순서
+
+1. 순수 타입/헬퍼 모듈 추가
+2. query param / OS context 테스트와 구현
+3. search-service 테스트 작성 후 구현
+4. version-service 테스트 작성 후 구현
+5. `useWizardSearchFlow`로 페이지 상태 일부 이관
+6. `WizardPage.tsx`를 조합형 컴포넌트로 축소
+7. 관련 문서 업데이트 및 검증
+
+## 리스크
+
+- 현재 `WizardPage`가 store와 UI state를 많이 직접 소유하고 있어, 훅 경계 이동 시 빠진 상태가 생길 수 있다.
+- Electron/HTTP fallback 경로가 package type마다 미묘하게 달라 회귀 가능성이 있다.
+- Maven classifier와 pip custom index는 일반 검색 흐름에 비해 부가 상태가 많아 누락 위험이 높다.
+
+## 완성 기준
+
+- `WizardPage.tsx`에서 검색/버전조회 세부 구현이 제거되고 UI 조합이 주가 된다.
+- 검색과 버전조회 계약이 별도 모듈에서 테스트 가능하다.
+- query param sync, OS distribution 분기, fallback 로직이 페이지 밖으로 이동한다.
+- 관련 테스트가 추가되고 기존 동작이 유지된다.

--- a/src/renderer/pages/WizardPage.tsx
+++ b/src/renderer/pages/WizardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Steps,
@@ -35,12 +35,24 @@ import {
 } from '@ant-design/icons';
 import { useCartStore, PackageType, Architecture } from '../stores/cart-store';
 import { useSettingsStore, DockerRegistry } from '../stores/settings-store';
-import type { OSPackageInfo } from '../../core/downloaders/os-shared/types';
+import {
+  buildOSCartContext,
+  getEffectiveArchitecture,
+  getOSCartContextSnapshot,
+} from './wizard-page/os-context';
+import {
+  resolveWizardTypeParam,
+  stripWizardTypeParam,
+} from './wizard-page/query-params';
+import { useWizardSearchFlow } from './wizard-page/useWizardSearchFlow';
+import {
+  LIBRARY_PACKAGE_TYPES,
+  OS_PACKAGE_TYPES,
+  type CategoryType,
+  type OSCartContextSnapshot,
+} from './wizard-page/types';
 
 const { Title, Text } = Typography;
-
-// 카테고리 타입
-type CategoryType = 'library' | 'os' | 'container';
 
 // 카테고리 옵션
 const categoryOptions: { value: CategoryType; label: string; icon: React.ReactNode; description: string }[] = [
@@ -143,59 +155,6 @@ const dockerRegistryOptions: { value: DockerRegistry; label: string; description
   { value: 'custom', label: '커스텀 레지스트리', description: '직접 레지스트리 URL 입력' },
 ];
 
-// 검색 결과 아이템
-interface SearchResult {
-  name: string;
-  version: string;
-  description?: string;
-  versions?: string[];
-  // OS 패키지용 추가 필드
-  downloadUrl?: string;
-  repository?: { baseUrl: string; name?: string };
-  location?: string;
-  architecture?: string;
-  // OS 패키지 전체 정보 (의존성 해결에 사용)
-  osPackageInfo?: OSPackageInfo;
-  // Docker 이미지용 추가 필드
-  registry?: string;
-  isOfficial?: boolean;
-  pullCount?: number;
-  // Maven 아티팩트용 추가 필드
-  popularityCount?: number;
-  groupId?: string;
-  artifactId?: string;
-}
-
-interface OSCartContextSnapshot {
-  distributionId: string;
-  architecture: Architecture;
-  packageManager: 'yum' | 'apt' | 'apk';
-}
-
-function getOSCartContextSnapshot(
-  metadata: Record<string, unknown> | undefined
-): OSCartContextSnapshot | null {
-  const raw = metadata?.osContext;
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
-
-  const { distributionId, architecture, packageManager } = raw as Partial<OSCartContextSnapshot>;
-  if (
-    typeof distributionId !== 'string' ||
-    typeof architecture !== 'string' ||
-    (packageManager !== 'yum' && packageManager !== 'apt' && packageManager !== 'apk')
-  ) {
-    return null;
-  }
-
-  return {
-    distributionId,
-    architecture: architecture as Architecture,
-    packageManager,
-  };
-}
-
 const WizardPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -209,33 +168,16 @@ const WizardPage: React.FC = () => {
 
   // URL 파라미터에서 패키지 타입 읽기
   useEffect(() => {
-    const typeParam = searchParams.get('type') as PackageType | null;
-    if (typeParam) {
-      const foundOption = packageTypeOptions.find(opt => opt.value === typeParam);
-      if (foundOption) {
-        setCategory(foundOption.category);
-        setPackageType(foundOption.value);
-        // 바로 검색 단계로 이동
-        setCurrentStep(2);
-        // 파라미터 사용 후 URL에서 제거 (깔끔한 URL 유지)
-        setSearchParams({}, { replace: true });
-      }
+    const resolved = resolveWizardTypeParam(searchParams);
+    if (!resolved) {
+      return;
     }
-  }, []);
 
-  // Step 3: 검색
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searching, setSearching] = useState(false);
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [selectedPackage, setSelectedPackage] = useState<SearchResult | null>(null);
-  const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Step 4: 버전
-  const [selectedVersion, setSelectedVersion] = useState<string>('');
-  const [availableVersions, setAvailableVersions] = useState<string[]>([]);
-  const [loadingVersions, setLoadingVersions] = useState(false);
+    setCategory(resolved.category);
+    setPackageType(resolved.packageType);
+    setCurrentStep(resolved.currentStep);
+    setSearchParams(stripWizardTypeParam(searchParams), { replace: true });
+  }, [searchParams, setSearchParams]);
 
   // Step 2: 언어 버전
   const [languageVersion, setLanguageVersion] = useState<string>('');
@@ -275,28 +217,12 @@ const WizardPage: React.FC = () => {
   // pip 커스텀 인덱스 URL 상태
   const [useCustomIndex, setUseCustomIndex] = useState(false);
   const [customIndexUrl, setCustomIndexUrl] = useState('');
-  const [usedIndexUrl, setUsedIndexUrl] = useState<string | undefined>(undefined); // 실제로 버전 조회 시 사용한 indexUrl
   const [showSaveIndexUrlModal, setShowSaveIndexUrlModal] = useState(false);
   const [indexUrlLabel, setIndexUrlLabel] = useState('');
 
-  // pip extras 상태 (예: jax[cuda] → ['cuda'])
-  const [extras, setExtras] = useState<string[]>([]);
-
-  // Maven classifier 관련 상태
-  const [isNativeLibrary, setIsNativeLibrary] = useState(false);
-  const [selectedClassifier, setSelectedClassifier] = useState<string | undefined>();
-  const [availableClassifiers, setAvailableClassifiers] = useState<string[]>([]);
-  const [customClassifier, setCustomClassifier] = useState('');
-
-  // 라이브러리 패키지 타입 (설정 기본값 적용 대상)
-  const libraryPackageTypes: PackageType[] = ['pip', 'conda', 'maven', 'npm'];
-
-  // OS 패키지 타입 (배포판별 설정 아키텍처 적용)
-  const osPackageTypes: PackageType[] = ['yum', 'apt', 'apk'];
-
   // OS/아키텍처 설정 적용 여부 판단 함수
   const shouldApplyDefaultOSArch = (type: PackageType): boolean => {
-    return libraryPackageTypes.includes(type);
+    return LIBRARY_PACKAGE_TYPES.includes(type);
   };
 
   // 카테고리에 맞는 패키지 타입 필터링
@@ -312,24 +238,6 @@ const WizardPage: React.FC = () => {
       setPackageType(firstType.value);
     }
     resetSearch();
-  };
-
-  // 검색 초기화
-  const resetSearch = () => {
-    setSearchQuery('');
-    setSearchResults([]);
-    setSelectedPackage(null);
-    setSelectedVersion('');
-    setAvailableVersions([]);
-    setSuggestions([]);
-    setShowSuggestions(false);
-    setUsedIndexUrl(undefined); // 사용한 indexUrl 초기화
-    // Maven classifier 초기화
-    setIsNativeLibrary(false);
-    setSelectedClassifier(undefined);
-    setAvailableClassifiers([]);
-    setCustomClassifier('');
-    // 언어 버전은 초기화하지 않음 (설정에서 가져온 기본값 유지)
   };
 
   // URL 유효성 검사
@@ -357,7 +265,7 @@ const WizardPage: React.FC = () => {
     if (shouldApplyDefaultOSArch(packageType)) {
       // 라이브러리 패키지: 설정에서 가져온 기본값 적용
       setArchitecture(defaultArchitecture as Architecture);
-    } else if (osPackageTypes.includes(packageType)) {
+    } else if (OS_PACKAGE_TYPES.includes(packageType)) {
       // OS 패키지: 각 배포판의 설정된 아키텍처 적용
       if (packageType === 'yum') {
         setArchitecture(yumDistribution.architecture as Architecture);
@@ -372,641 +280,48 @@ const WizardPage: React.FC = () => {
     }
   }, [packageType, defaultArchitecture, yumDistribution.architecture, aptDistribution.architecture, apkDistribution.architecture, dockerArchitecture]);
 
-  // 디바운스된 실시간 검색
-  const debouncedSearch = useCallback(async (query: string) => {
-    if (!query.trim() || query.length < 2) {
-      setSuggestions([]);
-      setShowSuggestions(false);
-      return;
-    }
-
-    setSearching(true);
-    try {
-      let results: SearchResult[];
-
-      // OS 패키지 타입인 경우 os.search 사용
-      const isOSPackage = ['yum', 'apt', 'apk'].includes(packageType);
-
-      if (isOSPackage && window.electronAPI?.os?.search) {
-        // OS 패키지: electronAPI.os.search 사용
-        const getDistributionInfo = () => {
-          switch (packageType) {
-            case 'yum':
-              return { id: yumDistribution.id, architecture: yumDistribution.architecture, packageManager: 'yum' };
-            case 'apt':
-              return { id: aptDistribution.id, architecture: aptDistribution.architecture, packageManager: 'apt' };
-            case 'apk':
-              return { id: apkDistribution.id, architecture: apkDistribution.architecture, packageManager: 'apk' };
-            default:
-              return null;
-          }
-        };
-
-        const distInfo = getDistributionInfo();
-        if (distInfo) {
-          const response = await window.electronAPI.os.search({
-            query,
-            distribution: {
-              id: distInfo.id,
-              name: distInfo.id,
-              packageManager: distInfo.packageManager,
-            },
-            architecture: distInfo.architecture as import('../../core/downloaders/os-shared/types').OSArchitecture,
-            matchType: 'partial',
-            limit: 20,
-          });
-
-          const packages = (response.packages || []) as OSPackageInfo[];
-          results = packages.map(pkg => ({
-            name: pkg.name,
-            version: pkg.version,
-            description: pkg.summary || pkg.description || '',
-            downloadUrl: `${pkg.repository.baseUrl}/${pkg.location}`,
-            repository: { baseUrl: pkg.repository.baseUrl, name: pkg.repository.name },
-            location: pkg.location,
-            architecture: pkg.architecture,
-            osPackageInfo: pkg,
-          }));
-        } else {
-          results = [];
-        }
-      } else if (window.electronAPI?.search?.packages) {
-        // 일반 패키지: search.packages 사용
-        let searchOptions: { channel?: string; registry?: string } | undefined;
-        if (packageType === 'conda') {
-          searchOptions = { channel: condaChannel };
-        } else if (packageType === 'docker') {
-          searchOptions = { registry: dockerRegistry };
-        }
-        const response = await window.electronAPI.search.packages(packageType, query, searchOptions);
-        results = response.results;
-      } else {
-        // 브라우저 환경: 패키지 타입별 API 직접 호출
-        results = await searchPackageByType(packageType, query);
-      }
-      setSuggestions(results);
-      setShowSuggestions(results.length > 0);
-    } catch (error) {
-      console.error('Search error:', error);
-      setSuggestions([]);
-    } finally {
-      setSearching(false);
-    }
-  }, [packageType, condaChannel, dockerRegistry, yumDistribution, aptDistribution, apkDistribution]);
-
-  // 입력 변경 핸들러 (디바운스 적용)
-  const handleInputChange = useCallback((value: string) => {
-    setSearchQuery(value);
-
-    // 기존 타이머 취소
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
-    }
-
-    // 새 디바운스 타이머 설정 (300ms)
-    debounceTimerRef.current = setTimeout(() => {
-      debouncedSearch(value);
-    }, 300);
-  }, [debouncedSearch]);
-
-  // 제안 항목 선택
-  const handleSuggestionSelect = (item: SearchResult) => {
-    setShowSuggestions(false);
-    setSearchQuery(item.name);
-    setSearchResults([item]);
-    handleSelectPackage(item);
-  };
-
-  // 브라우저에서 PyPI API로 패키지 검색
-  const searchPyPIPackage = async (query: string): Promise<SearchResult[]> => {
-    try {
-      const response = await fetch(`/api/pypi/pypi/${encodeURIComponent(query)}/json`);
-      if (!response.ok) {
-        if (response.status === 404) {
-          return [];
-        }
-        throw new Error('패키지를 찾을 수 없습니다');
-      }
-      const data = await response.json();
-      const versions = Object.keys(data.releases).sort((a, b) => {
-        // 버전 내림차순 정렬 (최신 버전 우선)
-        const partsA = a.split('.').map(Number);
-        const partsB = b.split('.').map(Number);
-        for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-          const numA = partsA[i] || 0;
-          const numB = partsB[i] || 0;
-          if (numB !== numA) return numB - numA;
-        }
-        return 0;
-      });
-      return [{
-        name: data.info.name,
-        version: data.info.version,
-        description: data.info.summary || '',
-        versions: versions.slice(0, 20), // 최신 20개 버전만
-      }];
-    } catch (error) {
-      console.error('PyPI search error:', error);
-      return [];
-    }
-  };
-
-  // 브라우저에서 Maven Central API로 패키지 검색
-  const searchMavenPackage = async (query: string): Promise<SearchResult[]> => {
-    try {
-      const response = await fetch(`/api/maven/search?q=${encodeURIComponent(query)}`);
-      if (!response.ok) {
-        return [];
-      }
-      const data = await response.json();
-      return data.results || [];
-    } catch (error) {
-      console.error('Maven search error:', error);
-      return [];
-    }
-  };
-
-  // npm Registry API로 패키지 검색 (IPC 우선, HTTP 폴백)
-  const searchNpmPackage = async (query: string): Promise<SearchResult[]> => {
-    try {
-      // Electron IPC 우선
-      if (window.electronAPI?.search?.packages) {
-        const result = await window.electronAPI.search.packages('npm', query);
-        return result.results || [];
-      }
-      // HTTP 폴백 (개발 환경)
-      const response = await fetch(`/api/npm/search?q=${encodeURIComponent(query)}`);
-      if (!response.ok) {
-        return [];
-      }
-      const data = await response.json();
-      return data.results || [];
-    } catch (error) {
-      console.error('npm search error:', error);
-      return [];
-    }
-  };
-
-  // Docker 이미지 검색 (레지스트리별, IPC 우선, HTTP 폴백)
-  const searchDockerImage = async (query: string, registry: DockerRegistry = 'docker.io'): Promise<SearchResult[]> => {
-    try {
-      const registryParam = registry === 'custom' && customRegistryUrl
-        ? customRegistryUrl
-        : registry;
-      // Electron IPC 우선
-      if (window.electronAPI?.search?.packages) {
-        const result = await window.electronAPI.search.packages('docker', query, { registry: registryParam });
-        // 검색 결과에 레지스트리 정보 추가
-        return (result.results || []).map((item: SearchResult) => ({
-          ...item,
-          registry: registryParam,
-        }));
-      }
-      // HTTP 폴백 (개발 환경)
-      const response = await fetch(`/api/docker/search?q=${encodeURIComponent(query)}&registry=${encodeURIComponent(registryParam)}`);
-      if (!response.ok) {
-        return [];
-      }
-      const data = await response.json();
-      // 검색 결과에 레지스트리 정보 추가
-      return (data.results || []).map((item: SearchResult) => ({
-        ...item,
-        registry: registryParam,
-      }));
-    } catch (error) {
-      console.error('Docker search error:', error);
-      return [];
-    }
-  };
-
-  // Docker 이미지 태그 목록 조회 (IPC 우선, HTTP 폴백)
-  const fetchDockerTags = async (imageName: string, registry: DockerRegistry = 'docker.io'): Promise<string[]> => {
-    try {
-      const registryParam = registry === 'custom' && customRegistryUrl
-        ? customRegistryUrl
-        : registry;
-      // Electron IPC 우선
-      if (window.electronAPI?.search?.versions) {
-        const result = await window.electronAPI.search.versions('docker', imageName, { registry: registryParam });
-        return result.versions || ['latest'];
-      }
-      // HTTP 폴백 (개발 환경)
-      const response = await fetch(`/api/docker/tags?image=${encodeURIComponent(imageName)}&registry=${encodeURIComponent(registryParam)}`);
-      if (!response.ok) {
-        return ['latest'];
-      }
-      const data = await response.json();
-      return data.tags || ['latest'];
-    } catch (error) {
-      console.error('Docker tags fetch error:', error);
-      return ['latest'];
-    }
-  };
-
-  // OS 패키지 API로 검색 (YUM, APT, APK) - IPC 우선, HTTP 폴백
-  const searchOSPackage = async (type: PackageType, query: string): Promise<SearchResult[]> => {
-    try {
-      // 패키지 타입에 따라 설정에서 배포판 정보 가져오기
-      const getDistributionInfo = (pkgType: string) => {
-        switch (pkgType) {
-          case 'yum':
-            return {
-              id: yumDistribution.id,
-              name: yumDistribution.id, // 서버에서 getDistributionById로 조회
-              osType: 'linux',
-              packageManager: 'yum',
-              architecture: yumDistribution.architecture,
-            };
-          case 'apt':
-            return {
-              id: aptDistribution.id,
-              name: aptDistribution.id,
-              osType: 'linux',
-              packageManager: 'apt',
-              architecture: aptDistribution.architecture,
-            };
-          case 'apk':
-            return {
-              id: apkDistribution.id,
-              name: apkDistribution.id,
-              osType: 'linux',
-              packageManager: 'apk',
-              architecture: apkDistribution.architecture,
-            };
-          default:
-            return null;
-        }
-      };
-
-      const distributionInfo = getDistributionInfo(type);
-      if (!distributionInfo) {
-        console.warn(`Unknown OS package type: ${type}`);
-        return [];
-      }
-
-      // OS 패키지 결과를 SearchResult 형식으로 변환하는 헬퍼 함수
-      // API는 OSPackageInfo[] 형식으로 반환함
-      const mapOSPackageResult = (data: { packages?: OSPackageInfo[]; totalCount?: number }): SearchResult[] => {
-        return (data.packages || []).map((pkg) => ({
-          name: pkg.name,
-          version: pkg.version,
-          description: pkg.summary || pkg.description || '',
-          versions: [pkg.version], // 단일 버전 (검색 결과는 각 패키지 1개씩)
-          downloadUrl: `${pkg.repository.baseUrl}/${pkg.location}`,
-          repository: { baseUrl: pkg.repository.baseUrl, name: pkg.repository.name },
-          location: pkg.location,
-          architecture: pkg.architecture,
-          // 전체 OSPackageInfo 저장 (의존성 해결에 사용)
-          osPackageInfo: pkg,
-        }));
-      };
-
-      // Electron IPC 사용 (개발/프로덕션 모두)
-      if (!window.electronAPI?.os?.search) {
-        console.error('OS 패키지 검색 API를 사용할 수 없습니다');
-        return [];
-      }
-      const result = await window.electronAPI.os.search({
-        query,
-        distribution: {
-          id: distributionInfo.id,
-          name: distributionInfo.name,
-          osType: distributionInfo.osType,
-          packageManager: distributionInfo.packageManager,
-        },
-        architecture: distributionInfo.architecture,
-        matchType: 'contains',
-        limit: 50,
-      }) as { packages: OSPackageInfo[]; totalCount: number };
-      return mapOSPackageResult(result);
-    } catch (error) {
-      console.error(`${type} search error:`, error);
-      return [];
-    }
-  };
-
-  // 패키지 타입별 브라우저 검색 함수
-  const searchPackageByType = async (type: PackageType, query: string): Promise<SearchResult[]> => {
-    switch (type) {
-      case 'pip':
-      case 'conda':
-        return searchPyPIPackage(query);
-      case 'maven':
-        return searchMavenPackage(query);
-      case 'npm':
-        return searchNpmPackage(query);
-      case 'docker':
-        return searchDockerImage(query, dockerRegistry);
-      case 'yum':
-      case 'apt':
-      case 'apk':
-        return searchOSPackage(type, query);
-      default:
-        return [];
-    }
-  };
-
-  // 패키지 검색 (IPC 호출)
-  const handleSearch = async (query: string) => {
-    if (!query.trim()) {
-      message.warning('검색어를 입력하세요');
-      return;
-    }
-
-    // pip 패키지명에서 extras 파싱 (예: jax[cuda] → name: jax, extras: [cuda])
-    let searchQuery = query;
-    let parsedExtras: string[] = [];
-
-    if (packageType === 'pip') {
-      const extrasMatch = query.match(/^([a-zA-Z0-9_-]+)\[([a-zA-Z0-9_,\s]+)\]$/);
-      if (extrasMatch) {
-        searchQuery = extrasMatch[1]; // 패키지명만 추출
-        parsedExtras = extrasMatch[2].split(',').map(e => e.trim()); // extras 배열
-        setExtras(parsedExtras);
-      } else {
-        setExtras([]); // extras 없는 경우 초기화
-      }
-    }
-
-    setSearching(true);
-    setSearchResults([]);
-
-    try {
-      let results: SearchResult[];
-
-      // OS 패키지 타입인 경우 별도의 OS API 사용
-      const isOSPackage = ['yum', 'apt', 'apk'].includes(packageType);
-
-      if (isOSPackage && window.electronAPI?.os?.search) {
-        // OS 패키지: electronAPI.os.search 사용
-        const getDistributionInfo = () => {
-          switch (packageType) {
-            case 'yum':
-              return { id: yumDistribution.id, architecture: yumDistribution.architecture, packageManager: 'yum' };
-            case 'apt':
-              return { id: aptDistribution.id, architecture: aptDistribution.architecture, packageManager: 'apt' };
-            case 'apk':
-              return { id: apkDistribution.id, architecture: apkDistribution.architecture, packageManager: 'apk' };
-            default:
-              return null;
-          }
-        };
-
-        const distInfo = getDistributionInfo();
-        if (!distInfo) {
-          throw new Error(`지원하지 않는 OS 패키지 타입: ${packageType}`);
-        }
-
-        const response = await window.electronAPI.os.search({
-          query: searchQuery,
-          distribution: {
-            id: distInfo.id,
-            name: distInfo.id,
-            osType: 'linux',
-            packageManager: distInfo.packageManager,
-          },
-          architecture: distInfo.architecture as import('../../core/downloaders/os-shared/types').OSArchitecture,
-          matchType: 'partial',
-          limit: 50,
-        });
-
-        // OS 패키지 결과를 SearchResult 형식으로 변환 (메타데이터 포함)
-        const packages = (response.packages || []) as OSPackageInfo[];
-        results = packages.map(pkg => ({
-          name: pkg.name,
-          version: pkg.version,
-          description: pkg.summary || pkg.description || '',
-          downloadUrl: `${pkg.repository.baseUrl}/${pkg.location}`,
-          repository: { baseUrl: pkg.repository.baseUrl, name: pkg.repository.name },
-          location: pkg.location,
-          architecture: pkg.architecture,
-          osPackageInfo: pkg,
-        }));
-      } else if (window.electronAPI?.search?.packages) {
-        // 일반 패키지: electronAPI.search.packages 사용
-        let searchOptions: { channel?: string; registry?: string; indexUrl?: string } | undefined;
-
-        if (packageType === 'pip') {
-          // pip 커스텀 인덱스 URL 전달
-          if (useCustomIndex && customIndexUrl) {
-            searchOptions = { indexUrl: customIndexUrl };
-          }
-        } else if (packageType === 'conda') {
-          searchOptions = { channel: condaChannel };
-        } else if (packageType === 'docker') {
-          const registryValue = dockerRegistry === 'custom' && customRegistryUrl
-            ? customRegistryUrl
-            : dockerRegistry;
-          searchOptions = { registry: registryValue };
-        }
-
-        const response = await window.electronAPI.search.packages(packageType, searchQuery, searchOptions);
-        results = response.results;
-      } else {
-        // 브라우저 환경: 패키지 타입별 API 직접 호출
-        results = await searchPackageByType(packageType, searchQuery);
-      }
-
-      setSearchResults(results);
-
-      if (results.length === 0) {
-        message.info('검색 결과가 없습니다');
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : '검색 중 오류가 발생했습니다';
-      message.error(errorMessage);
-      console.error('Search error:', error);
-    } finally {
-      setSearching(false);
-    }
-  };
-
-  // 브라우저에서 PyPI API로 버전 목록 조회
-  const fetchPyPIVersions = async (packageName: string): Promise<string[]> => {
-    try {
-      const response = await fetch(`/api/pypi/pypi/${encodeURIComponent(packageName)}/json`);
-      if (!response.ok) return [];
-      const data = await response.json();
-      const versions = Object.keys(data.releases).sort((a, b) => {
-        const partsA = a.split('.').map(Number);
-        const partsB = b.split('.').map(Number);
-        for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-          const numA = partsA[i] || 0;
-          const numB = partsB[i] || 0;
-          if (numB !== numA) return numB - numA;
-        }
-        return 0;
-      });
-      return versions;
-    } catch (error) {
-      console.error('PyPI versions fetch error:', error);
-      return [];
-    }
-  };
-
-  // 패키지 선택 및 버전 목록 조회
-  const handleSelectPackage = async (record: SearchResult) => {
-    setSelectedPackage(record);
-    setSelectedVersion(record.version);
-    setCurrentStep(3); // 버전 선택 단계로 이동
-    setLoadingVersions(true);
-
-    try {
-      if (window.electronAPI?.search?.versions) {
-        // 패키지 타입별 옵션 전달
-        let searchOptions: { channel?: string; registry?: string; indexUrl?: string } | undefined;
-        let actualIndexUrl: string | undefined = undefined;
-
-        if (packageType === 'pip') {
-          // pip 커스텀 인덱스 URL 전달
-          if (useCustomIndex && customIndexUrl) {
-            searchOptions = { indexUrl: customIndexUrl };
-            actualIndexUrl = customIndexUrl; // 실제 사용한 indexUrl 기록
-          }
-        } else if (packageType === 'conda') {
-          searchOptions = { channel: condaChannel };
-        } else if (packageType === 'docker') {
-          const registryValue = dockerRegistry === 'custom' && customRegistryUrl
-            ? customRegistryUrl
-            : dockerRegistry;
-          searchOptions = { registry: registryValue };
-        }
-
-        const response = await window.electronAPI.search.versions(packageType, record.name, searchOptions);
-        if (response.versions && response.versions.length > 0) {
-          setAvailableVersions(response.versions);
-          setSelectedVersion(response.versions[0]);
-          // pip의 경우 실제 사용한 indexUrl 저장
-          if (packageType === 'pip') {
-            setUsedIndexUrl(actualIndexUrl);
-          }
-        } else {
-          setAvailableVersions([record.version]);
-        }
-
-        // Maven: Electron 환경에서도 네이티브 아티팩트 여부 확인 및 classifier 조회
-        if (packageType === 'maven' && window.electronAPI?.maven) {
-          const groupId = record.groupId || record.name.split(':')[0];
-          const artifactId = record.artifactId || record.name.split(':')[1] || record.name;
-          const version = record.version;
-
-          console.log('[Classifier] Checking native artifact (Electron):', { groupId, artifactId, version, record });
-
-          try {
-            const isNative = await window.electronAPI.maven.isNativeArtifact(groupId, artifactId, version);
-            console.log('[Classifier] isNativeArtifact result:', isNative);
-            setIsNativeLibrary(isNative);
-
-            if (isNative) {
-              const classifiers = await window.electronAPI.maven.getAvailableClassifiers(groupId, artifactId, version);
-              console.log('[Classifier] Available classifiers:', classifiers);
-              setAvailableClassifiers(classifiers);
-              // 기본값: 선택 안함 (사용자가 명시적으로 선택)
-              setSelectedClassifier(undefined);
-            } else {
-              setAvailableClassifiers([]);
-              setSelectedClassifier(undefined);
-            }
-          } catch (err) {
-            console.error('Maven native check error:', err);
-            setIsNativeLibrary(false);
-            setAvailableClassifiers([]);
-            setSelectedClassifier(undefined);
-          }
-        }
-      } else if (packageType === 'pip' || packageType === 'conda') {
-        // 브라우저 환경: PyPI API 직접 호출
-        const versions = await fetchPyPIVersions(record.name);
-        if (versions.length > 0) {
-          setAvailableVersions(versions);
-          setSelectedVersion(versions[0]);
-          // 브라우저 환경에서는 항상 PyPI 사용 (커스텀 인덱스 미지원)
-          setUsedIndexUrl(undefined);
-        } else {
-          setAvailableVersions(record.versions || [record.version]);
-        }
-      } else if (packageType === 'maven') {
-        // 브라우저 환경: Maven 버전 API 직접 호출
-        try {
-          const response = await fetch(`/api/maven/versions?package=${encodeURIComponent(record.name)}`);
-          if (response.ok) {
-            const data = await response.json();
-            if (data.versions && data.versions.length > 0) {
-              setAvailableVersions(data.versions);
-              setSelectedVersion(data.versions[0]);
-            } else {
-              setAvailableVersions([record.version]);
-            }
-          } else {
-            setAvailableVersions([record.version]);
-          }
-        } catch (err) {
-          console.error('Maven version fetch error:', err);
-          setAvailableVersions([record.version]);
-        }
-
-        // Maven: 네이티브 아티팩트 여부 확인 및 classifier 조회
-        if (window.electronAPI?.maven) {
-          const groupId = record.groupId || record.name.split(':')[0];
-          const artifactId = record.artifactId || record.name.split(':')[1] || record.name;
-          const version = record.version;
-
-          console.log('[Classifier] Checking native artifact:', { groupId, artifactId, version, record });
-
-          try {
-            const isNative = await window.electronAPI.maven.isNativeArtifact(groupId, artifactId, version);
-            console.log('[Classifier] isNativeArtifact result:', isNative);
-            setIsNativeLibrary(isNative);
-
-            if (isNative) {
-              const classifiers = await window.electronAPI.maven.getAvailableClassifiers(groupId, artifactId, version);
-              console.log('[Classifier] Available classifiers:', classifiers);
-              setAvailableClassifiers(classifiers);
-              // 기본값: 선택 안함 (사용자가 명시적으로 선택)
-              setSelectedClassifier(undefined);
-            } else {
-              setAvailableClassifiers([]);
-              setSelectedClassifier(undefined);
-            }
-          } catch (err) {
-            console.error('Maven native check error:', err);
-            setIsNativeLibrary(false);
-            setAvailableClassifiers([]);
-            setSelectedClassifier(undefined);
-          }
-        } else {
-          console.log('[Classifier] electronAPI.maven not available');
-        }
-      } else if (packageType === 'docker') {
-        // Docker: 태그 목록 조회
-        const tags = await fetchDockerTags(record.name, dockerRegistry);
-        if (tags.length > 0) {
-          setAvailableVersions(tags);
-          // latest가 있으면 기본 선택, 아니면 첫 번째
-          const defaultTag = tags.includes('latest') ? 'latest' : tags[0];
-          setSelectedVersion(defaultTag);
-        } else {
-          setAvailableVersions(['latest']);
-          setSelectedVersion('latest');
-        }
-      } else if (['yum', 'apt', 'apk'].includes(packageType)) {
-        // OS 패키지: 검색 결과에 이미 버전 목록이 포함됨 (그룹화된 결과)
-        if (record.versions && record.versions.length > 0) {
-          setAvailableVersions(record.versions);
-          setSelectedVersion(record.versions[0]); // 최신 버전 선택
-        } else {
-          setAvailableVersions([record.version]);
-        }
-      } else {
-        setAvailableVersions(record.versions || [record.version]);
-      }
-    } catch (error) {
-      console.error('Version fetch error:', error);
-      setAvailableVersions([record.version]);
-    } finally {
-      setLoadingVersions(false);
-    }
-  };
+  const {
+    searchQuery,
+    searching,
+    selectedPackage,
+    suggestions,
+    showSuggestions,
+    setShowSuggestions,
+    selectedVersion,
+    setSelectedVersion,
+    availableVersions,
+    loadingVersions,
+    usedIndexUrl,
+    extras,
+    isNativeLibrary,
+    selectedClassifier,
+    setSelectedClassifier,
+    availableClassifiers,
+    customClassifier,
+    setCustomClassifier,
+    resetSearch,
+    handleInputChange,
+    handleSuggestionSelect,
+  } = useWizardSearchFlow({
+    packageType,
+    searchContext: {
+      packageType,
+      condaChannel,
+      dockerRegistry,
+      customRegistryUrl,
+      useCustomIndex,
+      customIndexUrl,
+      yumDistribution,
+      aptDistribution,
+      apkDistribution,
+    },
+    setCurrentStep,
+    notifier: {
+      info: message.info,
+      warning: message.warning,
+      error: message.error,
+    },
+  });
 
   // 장바구니 추가
   const handleAddToCart = () => {
@@ -1017,41 +332,28 @@ const WizardPage: React.FC = () => {
       return;
     }
 
-    // 아키텍처 결정 로직
-    const getEffectiveArchitecture = (): Architecture => {
-      // 라이브러리 패키지: 설정의 기본 아키텍처 사용
-      if (libraryPackageTypes.includes(packageType)) {
-        return defaultArchitecture as Architecture;
-      }
-      // OS 패키지: 각 배포판의 설정된 아키텍처 사용
-      if (packageType === 'yum') return yumDistribution.architecture as Architecture;
-      if (packageType === 'apt') return aptDistribution.architecture as Architecture;
-      if (packageType === 'apk') return apkDistribution.architecture as Architecture;
-      // Docker: 설정의 Docker 아키텍처 사용
-      if (packageType === 'docker') return dockerArchitecture as Architecture;
-      // 기타: 수동 선택된 아키텍처 사용 (폴백)
-      return architecture;
-    };
-    const effectiveArch = getEffectiveArchitecture();
-    const osCartContext = packageType === 'yum'
-      ? {
-          distributionId: yumDistribution.id,
-          architecture: effectiveArch,
-          packageManager: 'yum' as const,
-        }
-      : packageType === 'apt'
-      ? {
-          distributionId: aptDistribution.id,
-          architecture: effectiveArch,
-          packageManager: 'apt' as const,
-        }
-      : packageType === 'apk'
-      ? {
-          distributionId: apkDistribution.id,
-          architecture: effectiveArch,
-          packageManager: 'apk' as const,
-        }
-      : null;
+    const effectiveArch = getEffectiveArchitecture(
+      packageType,
+      {
+        defaultArchitecture,
+        yumDistribution,
+        aptDistribution,
+        apkDistribution,
+        dockerArchitecture,
+      },
+      architecture
+    );
+    const osCartContext = buildOSCartContext(
+      packageType,
+      {
+        defaultArchitecture,
+        yumDistribution,
+        aptDistribution,
+        apkDistribution,
+        dockerArchitecture,
+      },
+      effectiveArch
+    );
 
     // Docker 이미지: 레지스트리 정보 포함
     const dockerMetadata = packageType === 'docker' ? {
@@ -1070,11 +372,11 @@ const WizardPage: React.FC = () => {
         description: selectedPackage.description,
         category,
         // 라이브러리 패키지는 targetOS도 저장
-        ...(libraryPackageTypes.includes(packageType) && { targetOS: defaultTargetOS }),
+        ...(LIBRARY_PACKAGE_TYPES.includes(packageType) && { targetOS: defaultTargetOS }),
         // Docker 이미지 메타데이터
         ...dockerMetadata,
         // OS 패키지 전체 정보 (의존성 해결에 사용)
-        ...(osPackageTypes.includes(packageType) && selectedPackage.osPackageInfo && {
+        ...(OS_PACKAGE_TYPES.includes(packageType) && selectedPackage.osPackageInfo && {
           osPackageInfo: selectedPackage.osPackageInfo,
         }),
         ...(osCartContext && {

--- a/src/renderer/pages/wizard-page/os-context.test.ts
+++ b/src/renderer/pages/wizard-page/os-context.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { PackageType, Architecture } from '../../stores/cart-store';
+import type {
+  DefaultArchitecture,
+  DockerArchitecture,
+  OSDistributionSetting,
+  TargetOS,
+} from '../../stores/settings-store';
+import {
+  buildOSCartContext,
+  getEffectiveArchitecture,
+  getOSDistributionInfo,
+} from './os-context';
+
+interface SettingsFixture {
+  defaultArchitecture: DefaultArchitecture;
+  defaultTargetOS: TargetOS;
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+  dockerArchitecture: DockerArchitecture;
+}
+
+const settings: SettingsFixture = {
+  defaultArchitecture: 'arm64',
+  defaultTargetOS: 'linux',
+  yumDistribution: { id: 'rocky-9', architecture: 'x86_64' },
+  aptDistribution: { id: 'ubuntu-24.04', architecture: 'amd64' },
+  apkDistribution: { id: 'alpine-3.20', architecture: 'aarch64' },
+  dockerArchitecture: '386',
+};
+
+describe('os-context', () => {
+  it('OS 패키지 타입별 distribution 정보를 계산한다', () => {
+    expect(getOSDistributionInfo('yum', settings)).toEqual({
+      id: 'rocky-9',
+      name: 'rocky-9',
+      osType: 'linux',
+      packageManager: 'yum',
+      architecture: 'x86_64',
+    });
+
+    expect(getOSDistributionInfo('apt', settings)).toEqual({
+      id: 'ubuntu-24.04',
+      name: 'ubuntu-24.04',
+      osType: 'linux',
+      packageManager: 'apt',
+      architecture: 'amd64',
+    });
+  });
+
+  it('effective architecture는 package type별 기본 규칙을 따른다', () => {
+    expect(getEffectiveArchitecture('pip', settings, 'i386')).toBe('arm64');
+    expect(getEffectiveArchitecture('yum', settings, 'i386')).toBe('x86_64');
+    expect(getEffectiveArchitecture('docker', settings, 'i386')).toBe('386');
+    expect(getEffectiveArchitecture('maven', settings, 'i386')).toBe('arm64');
+  });
+
+  it('OS 패키지 타입은 장바구니용 osContext를 생성한다', () => {
+    expect(buildOSCartContext('apk', settings, 'aarch64')).toEqual({
+      distributionId: 'alpine-3.20',
+      architecture: 'aarch64',
+      packageManager: 'apk',
+    });
+
+    expect(buildOSCartContext('pip', settings, 'arm64')).toBeNull();
+  });
+});

--- a/src/renderer/pages/wizard-page/os-context.ts
+++ b/src/renderer/pages/wizard-page/os-context.ts
@@ -1,0 +1,130 @@
+import type { Architecture, PackageType } from '../../stores/cart-store';
+import type {
+  DefaultArchitecture,
+  DockerArchitecture,
+  OSDistributionSetting,
+} from '../../stores/settings-store';
+import {
+  LIBRARY_PACKAGE_TYPES,
+  type OSCartContextSnapshot,
+} from './types';
+
+type OSPackageType = OSCartContextSnapshot['packageManager'];
+
+export interface WizardOSContextSettings {
+  defaultArchitecture: DefaultArchitecture;
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+  dockerArchitecture: DockerArchitecture;
+}
+
+export interface WizardOSDistributionSettings {
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+}
+
+export interface WizardOSDistributionInfo {
+  id: string;
+  name: string;
+  osType: 'linux';
+  packageManager: OSPackageType;
+  architecture: string;
+}
+
+function getDistributionSetting(
+  packageType: PackageType,
+  settings: WizardOSDistributionSettings
+): { packageManager: OSPackageType; distribution: OSDistributionSetting } | null {
+  switch (packageType) {
+    case 'yum':
+      return { packageManager: 'yum', distribution: settings.yumDistribution };
+    case 'apt':
+      return { packageManager: 'apt', distribution: settings.aptDistribution };
+    case 'apk':
+      return { packageManager: 'apk', distribution: settings.apkDistribution };
+    default:
+      return null;
+  }
+}
+
+export function getOSDistributionInfo(
+  packageType: PackageType,
+  settings: WizardOSDistributionSettings
+): WizardOSDistributionInfo | null {
+  const match = getDistributionSetting(packageType, settings);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    id: match.distribution.id,
+    name: match.distribution.id,
+    osType: 'linux',
+    packageManager: match.packageManager,
+    architecture: match.distribution.architecture,
+  };
+}
+
+export function getEffectiveArchitecture(
+  packageType: PackageType,
+  settings: WizardOSContextSettings,
+  manualArchitecture: Architecture
+): Architecture {
+  if (LIBRARY_PACKAGE_TYPES.includes(packageType)) {
+    return settings.defaultArchitecture as Architecture;
+  }
+
+  const osDistribution = getOSDistributionInfo(packageType, settings);
+  if (osDistribution) {
+    return osDistribution.architecture as Architecture;
+  }
+
+  if (packageType === 'docker') {
+    return settings.dockerArchitecture as Architecture;
+  }
+
+  return manualArchitecture;
+}
+
+export function buildOSCartContext(
+  packageType: PackageType,
+  settings: WizardOSContextSettings,
+  architecture: Architecture
+): OSCartContextSnapshot | null {
+  const distribution = getOSDistributionInfo(packageType, settings);
+  if (!distribution) {
+    return null;
+  }
+
+  return {
+    distributionId: distribution.id,
+    architecture,
+    packageManager: distribution.packageManager,
+  };
+}
+
+export function getOSCartContextSnapshot(
+  metadata: Record<string, unknown> | undefined
+): OSCartContextSnapshot | null {
+  const raw = metadata?.osContext;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const { distributionId, architecture, packageManager } = raw as Partial<OSCartContextSnapshot>;
+  if (
+    typeof distributionId !== 'string' ||
+    typeof architecture !== 'string' ||
+    (packageManager !== 'yum' && packageManager !== 'apt' && packageManager !== 'apk')
+  ) {
+    return null;
+  }
+
+  return {
+    distributionId,
+    architecture: architecture as Architecture,
+    packageManager,
+  };
+}

--- a/src/renderer/pages/wizard-page/query-params.test.ts
+++ b/src/renderer/pages/wizard-page/query-params.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveWizardTypeParam,
+  stripWizardTypeParam,
+} from './query-params';
+
+describe('query-params', () => {
+  it('유효한 type 파라미터를 category/packageType/step으로 해석한다', () => {
+    expect(resolveWizardTypeParam(new URLSearchParams('type=yum'))).toEqual({
+      category: 'os',
+      packageType: 'yum',
+      currentStep: 2,
+    });
+  });
+
+  it('유효하지 않은 type 파라미터는 무시한다', () => {
+    expect(resolveWizardTypeParam(new URLSearchParams('type=unknown'))).toBeNull();
+    expect(resolveWizardTypeParam(new URLSearchParams('foo=bar'))).toBeNull();
+  });
+
+  it('type 파라미터만 제거하고 다른 파라미터는 유지한다', () => {
+    const params = stripWizardTypeParam(new URLSearchParams('type=apk&tab=advanced'));
+
+    expect(params.toString()).toBe('tab=advanced');
+  });
+});

--- a/src/renderer/pages/wizard-page/query-params.test.ts
+++ b/src/renderer/pages/wizard-page/query-params.test.ts
@@ -15,6 +15,8 @@ describe('query-params', () => {
 
   it('유효하지 않은 type 파라미터는 무시한다', () => {
     expect(resolveWizardTypeParam(new URLSearchParams('type=unknown'))).toBeNull();
+    expect(resolveWizardTypeParam(new URLSearchParams('type=toString'))).toBeNull();
+    expect(resolveWizardTypeParam(new URLSearchParams('type=__proto__'))).toBeNull();
     expect(resolveWizardTypeParam(new URLSearchParams('foo=bar'))).toBeNull();
   });
 

--- a/src/renderer/pages/wizard-page/query-params.ts
+++ b/src/renderer/pages/wizard-page/query-params.ts
@@ -1,0 +1,29 @@
+import type { PackageType } from '../../stores/cart-store';
+import { PACKAGE_TYPE_TO_CATEGORY, isPackageType } from './types';
+
+export interface WizardTypeParamState {
+  category: (typeof PACKAGE_TYPE_TO_CATEGORY)[PackageType];
+  packageType: PackageType;
+  currentStep: 2;
+}
+
+export function resolveWizardTypeParam(
+  searchParams: URLSearchParams
+): WizardTypeParamState | null {
+  const typeParam = searchParams.get('type');
+  if (!typeParam || !isPackageType(typeParam)) {
+    return null;
+  }
+
+  return {
+    category: PACKAGE_TYPE_TO_CATEGORY[typeParam],
+    packageType: typeParam,
+    currentStep: 2,
+  };
+}
+
+export function stripWizardTypeParam(searchParams: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.delete('type');
+  return next;
+}

--- a/src/renderer/pages/wizard-page/search-service.test.ts
+++ b/src/renderer/pages/wizard-page/search-service.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PackageType } from '../../stores/cart-store';
+import type { DockerRegistry, OSDistributionSetting } from '../../stores/settings-store';
+import { createSearchService } from './search-service';
+
+interface SearchContextFixture {
+  packageType: PackageType;
+  condaChannel: string;
+  dockerRegistry: DockerRegistry;
+  customRegistryUrl: string;
+  useCustomIndex: boolean;
+  customIndexUrl: string;
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+}
+
+const baseContext: SearchContextFixture = {
+  packageType: 'npm',
+  condaChannel: 'conda-forge',
+  dockerRegistry: 'docker.io',
+  customRegistryUrl: '',
+  useCustomIndex: false,
+  customIndexUrl: '',
+  yumDistribution: { id: 'rocky-9', architecture: 'x86_64' },
+  aptDistribution: { id: 'ubuntu-24.04', architecture: 'amd64' },
+  apkDistribution: { id: 'alpine-3.20', architecture: 'aarch64' },
+};
+
+describe('search-service', () => {
+  it('일반 패키지는 Electron search.packages를 우선 사용한다', async () => {
+    const electronAPI = {
+      search: {
+        packages: vi.fn().mockResolvedValue({
+          results: [{ name: 'react', version: '19.2.0', description: 'ui' }],
+        }),
+      },
+    };
+    const fetchImpl = vi.fn();
+    const service = createSearchService({ electronAPI, fetchImpl });
+
+    const results = await service.searchPackages(baseContext, 'react');
+
+    expect(electronAPI.search.packages).toHaveBeenCalledWith('npm', 'react', undefined);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(results).toEqual([{ name: 'react', version: '19.2.0', description: 'ui' }]);
+  });
+
+  it('Electron search가 없으면 npm HTTP fallback을 사용한다', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ name: 'vite', version: '7.2.0', description: 'build tool' }],
+      }),
+    });
+    const service = createSearchService({ fetchImpl });
+
+    const results = await service.searchPackages(baseContext, 'vite');
+
+    expect(fetchImpl).toHaveBeenCalledWith('/api/npm/search?q=vite');
+    expect(results).toEqual([{ name: 'vite', version: '7.2.0', description: 'build tool' }]);
+  });
+
+  it('docker 검색은 커스텀 registry를 Electron search 옵션으로 전달한다', async () => {
+    const electronAPI = {
+      search: {
+        packages: vi.fn().mockResolvedValue({
+          results: [{ name: 'org/app', version: 'latest', description: 'image' }],
+        }),
+      },
+    };
+    const service = createSearchService({ electronAPI });
+
+    await service.searchPackages(
+      {
+        ...baseContext,
+        packageType: 'docker',
+        dockerRegistry: 'custom',
+        customRegistryUrl: 'registry.example.internal',
+      },
+      'org/app'
+    );
+
+    expect(electronAPI.search.packages).toHaveBeenCalledWith('docker', 'org/app', {
+      registry: 'registry.example.internal',
+    });
+  });
+
+  it('OS 검색은 distribution payload를 포함한 os.search를 사용한다', async () => {
+    const electronAPI = {
+      os: {
+        search: vi.fn().mockResolvedValue({
+          packages: [
+            {
+              name: 'bash',
+              version: '5.2.21',
+              summary: 'GNU shell',
+              description: 'GNU shell',
+              architecture: 'amd64',
+              location: 'pool/bash.deb',
+              repository: { baseUrl: 'https://mirror.example', name: 'main' },
+            },
+          ],
+          totalCount: 1,
+        }),
+      },
+    };
+    const service = createSearchService({ electronAPI });
+
+    const results = await service.searchSuggestions(
+      {
+        ...baseContext,
+        packageType: 'apt',
+      },
+      'bash'
+    );
+
+    expect(electronAPI.os.search).toHaveBeenCalledWith({
+      query: 'bash',
+      distribution: {
+        id: 'ubuntu-24.04',
+        name: 'ubuntu-24.04',
+        osType: 'linux',
+        packageManager: 'apt',
+      },
+      architecture: 'amd64',
+      matchType: 'partial',
+      limit: 20,
+    });
+    expect(results).toEqual([
+      {
+        name: 'bash',
+        version: '5.2.21',
+        description: 'GNU shell',
+        downloadUrl: 'https://mirror.example/pool/bash.deb',
+        repository: { baseUrl: 'https://mirror.example', name: 'main' },
+        location: 'pool/bash.deb',
+        architecture: 'amd64',
+        osPackageInfo: {
+          name: 'bash',
+          version: '5.2.21',
+          summary: 'GNU shell',
+          description: 'GNU shell',
+          architecture: 'amd64',
+          location: 'pool/bash.deb',
+          repository: { baseUrl: 'https://mirror.example', name: 'main' },
+        },
+      },
+    ]);
+  });
+
+  it('pip 검색은 custom index 사용 시 indexUrl 옵션을 전달한다', async () => {
+    const electronAPI = {
+      search: {
+        packages: vi.fn().mockResolvedValue({ results: [] }),
+      },
+    };
+    const service = createSearchService({ electronAPI });
+
+    await service.searchPackages(
+      {
+        ...baseContext,
+        packageType: 'pip',
+        useCustomIndex: true,
+        customIndexUrl: 'https://download.pytorch.org/whl/cu124',
+      },
+      'torch'
+    );
+
+    expect(electronAPI.search.packages).toHaveBeenCalledWith('pip', 'torch', {
+      indexUrl: 'https://download.pytorch.org/whl/cu124',
+    });
+  });
+});

--- a/src/renderer/pages/wizard-page/search-service.ts
+++ b/src/renderer/pages/wizard-page/search-service.ts
@@ -1,0 +1,224 @@
+import type { OSPackageInfo } from '../../../core/downloaders/os-shared/types';
+import type { PackageType } from '../../stores/cart-store';
+import type {
+  CondaChannel,
+  DockerRegistry,
+  OSDistributionSetting,
+} from '../../stores/settings-store';
+import { getOSDistributionInfo } from './os-context';
+import type { SearchResult } from './types';
+
+interface SearchServiceElectronAPI {
+  search?: {
+    packages?: (
+      type: string,
+      query: string,
+      options?: { channel?: string; registry?: string; indexUrl?: string }
+    ) => Promise<{ results: SearchResult[] }>;
+  };
+  os?: {
+    search?: (options: {
+      query: string;
+      distribution: unknown;
+      architecture: string;
+      matchType?: string;
+      limit?: number;
+    }) => Promise<{ packages: unknown[]; totalCount: number }>;
+  };
+}
+
+export interface WizardSearchContext {
+  packageType: PackageType;
+  condaChannel: CondaChannel;
+  dockerRegistry: DockerRegistry;
+  customRegistryUrl: string;
+  useCustomIndex: boolean;
+  customIndexUrl: string;
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+}
+
+interface SearchServiceDependencies {
+  electronAPI?: SearchServiceElectronAPI;
+  fetchImpl?: typeof fetch;
+}
+
+function compareVersionsDescending(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const leftValue = leftParts[index] || 0;
+    const rightValue = rightParts[index] || 0;
+    if (leftValue !== rightValue) {
+      return rightValue - leftValue;
+    }
+  }
+
+  return 0;
+}
+
+function buildSearchOptions(context: WizardSearchContext): { channel?: string; registry?: string; indexUrl?: string } | undefined {
+  switch (context.packageType) {
+    case 'pip':
+      if (context.useCustomIndex && context.customIndexUrl) {
+        return { indexUrl: context.customIndexUrl };
+      }
+      return undefined;
+    case 'conda':
+      return { channel: context.condaChannel };
+    case 'docker':
+      return {
+        registry:
+          context.dockerRegistry === 'custom' && context.customRegistryUrl
+            ? context.customRegistryUrl
+            : context.dockerRegistry,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function mapOSPackages(packages: OSPackageInfo[]): SearchResult[] {
+  return packages.map((pkg) => ({
+    name: pkg.name,
+    version: pkg.version,
+    description: pkg.summary || pkg.description || '',
+    downloadUrl: `${pkg.repository.baseUrl}/${pkg.location}`,
+    repository: { baseUrl: pkg.repository.baseUrl, name: pkg.repository.name },
+    location: pkg.location,
+    architecture: pkg.architecture,
+    osPackageInfo: pkg,
+  }));
+}
+
+async function searchViaHttp(
+  fetchImpl: typeof fetch,
+  context: WizardSearchContext,
+  query: string
+): Promise<SearchResult[]> {
+  switch (context.packageType) {
+    case 'pip':
+    case 'conda': {
+      const response = await fetchImpl(`/api/pypi/pypi/${encodeURIComponent(query)}/json`);
+      if (!response.ok) {
+        return [];
+      }
+      const data = await response.json() as {
+        info: { name: string; version: string; summary?: string };
+        releases: Record<string, unknown>;
+      };
+
+      return [
+        {
+          name: data.info.name,
+          version: data.info.version,
+          description: data.info.summary || '',
+          versions: Object.keys(data.releases).sort(compareVersionsDescending).slice(0, 20),
+        },
+      ];
+    }
+    case 'maven': {
+      const response = await fetchImpl(`/api/maven/search?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        return [];
+      }
+      const data = await response.json() as { results?: SearchResult[] };
+      return data.results || [];
+    }
+    case 'npm': {
+      const response = await fetchImpl(`/api/npm/search?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        return [];
+      }
+      const data = await response.json() as { results?: SearchResult[] };
+      return data.results || [];
+    }
+    case 'docker': {
+      const registry =
+        context.dockerRegistry === 'custom' && context.customRegistryUrl
+          ? context.customRegistryUrl
+          : context.dockerRegistry;
+      const response = await fetchImpl(
+        `/api/docker/search?q=${encodeURIComponent(query)}&registry=${encodeURIComponent(registry)}`
+      );
+      if (!response.ok) {
+        return [];
+      }
+      const data = await response.json() as { results?: SearchResult[] };
+      return (data.results || []).map((item) => ({
+        ...item,
+        registry,
+      }));
+    }
+    default:
+      return [];
+  }
+}
+
+export function createSearchService({
+  electronAPI,
+  fetchImpl = fetch,
+}: SearchServiceDependencies) {
+  return {
+    async searchSuggestions(context: WizardSearchContext, query: string): Promise<SearchResult[]> {
+      if (context.packageType === 'yum' || context.packageType === 'apt' || context.packageType === 'apk') {
+        const distribution = getOSDistributionInfo(context.packageType, context);
+        if (!distribution || !electronAPI?.os?.search) {
+          return [];
+        }
+
+        const response = await electronAPI.os.search({
+          query,
+          distribution: {
+            id: distribution.id,
+            name: distribution.name,
+            osType: distribution.osType,
+            packageManager: distribution.packageManager,
+          },
+          architecture: distribution.architecture,
+          matchType: 'partial',
+          limit: 20,
+        });
+
+        return mapOSPackages((response.packages || []) as OSPackageInfo[]);
+      }
+
+      return this.searchPackages(context, query);
+    },
+
+    async searchPackages(context: WizardSearchContext, query: string): Promise<SearchResult[]> {
+      if (context.packageType === 'yum' || context.packageType === 'apt' || context.packageType === 'apk') {
+        const distribution = getOSDistributionInfo(context.packageType, context);
+        if (!distribution || !electronAPI?.os?.search) {
+          return [];
+        }
+
+        const response = await electronAPI.os.search({
+          query,
+          distribution: {
+            id: distribution.id,
+            name: distribution.name,
+            osType: distribution.osType,
+            packageManager: distribution.packageManager,
+          },
+          architecture: distribution.architecture,
+          matchType: 'partial',
+          limit: 50,
+        });
+
+        return mapOSPackages((response.packages || []) as OSPackageInfo[]);
+      }
+
+      const searchOptions = buildSearchOptions(context);
+
+      if (electronAPI?.search?.packages) {
+        const response = await electronAPI.search.packages(context.packageType, query, searchOptions);
+        return response.results || [];
+      }
+
+      return searchViaHttp(fetchImpl, context, query);
+    },
+  };
+}

--- a/src/renderer/pages/wizard-page/types.ts
+++ b/src/renderer/pages/wizard-page/types.ts
@@ -42,5 +42,5 @@ export const PACKAGE_TYPE_TO_CATEGORY: Record<PackageType, CategoryType> = {
 };
 
 export function isPackageType(value: string): value is PackageType {
-  return value in PACKAGE_TYPE_TO_CATEGORY;
+  return Object.prototype.hasOwnProperty.call(PACKAGE_TYPE_TO_CATEGORY, value);
 }

--- a/src/renderer/pages/wizard-page/types.ts
+++ b/src/renderer/pages/wizard-page/types.ts
@@ -1,0 +1,46 @@
+import type { OSPackageInfo } from '../../../core/downloaders/os-shared/types';
+import type { Architecture, PackageType } from '../../stores/cart-store';
+
+export type CategoryType = 'library' | 'os' | 'container';
+
+export interface SearchResult {
+  name: string;
+  version: string;
+  description?: string;
+  versions?: string[];
+  downloadUrl?: string;
+  repository?: { baseUrl: string; name?: string };
+  location?: string;
+  architecture?: string;
+  osPackageInfo?: OSPackageInfo;
+  registry?: string;
+  isOfficial?: boolean;
+  pullCount?: number;
+  popularityCount?: number;
+  groupId?: string;
+  artifactId?: string;
+}
+
+export interface OSCartContextSnapshot {
+  distributionId: string;
+  architecture: Architecture;
+  packageManager: 'yum' | 'apt' | 'apk';
+}
+
+export const LIBRARY_PACKAGE_TYPES: PackageType[] = ['pip', 'conda', 'maven', 'npm'];
+export const OS_PACKAGE_TYPES: PackageType[] = ['yum', 'apt', 'apk'];
+
+export const PACKAGE_TYPE_TO_CATEGORY: Record<PackageType, CategoryType> = {
+  pip: 'library',
+  conda: 'library',
+  maven: 'library',
+  npm: 'library',
+  yum: 'os',
+  apt: 'os',
+  apk: 'os',
+  docker: 'container',
+};
+
+export function isPackageType(value: string): value is PackageType {
+  return value in PACKAGE_TYPE_TO_CATEGORY;
+}

--- a/src/renderer/pages/wizard-page/useWizardSearchFlow.test.ts
+++ b/src/renderer/pages/wizard-page/useWizardSearchFlow.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseSearchInput } from './useWizardSearchFlow';
+
+describe('useWizardSearchFlow helpers', () => {
+  it('pip 검색어에서 extras를 분리한다', () => {
+    expect(parseSearchInput('pip', 'jax[cuda, tpu]')).toEqual({
+      searchQuery: 'jax',
+      extras: ['cuda', 'tpu'],
+    });
+  });
+
+  it('pip 이외 타입은 원본 검색어를 유지한다', () => {
+    expect(parseSearchInput('npm', '@scope/pkg')).toEqual({
+      searchQuery: '@scope/pkg',
+      extras: [],
+    });
+  });
+});

--- a/src/renderer/pages/wizard-page/useWizardSearchFlow.ts
+++ b/src/renderer/pages/wizard-page/useWizardSearchFlow.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PackageType } from '../../stores/cart-store';
+import type { SearchResult } from './types';
+import { createSearchService, type WizardSearchContext } from './search-service';
+import { createVersionService } from './version-service';
+
+export interface WizardSearchNotifier {
+  info: (message: string) => void;
+  warning: (message: string) => void;
+  error: (message: string) => void;
+}
+
+export interface ParsedSearchInput {
+  searchQuery: string;
+  extras: string[];
+}
+
+export interface UseWizardSearchFlowArgs {
+  packageType: PackageType;
+  searchContext: WizardSearchContext;
+  setCurrentStep: (step: number) => void;
+  notifier: WizardSearchNotifier;
+}
+
+export function parseSearchInput(
+  packageType: PackageType,
+  query: string
+): ParsedSearchInput {
+  if (packageType !== 'pip') {
+    return {
+      searchQuery: query,
+      extras: [],
+    };
+  }
+
+  const extrasMatch = query.match(/^([a-zA-Z0-9_-]+)\[([a-zA-Z0-9_,\s]+)\]$/);
+  if (!extrasMatch) {
+    return {
+      searchQuery: query,
+      extras: [],
+    };
+  }
+
+  return {
+    searchQuery: extrasMatch[1],
+    extras: extrasMatch[2].split(',').map((item) => item.trim()).filter(Boolean),
+  };
+}
+
+export function useWizardSearchFlow({
+  packageType,
+  searchContext,
+  setCurrentStep,
+  notifier,
+}: UseWizardSearchFlowArgs) {
+  const searchServiceRef = useRef(
+    createSearchService({
+      electronAPI: typeof window !== 'undefined' ? window.electronAPI : undefined,
+      fetchImpl: typeof fetch === 'function' ? fetch : undefined,
+    })
+  );
+  const versionServiceRef = useRef(
+    createVersionService({
+      electronAPI: typeof window !== 'undefined' ? window.electronAPI : undefined,
+      fetchImpl: typeof fetch === 'function' ? fetch : undefined,
+    })
+  );
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [selectedPackage, setSelectedPackage] = useState<SearchResult | null>(null);
+  const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedVersion, setSelectedVersion] = useState('');
+  const [availableVersions, setAvailableVersions] = useState<string[]>([]);
+  const [loadingVersions, setLoadingVersions] = useState(false);
+  const [usedIndexUrl, setUsedIndexUrl] = useState<string | undefined>(undefined);
+  const [extras, setExtras] = useState<string[]>([]);
+  const [isNativeLibrary, setIsNativeLibrary] = useState(false);
+  const [selectedClassifier, setSelectedClassifier] = useState<string | undefined>();
+  const [availableClassifiers, setAvailableClassifiers] = useState<string[]>([]);
+  const [customClassifier, setCustomClassifier] = useState('');
+
+  const resetSearch = useCallback(() => {
+    setSearchQuery('');
+    setSearchResults([]);
+    setSelectedPackage(null);
+    setSelectedVersion('');
+    setAvailableVersions([]);
+    setSuggestions([]);
+    setShowSuggestions(false);
+    setUsedIndexUrl(undefined);
+    setExtras([]);
+    setIsNativeLibrary(false);
+    setSelectedClassifier(undefined);
+    setAvailableClassifiers([]);
+    setCustomClassifier('');
+  }, []);
+
+  const handleSelectPackage = useCallback(async (record: SearchResult) => {
+    setSelectedPackage(record);
+    setSelectedVersion(record.version);
+    setCurrentStep(3);
+    setLoadingVersions(true);
+
+    try {
+      const details = await versionServiceRef.current.loadVersionDetails(searchContext, record);
+      setAvailableVersions(details.versions);
+      setSelectedVersion(details.selectedVersion);
+      setUsedIndexUrl(details.usedIndexUrl);
+      setIsNativeLibrary(details.isNativeLibrary);
+      setAvailableClassifiers(details.availableClassifiers);
+      setSelectedClassifier(undefined);
+    } catch (error) {
+      console.error('Version fetch error:', error);
+      setAvailableVersions(record.versions || [record.version]);
+      setIsNativeLibrary(false);
+      setAvailableClassifiers([]);
+      setSelectedClassifier(undefined);
+    } finally {
+      setLoadingVersions(false);
+    }
+  }, [searchContext, setCurrentStep]);
+
+  const handleSuggestionSelect = useCallback((item: SearchResult) => {
+    setShowSuggestions(false);
+    setSearchQuery(item.name);
+    setSearchResults([item]);
+    void handleSelectPackage(item);
+  }, [handleSelectPackage]);
+
+  const debouncedSearch = useCallback(async (query: string) => {
+    if (!query.trim() || query.length < 2) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+
+    setSearching(true);
+    try {
+      const results = await searchServiceRef.current.searchSuggestions(searchContext, query);
+      setSuggestions(results);
+      setShowSuggestions(results.length > 0);
+    } catch (error) {
+      console.error('Search error:', error);
+      setSuggestions([]);
+      setShowSuggestions(false);
+    } finally {
+      setSearching(false);
+    }
+  }, [searchContext]);
+
+  const handleInputChange = useCallback((value: string) => {
+    setSearchQuery(value);
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      void debouncedSearch(value);
+    }, 300);
+  }, [debouncedSearch]);
+
+  const handleSearch = useCallback(async (query: string) => {
+    if (!query.trim()) {
+      notifier.warning('검색어를 입력하세요');
+      return;
+    }
+
+    const parsed = parseSearchInput(packageType, query);
+    setExtras(parsed.extras);
+    setSearching(true);
+    setSearchResults([]);
+
+    try {
+      const results = await searchServiceRef.current.searchPackages(searchContext, parsed.searchQuery);
+      setSearchResults(results);
+
+      if (results.length === 0) {
+        notifier.info('검색 결과가 없습니다');
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : '검색 중 오류가 발생했습니다';
+      notifier.error(errorMessage);
+      console.error('Search error:', error);
+    } finally {
+      setSearching(false);
+    }
+  }, [notifier, packageType, searchContext]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    searching,
+    searchResults,
+    selectedPackage,
+    suggestions,
+    showSuggestions,
+    setShowSuggestions,
+    selectedVersion,
+    setSelectedVersion,
+    availableVersions,
+    loadingVersions,
+    usedIndexUrl,
+    extras,
+    isNativeLibrary,
+    selectedClassifier,
+    setSelectedClassifier,
+    availableClassifiers,
+    customClassifier,
+    setCustomClassifier,
+    resetSearch,
+    handleInputChange,
+    handleSuggestionSelect,
+    handleSearch,
+    handleSelectPackage,
+  };
+}

--- a/src/renderer/pages/wizard-page/version-service.test.ts
+++ b/src/renderer/pages/wizard-page/version-service.test.ts
@@ -87,6 +87,37 @@ describe('version-service', () => {
     expect(result.selectedVersion).toBe('5.3.0');
   });
 
+  it('pip 커스텀 인덱스 + HTTP fallback에서는 usedIndexUrl을 기록하지 않는다', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        releases: {
+          '2.32.0': [{}],
+          '2.31.0': [{}],
+        },
+      }),
+    });
+    const service = createVersionService({ fetchImpl });
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'pip',
+        useCustomIndex: true,
+        customIndexUrl: 'https://download.pytorch.org/whl/cu124',
+      },
+      {
+        name: 'requests',
+        version: '2.31.0',
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith('/api/pypi/pypi/requests/json');
+    expect(result.usedIndexUrl).toBeUndefined();
+    expect(result.versions).toEqual(['2.32.0', '2.31.0']);
+    expect(result.selectedVersion).toBe('2.32.0');
+  });
+
   it('docker는 태그 fallback에서 latest를 우선 선택한다', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/renderer/pages/wizard-page/version-service.test.ts
+++ b/src/renderer/pages/wizard-page/version-service.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PackageType } from '../../stores/cart-store';
+import type { DockerRegistry, OSDistributionSetting } from '../../stores/settings-store';
+import type { SearchResult } from './types';
+import { createVersionService } from './version-service';
+
+interface VersionContextFixture {
+  packageType: PackageType;
+  condaChannel: string;
+  dockerRegistry: DockerRegistry;
+  customRegistryUrl: string;
+  useCustomIndex: boolean;
+  customIndexUrl: string;
+  yumDistribution: OSDistributionSetting;
+  aptDistribution: OSDistributionSetting;
+  apkDistribution: OSDistributionSetting;
+}
+
+const baseContext: VersionContextFixture = {
+  packageType: 'pip',
+  condaChannel: 'conda-forge',
+  dockerRegistry: 'docker.io',
+  customRegistryUrl: '',
+  useCustomIndex: false,
+  customIndexUrl: '',
+  yumDistribution: { id: 'rocky-9', architecture: 'x86_64' },
+  aptDistribution: { id: 'ubuntu-24.04', architecture: 'amd64' },
+  apkDistribution: { id: 'alpine-3.20', architecture: 'aarch64' },
+};
+
+describe('version-service', () => {
+  it('Electron search.versions를 우선 사용하고 pip indexUrl을 기록한다', async () => {
+    const electronAPI = {
+      search: {
+        versions: vi.fn().mockResolvedValue({ versions: ['2.32.0', '2.31.0'] }),
+      },
+    };
+    const service = createVersionService({ electronAPI });
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'pip',
+        useCustomIndex: true,
+        customIndexUrl: 'https://download.pytorch.org/whl/cu124',
+      },
+      {
+        name: 'requests',
+        version: '2.31.0',
+      }
+    );
+
+    expect(electronAPI.search.versions).toHaveBeenCalledWith('pip', 'requests', {
+      indexUrl: 'https://download.pytorch.org/whl/cu124',
+    });
+    expect(result).toEqual({
+      versions: ['2.32.0', '2.31.0'],
+      selectedVersion: '2.32.0',
+      usedIndexUrl: 'https://download.pytorch.org/whl/cu124',
+      isNativeLibrary: false,
+      availableClassifiers: [],
+    });
+  });
+
+  it('Electron 버전 조회가 없으면 Maven HTTP fallback을 사용한다', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ versions: ['5.3.0', '5.2.9'] }),
+    });
+    const service = createVersionService({ fetchImpl });
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'maven',
+      },
+      {
+        name: 'org.springframework:spring-core',
+        version: '5.2.9',
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/maven/versions?package=org.springframework%3Aspring-core'
+    );
+    expect(result.versions).toEqual(['5.3.0', '5.2.9']);
+    expect(result.selectedVersion).toBe('5.3.0');
+  });
+
+  it('docker는 태그 fallback에서 latest를 우선 선택한다', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ tags: ['1.0.0', 'latest', '0.9.0'] }),
+    });
+    const service = createVersionService({ fetchImpl });
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'docker',
+        dockerRegistry: 'custom',
+        customRegistryUrl: 'registry.example.internal',
+      },
+      {
+        name: 'org/app',
+        version: '1.0.0',
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/docker/tags?image=org%2Fapp&registry=registry.example.internal'
+    );
+    expect(result.selectedVersion).toBe('latest');
+    expect(result.versions).toEqual(['1.0.0', 'latest', '0.9.0']);
+  });
+
+  it('OS 패키지는 검색 결과의 versions를 그대로 사용한다', async () => {
+    const service = createVersionService({});
+
+    const record: SearchResult = {
+      name: 'bash',
+      version: '5.2.21',
+      versions: ['5.2.21', '5.2.15'],
+    };
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'apt',
+      },
+      record
+    );
+
+    expect(result).toEqual({
+      versions: ['5.2.21', '5.2.15'],
+      selectedVersion: '5.2.21',
+      usedIndexUrl: undefined,
+      isNativeLibrary: false,
+      availableClassifiers: [],
+    });
+  });
+
+  it('Maven은 classifier 부가 정보를 함께 반환한다', async () => {
+    const electronAPI = {
+      search: {
+        versions: vi.fn().mockResolvedValue({ versions: ['1.0.0'] }),
+      },
+      maven: {
+        isNativeArtifact: vi.fn().mockResolvedValue(true),
+        getAvailableClassifiers: vi.fn().mockResolvedValue(['natives-linux', 'natives-osx']),
+      },
+    };
+    const service = createVersionService({ electronAPI });
+
+    const result = await service.loadVersionDetails(
+      {
+        ...baseContext,
+        packageType: 'maven',
+      },
+      {
+        name: 'com.example:native-lib',
+        version: '1.0.0',
+        groupId: 'com.example',
+        artifactId: 'native-lib',
+      }
+    );
+
+    expect(result.isNativeLibrary).toBe(true);
+    expect(result.availableClassifiers).toEqual(['natives-linux', 'natives-osx']);
+    expect(electronAPI.maven.isNativeArtifact).toHaveBeenCalledWith(
+      'com.example',
+      'native-lib',
+      '1.0.0'
+    );
+  });
+});

--- a/src/renderer/pages/wizard-page/version-service.ts
+++ b/src/renderer/pages/wizard-page/version-service.ts
@@ -162,9 +162,11 @@ export function createVersionService({
 
       const versionOptions = buildVersionOptions(context);
       let versions: string[];
+      const electronVersionLookup = electronAPI?.search?.versions;
+      const usedElectronVersionLookup = Boolean(electronVersionLookup);
 
-      if (electronAPI?.search?.versions) {
-        const response = await electronAPI.search.versions(
+      if (electronVersionLookup) {
+        const response = await electronVersionLookup(
           context.packageType,
           record.name,
           versionOptions
@@ -191,7 +193,9 @@ export function createVersionService({
         versions,
         selectedVersion,
         usedIndexUrl:
-          context.packageType === 'pip' && versionOptions?.indexUrl
+          usedElectronVersionLookup &&
+          context.packageType === 'pip' &&
+          versionOptions?.indexUrl
             ? versionOptions.indexUrl
             : undefined,
         ...mavenDetails,

--- a/src/renderer/pages/wizard-page/version-service.ts
+++ b/src/renderer/pages/wizard-page/version-service.ts
@@ -1,0 +1,201 @@
+import type { SearchResult } from './types';
+import type { WizardSearchContext } from './search-service';
+
+interface VersionServiceElectronAPI {
+  search?: {
+    versions?: (
+      type: string,
+      packageName: string,
+      options?: { channel?: string; registry?: string; indexUrl?: string }
+    ) => Promise<{ versions: string[] }>;
+  };
+  maven?: {
+    isNativeArtifact?: (groupId: string, artifactId: string, version?: string) => Promise<boolean>;
+    getAvailableClassifiers?: (
+      groupId: string,
+      artifactId: string,
+      version?: string
+    ) => Promise<string[]>;
+  };
+}
+
+interface VersionServiceDependencies {
+  electronAPI?: VersionServiceElectronAPI;
+  fetchImpl?: typeof fetch;
+}
+
+export interface VersionDetails {
+  versions: string[];
+  selectedVersion: string;
+  usedIndexUrl?: string;
+  isNativeLibrary: boolean;
+  availableClassifiers: string[];
+}
+
+function compareVersionsDescending(left: string, right: string): number {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const leftValue = leftParts[index] || 0;
+    const rightValue = rightParts[index] || 0;
+    if (leftValue !== rightValue) {
+      return rightValue - leftValue;
+    }
+  }
+
+  return 0;
+}
+
+function buildVersionOptions(
+  context: WizardSearchContext
+): { channel?: string; registry?: string; indexUrl?: string } | undefined {
+  switch (context.packageType) {
+    case 'pip':
+      if (context.useCustomIndex && context.customIndexUrl) {
+        return { indexUrl: context.customIndexUrl };
+      }
+      return undefined;
+    case 'conda':
+      return { channel: context.condaChannel };
+    case 'docker':
+      return {
+        registry:
+          context.dockerRegistry === 'custom' && context.customRegistryUrl
+            ? context.customRegistryUrl
+            : context.dockerRegistry,
+      };
+    default:
+      return undefined;
+  }
+}
+
+async function loadVersionsViaHttp(
+  fetchImpl: typeof fetch,
+  context: WizardSearchContext,
+  record: SearchResult
+): Promise<string[]> {
+  switch (context.packageType) {
+    case 'pip':
+    case 'conda': {
+      const response = await fetchImpl(`/api/pypi/pypi/${encodeURIComponent(record.name)}/json`);
+      if (!response.ok) {
+        return record.versions || [record.version];
+      }
+      const data = await response.json() as { releases: Record<string, unknown> };
+      return Object.keys(data.releases).sort(compareVersionsDescending);
+    }
+    case 'maven': {
+      const response = await fetchImpl(
+        `/api/maven/versions?package=${encodeURIComponent(record.name)}`
+      );
+      if (!response.ok) {
+        return record.versions || [record.version];
+      }
+      const data = await response.json() as { versions?: string[] };
+      return data.versions && data.versions.length > 0 ? data.versions : record.versions || [record.version];
+    }
+    case 'docker': {
+      const registry =
+        context.dockerRegistry === 'custom' && context.customRegistryUrl
+          ? context.customRegistryUrl
+          : context.dockerRegistry;
+      const response = await fetchImpl(
+        `/api/docker/tags?image=${encodeURIComponent(record.name)}&registry=${encodeURIComponent(registry)}`
+      );
+      if (!response.ok) {
+        return ['latest'];
+      }
+      const data = await response.json() as { tags?: string[] };
+      return data.tags && data.tags.length > 0 ? data.tags : ['latest'];
+    }
+    default:
+      return record.versions || [record.version];
+  }
+}
+
+async function loadMavenClassifierDetails(
+  electronAPI: VersionServiceElectronAPI | undefined,
+  record: SearchResult
+): Promise<Pick<VersionDetails, 'isNativeLibrary' | 'availableClassifiers'>> {
+  if (!electronAPI?.maven?.isNativeArtifact || !electronAPI.maven.getAvailableClassifiers) {
+    return {
+      isNativeLibrary: false,
+      availableClassifiers: [],
+    };
+  }
+
+  const groupId = record.groupId || record.name.split(':')[0];
+  const artifactId = record.artifactId || record.name.split(':')[1] || record.name;
+  const isNativeLibrary = await electronAPI.maven.isNativeArtifact(groupId, artifactId, record.version);
+
+  return {
+    isNativeLibrary,
+    availableClassifiers: isNativeLibrary
+      ? await electronAPI.maven.getAvailableClassifiers(groupId, artifactId, record.version)
+      : [],
+  };
+}
+
+export function createVersionService({
+  electronAPI,
+  fetchImpl = fetch,
+}: VersionServiceDependencies) {
+  return {
+    async loadVersionDetails(
+      context: WizardSearchContext,
+      record: SearchResult
+    ): Promise<VersionDetails> {
+      if (context.packageType === 'yum' || context.packageType === 'apt' || context.packageType === 'apk') {
+        const versions = record.versions && record.versions.length > 0
+          ? record.versions
+          : [record.version];
+
+        return {
+          versions,
+          selectedVersion: versions[0],
+          usedIndexUrl: undefined,
+          isNativeLibrary: false,
+          availableClassifiers: [],
+        };
+      }
+
+      const versionOptions = buildVersionOptions(context);
+      let versions: string[];
+
+      if (electronAPI?.search?.versions) {
+        const response = await electronAPI.search.versions(
+          context.packageType,
+          record.name,
+          versionOptions
+        );
+        versions = response.versions && response.versions.length > 0
+          ? response.versions
+          : record.versions || [record.version];
+      } else {
+        versions = await loadVersionsViaHttp(fetchImpl, context, record);
+      }
+
+      const selectedVersion = context.packageType === 'docker' && versions.includes('latest')
+        ? 'latest'
+        : versions[0] || record.version;
+
+      const mavenDetails = context.packageType === 'maven'
+        ? await loadMavenClassifierDetails(electronAPI, record)
+        : {
+            isNativeLibrary: false,
+            availableClassifiers: [],
+          };
+
+      return {
+        versions,
+        selectedVersion,
+        usedIndexUrl:
+          context.packageType === 'pip' && versionOptions?.indexUrl
+            ? versionOptions.indexUrl
+            : undefined,
+        ...mavenDetails,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## 요약
- WizardPage에서 검색/버전 조회/OS 배포판 분기를 훅과 서비스로 분리했습니다.
- package type별 검색 전략, Electron 우선 + HTTP fallback, query param 동기화 계약을 테스트 가능한 함수로 추출했습니다.
- 페이지 본체는 상태 조합과 화면 렌더링 중심으로 단순화했습니다.

## 변경 내용
- `src/renderer/pages/wizard-page/useWizardSearchFlow.ts`에서 검색 상태와 사용자 액션을 오케스트레이션하도록 분리
- `search-service.ts`, `version-service.ts`, `os-context.ts`, `query-params.ts`, `types.ts`로 책임 분리
- `WizardPage.tsx`에서 인라인 검색/버전 로직과 OS 분기 로직 제거
- 관련 단위 테스트 및 문서 업데이트 추가

## 검증
- `npx vitest run src/renderer/pages/wizard-page/query-params.test.ts src/renderer/pages/wizard-page/os-context.test.ts src/renderer/pages/wizard-page/search-service.test.ts src/renderer/pages/wizard-page/version-service.test.ts src/renderer/pages/wizard-page/useWizardSearchFlow.test.ts`
- `npx tsc --noEmit --pretty false`
- `bash scripts/verify-worktree.sh`