### PR TITLE
Playwright 산출물 경로를 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ build/
 
 # Test coverage
 coverage/
+playwright-report/
+test-results/
 
 # DepsSmuggler cache and config (for development)
 # .depssmuggler/


### PR DESCRIPTION
## 요약
- `playwright-report/`, `test-results/`를 `.gitignore`에 추가했습니다.
- 로컬 E2E/테스트 산출물이 메인 worktree를 dirty 상태로 유지하던 문제를 줄였습니다.

## 배경
- 현재 메인 worktree에 `playwright-report/`, `test-results/`가 untracked로 남아 있어 `git status`가 계속 오염되고 있었습니다.
- 이 경로들은 테스트 실행 산출물이라 버전 관리 대상이 아닙니다.

## 변경 사항
- `.gitignore`에 `playwright-report/` 추가
- `.gitignore`에 `test-results/` 추가

## 검증
- `git check-ignore -v playwright-report/.keep test-results/.keep`
- `git diff --check`
- `bash scripts/ensure_verify_worktree.sh "$PWD"`
- `bash scripts/verify-worktree.sh`

## 문서
- 없음
- 이유: 저장소 위생용 ignore 규칙 추가이며 사용자 플로우/API/운영 문서에 영향이 없습니다.
