### PR TITLE
다운로드 사전 확인 요약과 결과 화면 전이를 안정화

### DIFF
--- a/docs/ui-testing-playwright-conversion.md
+++ b/docs/ui-testing-playwright-conversion.md
@@ -8,9 +8,9 @@
 
 | 수동 케이스 | 현재 Playwright 파일 | 검증 포인트 |
 | --- | --- | --- |
-| `UI-DL-001` | `tests/e2e/download-smoke.spec.ts` | 장바구니에서 일반 다운로드 완료 화면까지, 로컬 저장 옵션 전달 |
+| `UI-DL-001` | `tests/e2e/download-smoke.spec.ts` | 장바구니에서 일반 다운로드 완료 화면까지, preflight 출력 형식 표시, 로컬 저장 옵션 전달 |
 | `UI-SET-001`, `UI-SET-002(성공 경로만)` | `tests/e2e/settings-regression.spec.ts` | SMTP 값 입력, 연결 테스트 성공 경로, 저장 후 새로고침 복원 |
-| `UI-HIS-001` | `tests/e2e/history-email-restore.spec.ts` | 이메일 히스토리 재다운로드, 저장된 수신자 복원, 전역 설정 보존 |
+| `UI-HIS-001` | `tests/e2e/history-email-restore.spec.ts` | 이메일 히스토리 재다운로드, 저장된 수신자 복원, 파일 분할 안내 표시, 전역 설정 보존 |
 | `UI-OS-001` | `tests/e2e/os-package-download.spec.ts` | OS 패키지 검색, 전용 다운로드 화면, 출력 옵션 결과 반영 |
 
 현재 회귀 세트는 `tests/e2e/fixtures/mock-electron-app.ts`와 `window.electronAPI` stub을 이용해 preload/IPC를 브라우저 쪽에서 모킹합니다.

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -75,6 +75,9 @@ function DownloadPage() {
       deliveryMethod={controller.deliveryMethod}
       onDeliveryMethodChange={controller.setDeliveryMethod}
       effectiveSmtpTo={controller.effectiveSmtpTo}
+      outputFormat={controller.outputFormat}
+      fileSplitEnabled={controller.fileSplitEnabled}
+      maxFileSizeMB={controller.maxFileSizeMB}
       isDownloading={controller.isDownloading}
       onSelectFolder={controller.handleSelectFolder}
       downloadItems={controller.downloadItems}

--- a/src/renderer/pages/download-page/components/DownloadStandardView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadStandardView.tsx
@@ -35,6 +35,9 @@ interface DownloadStandardViewProps {
   deliveryMethod: 'local' | 'email';
   onDeliveryMethodChange: (value: 'local' | 'email') => void;
   effectiveSmtpTo: string;
+  outputFormat: 'zip' | 'tar.gz';
+  fileSplitEnabled: boolean;
+  maxFileSizeMB: number;
   isDownloading: boolean;
   onSelectFolder: () => Promise<void> | void;
   downloadItems: DownloadItem[];
@@ -69,6 +72,9 @@ export function DownloadStandardView({
   deliveryMethod,
   onDeliveryMethodChange,
   effectiveSmtpTo,
+  outputFormat,
+  fileSplitEnabled,
+  maxFileSizeMB,
   isDownloading,
   onSelectFolder,
   downloadItems,
@@ -120,6 +126,13 @@ export function DownloadStandardView({
           </Space.Compact>
         </div>
 
+        <div style={{ marginBottom: 16 }}>
+          <Text strong>출력 형식</Text>
+          <div style={{ marginTop: 8 }}>
+            <Tag color="blue">{outputFormat.toUpperCase()}</Tag>
+          </div>
+        </div>
+
         <div>
           <Text strong>전달 방식</Text>
           <Radio.Group
@@ -139,11 +152,23 @@ export function DownloadStandardView({
               showIcon
               style={{ marginTop: 12 }}
               message="설정 화면의 SMTP 발신자/수신자와 파일 분할 값을 사용합니다."
-              description={
-                effectiveSmtpTo
-                  ? `현재 수신자: ${effectiveSmtpTo}`
-                  : '수신자가 비어 있습니다. 설정 화면에서 SMTP 수신자를 먼저 입력하세요.'
-              }
+              description={(
+                <Space direction="vertical" size={4}>
+                  <Text>
+                    {effectiveSmtpTo
+                      ? `현재 수신자: ${effectiveSmtpTo}`
+                      : '현재 수신자: 없음 (설정 화면에서 SMTP 수신자를 먼저 입력하세요.)'}
+                  </Text>
+                  <Text>
+                    파일 분할: {fileSplitEnabled ? '활성' : '비활성'}
+                  </Text>
+                  <Text>
+                    {fileSplitEnabled
+                      ? `${maxFileSizeMB}MB 초과 시 자동 분할하여 첨부 제한에 맞춰 전달합니다.`
+                      : `자동 분할 비활성: ${maxFileSizeMB}MB 기준을 초과하면 이메일 전달이 실패할 수 있습니다.`}
+                  </Text>
+                </Space>
+              )}
             />
           )}
         </div>

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
@@ -1317,6 +1317,8 @@ export function useDownloadPageController() {
     setDeliveryMethod,
     effectiveSmtpTo,
     outputFormat,
+    fileSplitEnabled: enableFileSplit,
+    maxFileSizeMB: maxFileSize,
     includeDependencies,
     downloadItems,
     logs,

--- a/src/renderer/pages/download-page/view-state.test.ts
+++ b/src/renderer/pages/download-page/view-state.test.ts
@@ -80,6 +80,36 @@ describe('download-page/view-state', () => {
     ).toBe('empty');
   });
 
+  it('완료 산출물이 있으면 카트가 비어도 completed mode를 유지해야 함', () => {
+    expect(
+      deriveDownloadPageMode({
+        cartItemCount: 0,
+        downloadItemCount: 0,
+        packagingStatus: 'completed',
+        isDedicatedOSFlow: false,
+        osDownloading: false,
+        hasOSResult: false,
+        requiresOSCartReselection: false,
+        hasRecoverableFailureArtifacts: false,
+      })
+    ).toBe('completed');
+  });
+
+  it('복구 가능한 실패 산출물이 있으면 카트가 비어도 failed mode를 유지해야 함', () => {
+    expect(
+      deriveDownloadPageMode({
+        cartItemCount: 0,
+        downloadItemCount: 0,
+        packagingStatus: 'failed',
+        isDedicatedOSFlow: false,
+        osDownloading: false,
+        hasOSResult: false,
+        requiresOSCartReselection: false,
+        hasRecoverableFailureArtifacts: true,
+      })
+    ).toBe('failed');
+  });
+
   it('다운로드 카운트는 completed/failed/skipped를 분리해야 함', () => {
     expect(
       getDownloadCounts([

--- a/src/renderer/pages/download-page/view-state.ts
+++ b/src/renderer/pages/download-page/view-state.ts
@@ -49,16 +49,16 @@ export function deriveDownloadPageMode(input: DeriveDownloadPageModeInput): Down
     return 'os-reselection';
   }
 
-  if (input.cartItemCount === 0 && input.downloadItemCount === 0) {
-    return 'empty';
-  }
-
   if (input.packagingStatus === 'completed') {
     return 'completed';
   }
 
   if (input.packagingStatus === 'failed' && input.hasRecoverableFailureArtifacts) {
     return 'failed';
+  }
+
+  if (input.cartItemCount === 0 && input.downloadItemCount === 0) {
+    return 'empty';
   }
 
   return 'active';

--- a/tests/e2e/download-smoke.spec.ts
+++ b/tests/e2e/download-smoke.spec.ts
@@ -31,9 +31,12 @@ test('장바구니에서 일반 다운로드 완료 화면까지 도달한다', 
 
   await expect(page.getByRole('heading', { name: '다운로드' })).toBeVisible();
   await expect(page.locator('input[placeholder="다운로드 폴더 경로"]')).toHaveValue('/tmp/depssmuggler-e2e');
+  await expect(page.getByText('TAR.GZ')).toBeVisible();
   await expect(page.getByText('1개 패키지')).toBeVisible();
   await expect(page.getByText('requests')).toBeVisible();
   await expect(page.getByRole('button', { name: '다운로드 시작' })).toBeVisible();
+  await expect(page.getByText(/^현재 수신자:/)).toHaveCount(0);
+  await expect(page.getByText(/^파일 분할:/)).toHaveCount(0);
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
 

--- a/tests/e2e/history-email-restore.spec.ts
+++ b/tests/e2e/history-email-restore.spec.ts
@@ -60,6 +60,8 @@ test('이메일 히스토리 재다운로드는 저장된 수신자를 복원하
 
   await expect(page).toHaveURL(/#\/download$/);
   await expect(page.getByText('현재 수신자: history@example.com')).toBeVisible();
+  await expect(page.getByText('파일 분할: 활성')).toBeVisible();
+  await expect(page.getByText('10MB 초과 시 자동 분할하여 첨부 제한에 맞춰 전달합니다.')).toBeVisible();
   await expect(page.getByText('left-pad')).toBeVisible();
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();


### PR DESCRIPTION
## 요약
- 다운로드 사전 확인 카드에 출력 형식과 이메일 전달 요약을 노출했습니다.
- 이메일 히스토리 복원 시 파일 분할 안내가 보이도록 E2E를 보강했습니다.
- 완료 직후 cart clear 레이스로 결과 화면이 empty로 바뀌는 문제를 수정했습니다.

## 배경
- `docs/ui-testing-fix-prompt-2026-04-14.md`의 A 항목은 다운로드 시작 전 사용자가 출력 형식과 이메일 전달 요약을 확인할 수 있어야 한다는 요구사항입니다.
- 기존 UI는 출력 형식과 파일 분할 상태를 명확히 보여주지 않았고, 관련 Playwright 회귀도 부족했습니다.
- 수정 과정에서 완료 화면이 empty로 전이되는 기존 레이스가 드러나 함께 정리했습니다.

## 변경 사항
- DownloadPage controller에서 preflight 카드에 필요한 출력 형식/파일 분할 설정을 전달합니다.
- DownloadStandardView에 출력 형식 태그와 이메일 전달 요약 문구를 추가했습니다.
- download page view-state가 completed/failed 결과를 empty보다 우선 렌더링하도록 수정했습니다.
- 관련 unit/E2E 테스트와 문서를 갱신했습니다.

## 검증
- `npm test -- src/renderer/pages/download-page/view-state.test.ts`
- `npm run test:e2e -- tests/e2e/download-smoke.spec.ts tests/e2e/history-email-restore.spec.ts`
- `bash scripts/verify-worktree.sh`
- `npx tsc --noEmit`

## 문서
- `docs/ui-testing-playwright-conversion.md`
