### PR TITLE
Settings 캐시 상세 통계 UI 보강

### DIFF
--- a/docs/ui-testing-checklist.md
+++ b/docs/ui-testing-checklist.md
@@ -37,8 +37,8 @@
 
 ## 자동화 연계
 
-- 현재 Playwright 회귀 세트와 직접 매핑되는 항목: `UI-CHK-03`, `UI-CHK-05`, `UI-CHK-06(성공 경로)`, `UI-CHK-07`, `UI-CHK-08`
+- 현재 Playwright 회귀 세트와 직접 매핑되는 항목: `UI-CHK-03`, `UI-CHK-05`, `UI-CHK-06(성공 경로)`, `UI-CHK-07`, `UI-CHK-08`, `UI-CHK-11`
 - 자동화 후보 우선순위가 높은 항목: `UI-CHK-01`, `UI-CHK-02`, `UI-CHK-04`
-- 수동 확인 비중이 더 큰 항목: `UI-CHK-10`, `UI-CHK-11`, `UI-CHK-12`
+- 수동 확인 비중이 더 큰 항목: `UI-CHK-10`, `UI-CHK-12`
 
 세부 절차와 실패 기준은 [UI 상세 테스트 케이스](./ui-testing-test-cases.md), Playwright 전환 설계는 [UI Playwright 전환 시나리오](./ui-testing-playwright-conversion.md)를 참고합니다.

--- a/docs/ui-testing-playwright-conversion.md
+++ b/docs/ui-testing-playwright-conversion.md
@@ -10,6 +10,7 @@
 | --- | --- | --- |
 | `UI-DL-001` | `tests/e2e/download-smoke.spec.ts` | 장바구니에서 일반 다운로드 완료 화면까지, 로컬 저장 옵션 전달 |
 | `UI-SET-001`, `UI-SET-002(성공 경로만)` | `tests/e2e/settings-regression.spec.ts` | SMTP 값 입력, 연결 테스트 성공 경로, 저장 후 새로고침 복원 |
+| `UI-CFG-001` | `tests/e2e/settings-cache-breakdown.spec.ts` | 캐시 총합, 타입별 breakdown, 캐시 비우기 후 0 값 갱신 |
 | `UI-HIS-001` | `tests/e2e/history-email-restore.spec.ts` | 이메일 히스토리 재다운로드, 저장된 수신자 복원, 전역 설정 보존 |
 | `UI-OS-001` | `tests/e2e/os-package-download.spec.ts` | OS 패키지 검색, 전용 다운로드 화면, 출력 옵션 결과 반영 |
 
@@ -73,7 +74,6 @@
 | 수동 케이스 | 수동 우선 이유 |
 | --- | --- |
 | `UI-DL-004` | 취소/실패 재현이 mock만으로는 실제 체감과 차이가 날 수 있음 |
-| `UI-CFG-001` | 캐시 크기와 정리 결과는 로컬 파일 상태에 따라 달라질 수 있음 |
 | `UI-ROUTE-001` | 새로고침, 창 크기 변경, 라우트 왕복은 조합이 많고 탐색적 확인 가치가 큼 |
 
 ## Playwright 작성 원칙

--- a/src/renderer/pages/SettingsPage.tsx
+++ b/src/renderer/pages/SettingsPage.tsx
@@ -205,6 +205,7 @@ const SettingsPage: React.FC = () => {
 
   const {
     cacheCount,
+    cacheDetails,
     cacheSize,
     clearingCache,
     handleCheckForUpdates,
@@ -1193,6 +1194,7 @@ const SettingsPage: React.FC = () => {
 
         <CacheSettingsSection
           cacheCount={cacheCount}
+          cacheDetails={cacheDetails}
           cacheSize={cacheSize}
           clearingCache={clearingCache}
           formatBytes={formatBytes}

--- a/src/renderer/pages/settings/CacheSettingsSection.tsx
+++ b/src/renderer/pages/settings/CacheSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { DeleteOutlined, FolderOpenOutlined } from '@ant-design/icons';
 import { Button, Card, Col, Form, Input, Popconfirm, Row, Space, Spin, Switch, Typography } from 'antd';
 import React from 'react';
+import type { CacheDetailItem } from './cache-stats-utils';
 import {
   SETTINGS_CARD_BODY_PADDING,
   SETTINGS_CARD_MARGIN,
@@ -10,6 +11,7 @@ const { Text } = Typography;
 
 interface CacheSettingsSectionProps {
   cacheCount: number;
+  cacheDetails: CacheDetailItem[];
   cacheSize: number;
   clearingCache: boolean;
   formatBytes: (bytes: number) => string;
@@ -21,6 +23,7 @@ interface CacheSettingsSectionProps {
 
 export const CacheSettingsSection: React.FC<CacheSettingsSectionProps> = ({
   cacheCount,
+  cacheDetails,
   cacheSize,
   clearingCache,
   formatBytes,
@@ -104,6 +107,7 @@ export const CacheSettingsSection: React.FC<CacheSettingsSectionProps> = ({
                   <Button
                     size="small"
                     danger
+                    aria-label="패키지 캐시 삭제"
                     icon={<DeleteOutlined />}
                     loading={clearingCache}
                     disabled={cacheSize === 0 && cacheCount === 0}
@@ -113,6 +117,35 @@ export const CacheSettingsSection: React.FC<CacheSettingsSectionProps> = ({
             </Col>
           </Row>
         </Spin>
+        <Row gutter={[8, 8]} style={{ marginTop: 12 }}>
+          {cacheDetails.map((detail) => (
+            <Col key={detail.key} xs={24} sm={12} md={6}>
+              <div
+                data-testid={`cache-detail-${detail.key}`}
+                style={{
+                  background: '#ffffff',
+                  border: '1px solid #d9d9d9',
+                  borderRadius: 6,
+                  padding: '10px 12px',
+                  minHeight: 88,
+                }}
+              >
+                <Text strong style={{ display: 'block', fontSize: 12 }}>
+                  {detail.label}
+                </Text>
+                <Text style={{ display: 'block', marginTop: 4, fontSize: 16 }}>
+                  {detail.entryCount}개
+                </Text>
+                <Text type="secondary" style={{ display: 'block', marginTop: 2, fontSize: 12 }}>
+                  {detail.sizeBytes === undefined ? '메모리 캐시' : formatBytes(detail.sizeBytes)}
+                </Text>
+                <Text type="secondary" style={{ display: 'block', marginTop: 6, fontSize: 11 }}>
+                  {detail.description}
+                </Text>
+              </div>
+            </Col>
+          ))}
+        </Row>
         <Text type="secondary" style={{ display: 'block', marginTop: 8, fontSize: 12 }}>
           이 영역은 패키지 메타데이터 캐시만 집계합니다. 크기는 디스크 기준이며, 캐시 항목
           수에는 메모리 기반 npm 캐시도 포함될 수 있습니다. Python 버전 목록은

--- a/src/renderer/pages/settings/cache-stats-utils.test.ts
+++ b/src/renderer/pages/settings/cache-stats-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildCacheDetailItems } from './cache-stats-utils';
+
+describe('cache-stats-utils', () => {
+  it('cache.getStats().details를 타입별 breakdown 뷰 모델로 정규화한다', () => {
+    expect(
+      buildCacheDetailItems({
+        pip: { memoryEntries: 2, diskEntries: 5, diskSize: 4096 },
+        npm: { entries: 4, oldestEntry: 1, newestEntry: 2 },
+        maven: { memoryEntries: 1, diskEntries: 3, diskSize: 8192, pendingRequests: 0 },
+        conda: {
+          totalSize: 3072,
+          channelCount: 2,
+          entries: [
+            { channel: 'conda-forge', subdir: 'linux-64', meta: {}, dataSize: 1024 },
+            { channel: 'defaults', subdir: 'linux-64', meta: {}, dataSize: 2048 },
+          ],
+        },
+      })
+    ).toEqual([
+      {
+        key: 'pip',
+        label: 'PIP',
+        entryCount: 5,
+        sizeBytes: 4096,
+        description: '메모리 2 / 디스크 5',
+      },
+      {
+        key: 'npm',
+        label: 'NPM',
+        entryCount: 4,
+        sizeBytes: undefined,
+        description: '메모리 캐시',
+      },
+      {
+        key: 'maven',
+        label: 'MAVEN',
+        entryCount: 3,
+        sizeBytes: 8192,
+        description: '메모리 1 / 디스크 3',
+      },
+      {
+        key: 'conda',
+        label: 'CONDA',
+        entryCount: 2,
+        sizeBytes: 3072,
+        description: '채널 2개',
+      },
+    ]);
+  });
+
+  it('details가 비어 있어도 네 타입을 0 값으로 유지한다', () => {
+    expect(buildCacheDetailItems(undefined)).toEqual([
+      { key: 'pip', label: 'PIP', entryCount: 0, sizeBytes: 0, description: '메모리 0 / 디스크 0' },
+      { key: 'npm', label: 'NPM', entryCount: 0, sizeBytes: undefined, description: '메모리 캐시' },
+      { key: 'maven', label: 'MAVEN', entryCount: 0, sizeBytes: 0, description: '메모리 0 / 디스크 0' },
+      { key: 'conda', label: 'CONDA', entryCount: 0, sizeBytes: 0, description: '채널 0개' },
+    ]);
+  });
+});

--- a/src/renderer/pages/settings/cache-stats-utils.ts
+++ b/src/renderer/pages/settings/cache-stats-utils.ts
@@ -1,0 +1,73 @@
+export type CacheDetailKey = 'pip' | 'npm' | 'maven' | 'conda';
+
+export interface CacheDetailItemsInput {
+  pip?: unknown;
+  npm?: unknown;
+  maven?: unknown;
+  conda?: unknown;
+}
+
+export interface CacheDetailItem {
+  key: CacheDetailKey;
+  label: string;
+  entryCount: number;
+  sizeBytes?: number;
+  description: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export function buildCacheDetailItems(details?: CacheDetailItemsInput): CacheDetailItem[] {
+  const pip = asRecord(details?.pip);
+  const npm = asRecord(details?.npm);
+  const maven = asRecord(details?.maven);
+  const conda = asRecord(details?.conda);
+
+  const pipMemoryEntries = asNumber(pip.memoryEntries);
+  const pipDiskEntries = asNumber(pip.diskEntries);
+  const mavenMemoryEntries = asNumber(maven.memoryEntries);
+  const mavenDiskEntries = asNumber(maven.diskEntries);
+  const condaEntries = asArray(conda.entries);
+  const condaChannelCount = asNumber(conda.channelCount);
+
+  return [
+    {
+      key: 'pip',
+      label: 'PIP',
+      entryCount: Math.max(pipMemoryEntries, pipDiskEntries),
+      sizeBytes: asNumber(pip.diskSize),
+      description: `메모리 ${pipMemoryEntries} / 디스크 ${pipDiskEntries}`,
+    },
+    {
+      key: 'npm',
+      label: 'NPM',
+      entryCount: asNumber(npm.entries),
+      sizeBytes: undefined,
+      description: '메모리 캐시',
+    },
+    {
+      key: 'maven',
+      label: 'MAVEN',
+      entryCount: Math.max(mavenMemoryEntries, mavenDiskEntries),
+      sizeBytes: asNumber(maven.diskSize),
+      description: `메모리 ${mavenMemoryEntries} / 디스크 ${mavenDiskEntries}`,
+    },
+    {
+      key: 'conda',
+      label: 'CONDA',
+      entryCount: condaEntries.length,
+      sizeBytes: asNumber(conda.totalSize),
+      description: `채널 ${condaChannelCount}개`,
+    },
+  ];
+}

--- a/src/renderer/pages/settings/use-settings-form-actions.ts
+++ b/src/renderer/pages/settings/use-settings-form-actions.ts
@@ -11,6 +11,10 @@ import {
   type SettingsStoreSnapshot,
   type SmtpTestMode,
 } from './settings-form-utils';
+import {
+  buildCacheDetailItems,
+  type CacheDetailItem,
+} from './cache-stats-utils';
 
 type SmtpTestResult = 'success' | 'failed' | null;
 
@@ -23,6 +27,7 @@ interface UseSettingsFormActionsOptions {
 
 interface UseSettingsFormActionsResult {
   cacheCount: number;
+  cacheDetails: CacheDetailItem[];
   cacheSize: number;
   clearingCache: boolean;
   handleCheckForUpdates: () => Promise<void>;
@@ -61,6 +66,9 @@ export function useSettingsFormActions({
   const [initialValues, setInitialValues] = React.useState<SettingsFormSubmission>({});
   const [cacheSize, setCacheSize] = React.useState(0);
   const [cacheCount, setCacheCount] = React.useState(0);
+  const [cacheDetails, setCacheDetails] = React.useState<CacheDetailItem[]>(() =>
+    buildCacheDetailItems()
+  );
   const [loadingCache, setLoadingCache] = React.useState(false);
   const [clearingCache, setClearingCache] = React.useState(false);
   const [testingSmtp, setTestingSmtp] = React.useState(false);
@@ -154,10 +162,12 @@ export function useSettingsFormActions({
       const stats = await window.electronAPI.cache.getStats();
       setCacheSize(stats.totalSize);
       setCacheCount(stats.entryCount);
+      setCacheDetails(buildCacheDetailItems(stats.details));
     } catch (error) {
       console.error('패키지 캐시 정보 로드 실패:', error);
       setCacheSize(0);
       setCacheCount(0);
+      setCacheDetails(buildCacheDetailItems());
     } finally {
       setLoadingCache(false);
     }
@@ -177,6 +187,7 @@ export function useSettingsFormActions({
       await window.electronAPI.cache.clear();
       setCacheSize(0);
       setCacheCount(0);
+      setCacheDetails(buildCacheDetailItems());
       message.success('패키지 캐시가 삭제되었습니다');
     } catch (error) {
       console.error('패키지 캐시 삭제 실패:', error);
@@ -336,6 +347,7 @@ export function useSettingsFormActions({
 
   return {
     cacheCount,
+    cacheDetails,
     cacheSize,
     clearingCache,
     handleCheckForUpdates,

--- a/tests/e2e/fixtures/mock-electron-app.ts
+++ b/tests/e2e/fixtures/mock-electron-app.ts
@@ -7,6 +7,18 @@ interface MockElectronAppOptions {
   cartItems?: CartItem[];
   histories?: DownloadHistory[];
   downloadDelayMs?: number;
+  cacheStats?: {
+    scope?: string;
+    excludes?: string[];
+    totalSize?: number;
+    entryCount?: number;
+    details?: {
+      pip?: unknown;
+      npm?: unknown;
+      maven?: unknown;
+      conda?: unknown;
+    };
+  };
 }
 
 interface MockElectronAppState {
@@ -109,6 +121,18 @@ export async function setupMockElectronApp(
         downloadCalls: [],
         smtpTestCalls: [],
         openedPaths: [],
+      },
+    };
+    let cacheStats = {
+      scope: String(seed.cacheStats?.scope || 'package-metadata'),
+      excludes: Array.isArray(seed.cacheStats?.excludes) ? [...seed.cacheStats!.excludes!] : [],
+      totalSize: Number(seed.cacheStats?.totalSize || 0),
+      entryCount: Number(seed.cacheStats?.entryCount || 0),
+      details: {
+        pip: seed.cacheStats?.details?.pip || {},
+        npm: seed.cacheStats?.details?.npm || {},
+        maven: seed.cacheStats?.details?.maven || {},
+        conda: seed.cacheStats?.details?.conda || {},
       },
     };
 
@@ -253,14 +277,21 @@ export async function setupMockElectronApp(
       },
       cache: {
         getSize: async () => 0,
-        getStats: async () => ({
-          scope: 'all',
-          excludes: [],
-          totalSize: 0,
-          entryCount: 0,
-          details: { pip: {}, npm: {}, maven: {}, conda: {} },
-        }),
-        clear: async () => ({ success: true }),
+        getStats: async () => clone(cacheStats),
+        clear: async () => {
+          cacheStats = {
+            ...cacheStats,
+            totalSize: 0,
+            entryCount: 0,
+            details: {
+              pip: {},
+              npm: {},
+              maven: {},
+              conda: {},
+            },
+          };
+          return { success: true };
+        },
       },
       history: {
         load: async () => clone(readHistories()),

--- a/tests/e2e/settings-cache-breakdown.spec.ts
+++ b/tests/e2e/settings-cache-breakdown.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { setupMockElectronApp } from './fixtures/mock-electron-app';
+
+test('설정 화면이 캐시 타입별 상세 통계와 삭제 후 갱신을 보여준다', async ({ page }) => {
+  await setupMockElectronApp(page, {
+    cacheStats: {
+      scope: 'package-metadata',
+      excludes: ['version caches'],
+      totalSize: 15360,
+      entryCount: 14,
+      details: {
+        pip: { memoryEntries: 2, diskEntries: 5, diskSize: 4096 },
+        npm: { entries: 4, oldestEntry: 1, newestEntry: 2 },
+        maven: { memoryEntries: 1, diskEntries: 3, diskSize: 8192, pendingRequests: 0 },
+        conda: {
+          totalSize: 3072,
+          channelCount: 2,
+          entries: [
+            { channel: 'conda-forge', subdir: 'linux-64', meta: {}, dataSize: 1024 },
+            { channel: 'defaults', subdir: 'linux-64', meta: {}, dataSize: 2048 },
+          ],
+        },
+      },
+    },
+  });
+
+  await page.goto('/#/settings');
+
+  const cacheCard = page.locator('.ant-card').filter({ has: page.getByText('패키지 캐시 설정') });
+
+  await expect(cacheCard.getByText('15 KB')).toBeVisible();
+  await expect(cacheCard.getByText('14개')).toBeVisible();
+
+  const pipCard = cacheCard.getByTestId('cache-detail-pip');
+  const npmCard = cacheCard.getByTestId('cache-detail-npm');
+  const mavenCard = cacheCard.getByTestId('cache-detail-maven');
+  const condaCard = cacheCard.getByTestId('cache-detail-conda');
+
+  await expect(pipCard.getByText('PIP')).toBeVisible();
+  await expect(npmCard.getByText('NPM')).toBeVisible();
+  await expect(mavenCard.getByText('MAVEN')).toBeVisible();
+  await expect(condaCard.getByText('CONDA')).toBeVisible();
+
+  await expect(pipCard.getByText(/^5개$/)).toBeVisible();
+  await expect(npmCard.getByText(/^4개$/)).toBeVisible();
+  await expect(mavenCard.getByText(/^3개$/)).toBeVisible();
+  await expect(condaCard.getByText(/^2개$/)).toBeVisible();
+
+  await expect(pipCard.getByText(/^4 KB$/)).toBeVisible();
+  await expect(mavenCard.getByText(/^8 KB$/)).toBeVisible();
+  await expect(condaCard.getByText(/^3 KB$/)).toBeVisible();
+
+  await cacheCard.locator('button.ant-btn-dangerous').click();
+  await page.getByRole('button', { name: '삭제', exact: true }).click();
+  await expect(page.getByText('패키지 캐시가 삭제되었습니다')).toBeVisible();
+
+  await expect(cacheCard.getByText(/^0 B$/)).toHaveCount(4);
+  await expect(cacheCard.getByText(/^0개$/)).toHaveCount(5);
+});


### PR DESCRIPTION
## 요약
- 설정 화면 캐시 섹션에 pip/npm/maven/conda 타입별 breakdown을 추가했습니다.
- cache.getStats().details를 공통 뷰 모델로 정규화하고, 캐시 삭제 후 총합과 breakdown이 함께 0으로 갱신되도록 맞췄습니다.
- Playwright settings 회귀에 cache breakdown/clear 시나리오를 추가했습니다.

## 배경
- 기준 문서: `docs/ui-testing-fix-prompt-2026-04-14.md`
- 진행 범위: 병렬 작업 분해의 `B. Cache 상세 통계 UI`
- 대응 finding: `F-03`

## 변경 사항
- `src/renderer/pages/settings/cache-stats-utils.ts`에 타입별 breakdown 정규화 helper 추가
- `use-settings-form-actions.ts`에서 캐시 총합과 breakdown 상태를 함께 관리
- `CacheSettingsSection.tsx`에 타입별 상세 통계 카드와 접근성 라벨 추가
- `tests/e2e/fixtures/mock-electron-app.ts`에 cache stats seed/clear 동작 추가
- `tests/e2e/settings-cache-breakdown.spec.ts` 신규 추가
- 관련 UI testing 문서 갱신

## 검증
- `npx vitest run src/renderer/pages/settings/cache-stats-utils.test.ts src/renderer/pages/settings/settings-form-utils.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run test:e2e -- tests/e2e/settings-regression.spec.ts tests/e2e/settings-cache-breakdown.spec.ts`
- `bash scripts/verify-worktree.sh`

## 문서
- `docs/ui-testing-checklist.md`
- `docs/ui-testing-playwright-conversion.md`