### PR TITLE
리팩터링 후 저커버리지 OS/Resolver 테스트 부채 상환

### DIFF
--- a/src/core/downloaders/os-metadata-parsers.test.ts
+++ b/src/core/downloaders/os-metadata-parsers.test.ts
@@ -1,0 +1,215 @@
+import { gzipSync } from 'zlib';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApkMetadataParser } from './apk';
+import { AptMetadataParser } from './apt';
+import { YumMetadataParser } from './yum';
+import type { Repository } from './os-shared/types';
+
+describe('OS metadata parsers', () => {
+  const fetchMock = vi.fn();
+  const repo: Repository = {
+    id: 'repo',
+    name: 'Main Repo',
+    baseUrl: 'https://example.test/repo',
+    enabled: true,
+    gpgCheck: false,
+    isOfficial: true,
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('APT parser는 component 포함 baseUrl과 대체 의존성을 처리한다', async () => {
+    const parser = new AptMetadataParser(
+      {
+        ...repo,
+        baseUrl: 'https://archive.ubuntu.test/ubuntu/dists/jammy/main',
+      },
+      'main',
+      'amd64'
+    );
+    const packagesContent = [
+      'Package: libc6',
+      'Version: 2.35-0ubuntu3',
+      'Architecture: amd64',
+      'Size: 1024',
+      'Filename: pool/main/g/glibc/libc6_2.35_amd64.deb',
+      'SHA256: deadbeef',
+      'Depends: libgcc-s1 (>= 3.0) | libgcc1',
+      'Suggests: glibc-doc',
+      'Recommends: locales',
+      'Provides: libc6-abi',
+      'Description: GNU C Library',
+      ' More details',
+    ].join('\n');
+    fetchMock.mockResolvedValue(
+      new Response(gzipSync(packagesContent), {
+        status: 200,
+        headers: { 'content-type': 'application/gzip' },
+      })
+    );
+
+    const packages = await parser.parsePackages();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://archive.ubuntu.test/ubuntu/dists/jammy/main/binary-amd64/Packages.gz',
+      expect.anything()
+    );
+    expect(packages).toEqual([
+      expect.objectContaining({
+        name: 'libc6',
+        summary: 'GNU C Library',
+        provides: ['libc6-abi'],
+        suggests: ['glibc-doc'],
+        recommends: ['locales'],
+        dependencies: [
+          expect.objectContaining({
+            name: 'libgcc-s1',
+            operator: '>=',
+            version: '3.0',
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it('APK parser는 인덱스 아카이브를 읽고 시스템 의존성을 제외한다', async () => {
+    const parser = new ApkMetadataParser(repo, 'x86_64');
+    vi.spyOn(parser as never, 'extractApkIndex').mockResolvedValue(
+      [
+        'P:busybox',
+        'V:1.36.1-r0',
+        'A:x86_64',
+        'S:1024',
+        'I:2048',
+        'T:Busybox utilities',
+        'L:GPL-2.0-only',
+        'C:Q1YWJjZA==',
+        'D:so:libc.musl-x86_64.so.1 cmd:sh ssl-client>=1.0',
+        'p:cmd:sh so:libcrypto.so.3=3.0.0',
+      ].join('\n')
+    );
+    fetchMock.mockResolvedValue(new Response(gzipSync('placeholder')));
+
+    const packages = await parser.parseIndex();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.test/repo/x86_64/APKINDEX.tar.gz',
+      expect.anything()
+    );
+    expect(packages).toEqual([
+      expect.objectContaining({
+        name: 'busybox',
+        location: 'x86_64/busybox-1.36.1-r0.apk',
+        checksum: { type: 'sha1', value: 'YWJjZA==' },
+        dependencies: [
+          expect.objectContaining({
+            name: 'ssl-client',
+            operator: '>=',
+            version: '1.0',
+          }),
+        ],
+        provides: ['cmd:sh', 'so:libcrypto.so.3=3.0.0'],
+      }),
+    ]);
+  });
+
+  it('YUM parser는 repomd와 primary.xml.gz를 읽어 시스템 requires를 제외한다', async () => {
+    const parser = new YumMetadataParser(
+      {
+        ...repo,
+        id: 'rocky-9-baseos',
+        baseUrl: 'https://mirror.example.test/$releasever/BaseOS/$basearch/os',
+      },
+      'x86_64'
+    );
+    const repomdXml = [
+      '<repomd>',
+      '  <revision>123</revision>',
+      '  <data type="primary">',
+      '    <checksum type="sha256">deadbeef</checksum>',
+      '    <location href="repodata/primary.xml.gz" />',
+      '  </data>',
+      '  <data type="filelists">',
+      '    <checksum type="sha256">f1</checksum>',
+      '    <location href="repodata/filelists.xml.gz" />',
+      '  </data>',
+      '</repomd>',
+    ].join('');
+    const primaryXml = [
+      '<metadata>',
+      '  <package>',
+      '    <name>openssl-libs</name>',
+      '    <arch>x86_64</arch>',
+      '    <version epoch="1" ver="3.0.0" rel="1.el9" />',
+      '    <checksum type="sha256">feedface</checksum>',
+      '    <summary>OpenSSL libraries</summary>',
+      '    <description>Crypto libs</description>',
+      '    <size package="4096" installed="8192" />',
+      '    <location href="Packages/o/openssl-libs.rpm" />',
+      '    <format>',
+      '      <rpm:license>OpenSSL</rpm:license>',
+      '      <rpm:requires>',
+      '        <rpm:entry name="rpmlib(CompressedFileNames)" flags="EQ" ver="3.0.4-1" />',
+      '        <rpm:entry name="libcrypto.so.3()(64bit)" flags="GE" ver="3.0.0" />',
+      '        <rpm:entry name="openssl" flags="EQ" ver="3.0.0" pre="1" />',
+      '      </rpm:requires>',
+      '      <rpm:provides>',
+      '        <rpm:entry name="libcrypto.so.3()(64bit)" />',
+      '      </rpm:provides>',
+      '    </format>',
+      '  </package>',
+      '</metadata>',
+    ].join('');
+    fetchMock
+      .mockResolvedValueOnce(new Response(repomdXml))
+      .mockResolvedValueOnce(new Response(gzipSync(primaryXml)));
+
+    const repomd = await parser.parseRepomd();
+    const packages = await parser.parsePrimary(repomd.primary!.location);
+
+    expect(repomd).toEqual(
+      expect.objectContaining({
+        revision: '123',
+        primary: expect.objectContaining({
+          location: 'repodata/primary.xml.gz',
+          checksum: { type: 'sha256', value: 'deadbeef' },
+        }),
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://mirror.example.test/9/BaseOS/x86_64/os/repodata/repomd.xml',
+      expect.anything()
+    );
+    expect(packages).toEqual([
+      expect.objectContaining({
+        name: 'openssl-libs',
+        epoch: 1,
+        release: '1.el9',
+        provides: ['libcrypto.so.3()(64bit)'],
+        dependencies: [
+          expect.objectContaining({
+            name: 'libcrypto.so.3()(64bit)',
+            operator: '>=',
+            version: '3.0.0',
+            isOptional: false,
+          }),
+          expect.objectContaining({
+            name: 'openssl',
+            operator: '=',
+            version: '3.0.0',
+            isOptional: true,
+          }),
+        ],
+      }),
+    ]);
+  });
+});

--- a/src/core/downloaders/os-shared/base-downloader.test.ts
+++ b/src/core/downloaders/os-shared/base-downloader.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaseOSDownloader, type BaseDownloaderOptions } from './base-downloader';
+import type { OSPackageInfo } from './types';
+
+class TestDownloader extends BaseOSDownloader {
+  failures: Array<Error | null> = [];
+
+  protected getDownloadUrl(pkg: OSPackageInfo): string {
+    return `https://example.test/${pkg.location}`;
+  }
+
+  protected getFilename(pkg: OSPackageInfo): string {
+    return `${pkg.name}.pkg`;
+  }
+
+  protected override async downloadFile(
+    _url: string,
+    destPath: string,
+    _pkg: OSPackageInfo
+  ): Promise<void> {
+    const nextFailure = this.failures.shift();
+    if (nextFailure) {
+      throw nextFailure;
+    }
+
+    fs.writeFileSync(destPath, 'ok');
+  }
+
+  async exposeDownloadFile(url: string, destPath: string, pkg: OSPackageInfo): Promise<void> {
+    await super.downloadFile(url, destPath, pkg);
+  }
+}
+
+describe('BaseOSDownloader', () => {
+  const fetchMock = vi.fn();
+  let tempDir: string;
+  let pkg: OSPackageInfo;
+
+  const createOptions = (overrides: Partial<BaseDownloaderOptions> = {}): BaseDownloaderOptions => ({
+    outputDir: tempDir,
+    distribution: {
+      id: 'rocky-9',
+      name: 'Rocky Linux 9',
+      version: '9',
+      packageManager: 'yum',
+      architectures: ['x86_64'],
+      defaultRepos: [],
+      extendedRepos: [],
+    },
+    architecture: 'x86_64',
+    repositories: [],
+    concurrency: 2,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'depssmuggler-downloader-'));
+    pkg = {
+      name: 'bash',
+      version: '5.1',
+      architecture: 'x86_64',
+      size: 5,
+      checksum: { type: 'sha256', value: '' },
+      location: 'Packages/bash.rpm',
+      repository: {
+        id: 'baseos',
+        name: 'BaseOS',
+        baseUrl: 'https://example.test/repo',
+        enabled: true,
+        gpgCheck: false,
+        isOfficial: true,
+      },
+      dependencies: [],
+    };
+
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it('취소 신호가 이미 설정되면 즉시 취소 결과를 반환한다', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const downloader = new TestDownloader(createOptions({ abortSignal: controller.signal }));
+
+    const result = await downloader.downloadPackage(pkg);
+
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(result.error?.name).toBe('AbortError');
+  });
+
+  it('최종 실패 후 onError가 retry를 반환하면 처음부터 다시 시도한다', async () => {
+    const downloader = new TestDownloader(
+      createOptions({
+        onError: vi.fn().mockResolvedValue('retry'),
+      })
+    );
+    (downloader as any).maxRetries = 1;
+    (downloader as any).retryDelay = 0;
+    downloader.failures = [new Error('network down'), null];
+
+    const result = await downloader.downloadPackage(pkg);
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, 'bash.pkg'))).toBe(true);
+  });
+
+  it('최종 실패 후 onError가 skip을 반환하면 건너뛴 결과를 남긴다', async () => {
+    const downloader = new TestDownloader(
+      createOptions({
+        onError: vi.fn().mockResolvedValue('skip'),
+      })
+    );
+    (downloader as any).maxRetries = 1;
+    downloader.failures = [new Error('network down')];
+
+    const result = await downloader.downloadPackage(pkg);
+
+    expect(result.success).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.error?.message).toBe('network down');
+  });
+
+  it('응답 본문을 읽을 수 없으면 다운로드를 실패 처리한다', async () => {
+    const downloader = new TestDownloader(createOptions());
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-length': '5' }),
+      body: null,
+    });
+
+    await expect(
+      downloader.exposeDownloadFile('https://example.test/bash', path.join(tempDir, 'bash.pkg'), pkg)
+    ).rejects.toThrow('Response body is not readable');
+  });
+
+  it('스트리밍 다운로드 중 진행률 콜백을 호출하고 파일을 저장한다', async () => {
+    const onProgress = vi.fn();
+    const downloader = new TestDownloader(createOptions({ onProgress }));
+    const destPath = path.join(tempDir, 'streamed.pkg');
+    fetchMock.mockResolvedValue(
+      new Response('hello', {
+        status: 200,
+        headers: { 'content-length': '5' },
+      })
+    );
+
+    await downloader.exposeDownloadFile('https://example.test/bash', destPath, pkg);
+
+    expect(fs.readFileSync(destPath, 'utf-8')).toBe('hello');
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentPackage: 'bash',
+        bytesDownloaded: 5,
+        totalBytes: 5,
+        phase: 'downloading',
+      })
+    );
+  });
+});

--- a/src/core/downloaders/os-shared/base-resolver.test.ts
+++ b/src/core/downloaders/os-shared/base-resolver.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { BaseOSDependencyResolver, type DependencyResolverOptions } from './base-resolver';
+import type { OSPackageInfo, PackageDependency, Repository } from './types';
+
+class TestResolver extends BaseOSDependencyResolver {
+  apiResponses = new Map<string, PackageDependency[] | null>();
+  metadataResponses = new Map<string, PackageDependency[]>();
+  candidates = new Map<string, OSPackageInfo[]>();
+  metadataLoaded = false;
+
+  protected override async loadMetadata(): Promise<void> {
+    this.metadataLoaded = true;
+  }
+
+  protected override async fetchDependenciesFromAPI(
+    pkg: OSPackageInfo
+  ): Promise<PackageDependency[] | null> {
+    return this.apiResponses.get(pkg.name) ?? null;
+  }
+
+  protected override async fetchDependenciesFromMetadata(pkg: OSPackageInfo): Promise<PackageDependency[]> {
+    return this.metadataResponses.get(pkg.name) ?? pkg.dependencies;
+  }
+
+  protected override async findPackagesForDependency(dep: PackageDependency): Promise<OSPackageInfo[]> {
+    return this.candidates.get(dep.name) ?? [];
+  }
+
+  async exposeFetchDependencies(pkg: OSPackageInfo): Promise<PackageDependency[]> {
+    return this.fetchDependencies(pkg);
+  }
+
+  exposeCompare(pkgVersion: string, operator: PackageDependency['operator'], requiredVersion: string): boolean {
+    return this.compareVersionWithOperator(pkgVersion, operator!, requiredVersion);
+  }
+}
+
+describe('BaseOSDependencyResolver', () => {
+  const repo: Repository = {
+    id: 'baseos',
+    name: 'BaseOS',
+    baseUrl: 'https://example.test/repo',
+    enabled: true,
+    gpgCheck: false,
+    isOfficial: true,
+  };
+
+  const createPackage = (
+    name: string,
+    version: string,
+    architecture: OSPackageInfo['architecture'] = 'x86_64',
+    dependencies: PackageDependency[] = []
+  ): OSPackageInfo => ({
+    name,
+    version,
+    architecture,
+    size: 1,
+    checksum: { type: 'sha256', value: '' },
+    location: `${name}.pkg`,
+    repository: repo,
+    dependencies,
+  });
+
+  const createResolver = (overrides: Partial<DependencyResolverOptions> = {}): TestResolver =>
+    new TestResolver({
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+      repositories: [repo],
+      architecture: 'x86_64',
+      includeOptional: false,
+      includeRecommends: false,
+      ...overrides,
+    });
+
+  it('API가 null을 반환하면 메타데이터 의존성으로 폴백한다', async () => {
+    const resolver = createResolver();
+    const pkg = createPackage('bash', '5.1', 'x86_64', [{ name: 'glibc' }]);
+    resolver.apiResponses.set('bash', null);
+    resolver.metadataResponses.set('bash', [{ name: 'glibc' }]);
+
+    await expect(resolver.exposeFetchDependencies(pkg)).resolves.toEqual([{ name: 'glibc' }]);
+  });
+
+  it('epoch와 비교 연산자를 포함한 버전 비교를 처리한다', () => {
+    const resolver = createResolver();
+
+    expect(resolver.exposeCompare('1:1.0.0', '>', '99.0.0')).toBe(true);
+    expect(resolver.exposeCompare('2.0.0', '>=', '2.0.0')).toBe(true);
+    expect(resolver.exposeCompare('1.9.9', '<', '2.0.0')).toBe(true);
+    expect(resolver.exposeCompare('1.0.0', '=', '1.0.1')).toBe(false);
+  });
+
+  it('충돌, 누락, 선택 의존성 skip을 함께 처리하고 경고를 생성한다', async () => {
+    const resolver = createResolver();
+    const root = createPackage('root', '1.0.0', 'x86_64', [
+      { name: 'conflict-lib' },
+      { name: 'missing-lib', version: '2.0.0', operator: '>=' },
+      { name: 'arm-only' },
+      { name: 'optional-lib', isOptional: true },
+    ]);
+    const conflictV1 = createPackage('conflict-lib', '1.0.0');
+    const conflictV2 = createPackage('conflict-lib', '2.0.0');
+    const armOnly = createPackage('arm-only', '1.0.0', 'aarch64');
+
+    resolver.candidates.set('conflict-lib', [conflictV1, conflictV2]);
+    resolver.candidates.set('missing-lib', [createPackage('missing-lib', '1.0.0')]);
+    resolver.candidates.set('arm-only', [armOnly]);
+    resolver.candidates.set('optional-lib', [createPackage('optional-lib', '1.0.0')]);
+
+    const result = await resolver.resolveDependencies([root]);
+
+    expect(result.packages.map((pkg) => pkg.name)).toEqual(['conflict-lib', 'root']);
+    expect(result.unresolved).toEqual([
+      expect.objectContaining({ name: 'missing-lib' }),
+      expect.objectContaining({ name: 'arm-only' }),
+    ]);
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        package: 'conflict-lib',
+        versions: [
+          expect.objectContaining({ version: '1.0.0' }),
+          expect.objectContaining({ version: '2.0.0' }),
+        ],
+      }),
+    ]);
+    expect(result.warnings).toEqual([
+      '2 dependencies could not be resolved',
+      '1 version conflicts detected (all versions will be downloaded)',
+    ]);
+    expect(result.packages.find((pkg) => pkg.name === 'optional-lib')).toBeUndefined();
+  });
+
+  it('취소 신호가 있으면 메타데이터 로드 전에 중단한다', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const resolver = createResolver({ abortSignal: controller.signal });
+
+    await expect(resolver.resolveDependencies([createPackage('root', '1.0.0')])).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Dependency resolution cancelled',
+    });
+    expect(resolver.metadataLoaded).toBe(false);
+  });
+});

--- a/src/core/downloaders/os-shared/distribution-fetcher.test.ts
+++ b/src/core/downloaders/os-shared/distribution-fetcher.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  convertToOSDistributions,
+  fetchAllDistributions,
+  getDistributionsByPackageManager,
+  invalidateDistributionCache,
+} from './distribution-fetcher';
+
+describe('distribution-fetcher', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    invalidateDistributionCache();
+    fetchMock.mockReset();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    invalidateDistributionCache();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('원격 릴리스를 파싱하고 패키지 관리자별 결과를 캐시한다', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response('<a href="v3.14/"></a><a href="v3.18/"></a><a href="v3.21/"></a>')
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          [
+            'Dist: Noble',
+            'Version: 24.04',
+            'Supported: 1',
+            '',
+            'Dist: Jammy',
+            'Version: 22.04',
+            'Supported: 1',
+            '',
+            'Dist: Bionic',
+            'Version: 18.04',
+            'Supported: 1',
+          ].join('\n')
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          '<a href="trixie/"></a><a href="bookworm/"></a><a href="bullseye/"></a><a href="buster/"></a>'
+        )
+      )
+      .mockResolvedValueOnce(new Response('<a href="7/"></a><a href="8/"></a><a href="9/"></a><a href="10/"></a>'))
+      .mockResolvedValueOnce(new Response('<a href="8/"></a><a href="9/"></a><a href="11/"></a>'));
+
+    const families = await fetchAllDistributions();
+    const aptFamilies = await getDistributionsByPackageManager('apt');
+    const flattened = convertToOSDistributions(families);
+
+    expect(families).toHaveLength(6);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(aptFamilies.map((family) => family.id)).toEqual(['ubuntu', 'debian']);
+    expect(families.find((family) => family.id === 'centos')?.versions).toEqual([
+      expect.objectContaining({ id: 'centos-stream-9', version: 'stream-9' }),
+    ]);
+    expect(families.find((family) => family.id === 'ubuntu')?.versions.map((version) => version.version)).toEqual([
+      '24.04',
+      '22.04',
+    ]);
+    expect(flattened).toContainEqual(
+      expect.objectContaining({
+        id: 'alpine-3.21',
+        packageManager: 'apk',
+        architectures: ['x86_64', 'aarch64', 'x86', 'armv7'],
+      })
+    );
+
+    await fetchAllDistributions();
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('원격 조회 실패 시 각 배포판의 폴백 목록을 사용한다', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    const families = await fetchAllDistributions();
+
+    expect(families.find((family) => family.id === 'rocky')?.versions).toEqual([
+      expect.objectContaining({ version: '9', status: 'current' }),
+      expect.objectContaining({ version: '8', status: 'lts' }),
+    ]);
+    expect(families.find((family) => family.id === 'ubuntu')?.versions).toEqual([
+      expect.objectContaining({ version: '24.04', codename: 'noble' }),
+      expect.objectContaining({ version: '22.04', codename: 'jammy' }),
+      expect.objectContaining({ version: '20.04', codename: 'focal' }),
+    ]);
+    expect(families.find((family) => family.id === 'alpine')?.versions[0]).toEqual(
+      expect.objectContaining({ version: '3.21', status: 'current' })
+    );
+
+    invalidateDistributionCache();
+    await fetchAllDistributions();
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+  });
+});

--- a/src/core/downloaders/os-shared/gpg-verifier.test.ts
+++ b/src/core/downloaders/os-shared/gpg-verifier.test.ts
@@ -1,0 +1,157 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GPGVerifier } from './gpg-verifier';
+import type { OSPackageInfo, Repository } from './types';
+
+describe('GPGVerifier', () => {
+  const fetchMock = vi.fn();
+  let tempDir: string;
+  let repo: Repository;
+  let packageInfo: OSPackageInfo;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'depssmuggler-gpg-'));
+    repo = {
+      id: 'rocky-9-baseos',
+      name: 'BaseOS',
+      baseUrl: 'https://mirror.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os',
+      enabled: true,
+      gpgCheck: true,
+      gpgKeyUrl: 'https://example.test/RPM-GPG-KEY',
+      isOfficial: true,
+    };
+    packageInfo = {
+      name: 'bash',
+      version: '5.1',
+      architecture: 'x86_64',
+      size: 4,
+      checksum: { type: 'sha256', value: '' },
+      location: 'Packages/bash.rpm',
+      repository: repo,
+      dependencies: [],
+    };
+
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('GPG 키 가져오기는 재시도 후 fingerprint와 short id로 키링에 저장한다', async () => {
+    const verifier = new GPGVerifier();
+    (verifier as any).retryDelay = 0;
+    const fingerprint = 'A1B2C3D4E5F60123456789ABCDE0123456789ABC';
+
+    fetchMock
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce(new Response('temporary', { status: 500, statusText: 'boom' }))
+      .mockResolvedValueOnce(
+        new Response(
+          [
+            '-----BEGIN PGP PUBLIC KEY BLOCK-----',
+            'Version: Test',
+            '',
+            `Key fingerprint = ${fingerprint.match(/.{1,4}/g)?.join(' ')}`,
+            '-----END PGP PUBLIC KEY BLOCK-----',
+          ].join('\n')
+        )
+      );
+
+    const key = await verifier.importKey('https://example.test/key.asc', repo.id);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(key).toEqual(
+      expect.objectContaining({
+        fingerprint,
+        keyId: fingerprint.slice(-8),
+        repositoryId: repo.id,
+      })
+    );
+    expect(verifier.getKey(fingerprint)?.fingerprint).toBe(fingerprint);
+    expect(verifier.getKey(fingerprint.slice(-8))?.repositoryId).toBe(repo.id);
+  });
+
+  it('검증이 비활성화되면 서명을 바로 건너뛴다', async () => {
+    const verifier = new GPGVerifier({ enabled: false });
+
+    const result = await verifier.verifyPackage(packageInfo, '/unused/file.rpm');
+
+    expect(result).toEqual({ verified: true, skipped: true, reason: 'gpg-disabled' });
+  });
+
+  it('공식 저장소 전용 설정이면 서드파티 저장소를 건너뛴다', async () => {
+    const verifier = new GPGVerifier({ officialOnly: true });
+    const thirdPartyPackage: OSPackageInfo = {
+      ...packageInfo,
+      repository: {
+        ...repo,
+        id: 'epel',
+        isOfficial: false,
+      },
+    };
+
+    const result = await verifier.verifyPackage(thirdPartyPackage, '/unused/file.rpm');
+
+    expect(result).toEqual({ verified: true, skipped: true, reason: 'non-official-repo' });
+  });
+
+  it('체크섬 불일치를 검출한다', async () => {
+    const verifier = new GPGVerifier();
+    const filePath = path.join(tempDir, 'bash.rpm');
+    fs.writeFileSync(filePath, 'actual-content');
+    packageInfo.checksum = {
+      type: 'sha256',
+      value: crypto.createHash('sha256').update('expected-content').digest('hex'),
+    };
+
+    const result = await verifier.verifyChecksum(packageInfo, filePath);
+
+    expect(result.verified).toBe(false);
+    expect(result.skipped).toBe(false);
+    expect(result.reason).toBe('checksum-mismatch');
+  });
+
+  it('체크섬이 일치하면 패키지 관리자별 서명 검증 단계로 진행한다', async () => {
+    const verifier = new GPGVerifier();
+    const filePath = path.join(tempDir, 'bash.rpm');
+    fs.writeFileSync(filePath, 'actual-content');
+    packageInfo.checksum = {
+      type: 'sha256',
+      value: crypto.createHash('sha256').update('actual-content').digest('hex'),
+    };
+
+    const result = await verifier.verifyPackage(packageInfo, filePath);
+
+    expect(result).toEqual({
+      verified: true,
+      skipped: true,
+      reason: 'gpg-disabled',
+    });
+  });
+
+  it('알 수 없는 체크섬 타입은 실패 대신 건너뛴다', async () => {
+    const verifier = new GPGVerifier();
+    const filePath = path.join(tempDir, 'bash.rpm');
+    fs.writeFileSync(filePath, 'actual-content');
+
+    const result = await verifier.verifyChecksum(
+      { ...packageInfo, checksum: { type: 'sha3' as never, value: 'unused' } },
+      filePath
+    );
+
+    expect(result).toEqual({ verified: true, skipped: true });
+
+    const verified = await verifier.verifyChecksum(
+      { ...packageInfo, checksum: { type: 'sha1' as const, value: crypto.createHash('sha1').update('actual-content').digest('hex') } },
+      filePath
+    );
+    expect(verified).toEqual({ verified: true, skipped: false });
+  });
+});

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApkMetadataParser } from '../downloaders/apk';
+import { AptMetadataParser } from '../downloaders/apt';
+import { YumMetadataParser } from '../downloaders/yum';
+import { ApkDependencyResolver } from './apk-resolver';
+import { AptDependencyResolver } from './apt-resolver';
+import { YumDependencyResolver } from './yum-resolver';
+import type { OSPackageInfo, Repository } from '../downloaders/os-shared/types';
+
+describe('OS dependency resolvers', () => {
+  const repo: Repository = {
+    id: 'repo',
+    name: 'Main Repo',
+    baseUrl: 'https://example.test/repo',
+    enabled: true,
+    gpgCheck: false,
+    isOfficial: true,
+  };
+
+  const createPackage = (
+    name: string,
+    version: string,
+    architecture: OSPackageInfo['architecture'] = 'x86_64',
+    provides?: string[]
+  ): OSPackageInfo => ({
+    name,
+    version,
+    architecture,
+    size: 1,
+    checksum: { type: 'sha256', value: '' },
+    location: `${name}.pkg`,
+    repository: repo,
+    dependencies: [],
+    provides,
+  });
+
+  const createOptions = (repository: Repository) => ({
+    distribution: {
+      id: 'test',
+      name: 'Test',
+      version: '1',
+      packageManager: 'yum' as const,
+      architectures: ['x86_64'],
+      defaultRepos: [],
+      extendedRepos: [],
+    },
+    repositories: [repository],
+    architecture: 'x86_64' as const,
+    includeOptional: false,
+    includeRecommends: false,
+    cacheManager: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('APT resolver는 컴포넌트 URL, provides, 아키텍처 접미사 검색을 모두 처리한다', async () => {
+    const aptRepo = {
+      ...repo,
+      id: 'ubuntu-main',
+      baseUrl: 'https://archive.ubuntu.test/ubuntu/dists/jammy/main',
+    };
+    vi.spyOn(AptMetadataParser.prototype, 'parsePackages').mockResolvedValue([
+      createPackage('libc6', '2.35', 'amd64'),
+      createPackage('mail-transport-agent', '1.0', 'amd64', ['mail-transport-agent']),
+      createPackage('libc6', '2.35', 'i386'),
+    ]);
+    const resolver = new AptDependencyResolver({
+      ...createOptions(aptRepo),
+      distribution: {
+        id: 'ubuntu-22.04',
+        name: 'Ubuntu 22.04',
+        version: '22.04',
+        packageManager: 'apt',
+        architectures: ['amd64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+      architecture: 'amd64',
+    });
+
+    await (resolver as any).loadMetadata();
+    const byProvides = await (resolver as any).findPackagesForDependency({ name: 'mail-transport-agent' });
+    const byArchSuffix = await (resolver as any).findPackagesForDependency({ name: 'libc6:amd64' });
+
+    expect(byProvides).toHaveLength(1);
+    expect(byProvides[0].name).toBe('mail-transport-agent');
+    expect(byArchSuffix).toHaveLength(1);
+    expect(byArchSuffix[0].architecture).toBe('amd64');
+  });
+
+  it('APK resolver는 provides 기반 so/cmd 의존성을 해석한다', async () => {
+    vi.spyOn(ApkMetadataParser.prototype, 'parseIndex').mockResolvedValue([
+      createPackage('busybox', '1.36.1-r0', 'x86_64', ['cmd:sh', 'so:libcrypto.so.3=3.0.0']),
+      createPackage('busybox', '1.36.1-r0', 'x86'),
+    ]);
+    const resolver = new ApkDependencyResolver({
+      ...createOptions(repo),
+      distribution: {
+        id: 'alpine-3.21',
+        name: 'Alpine 3.21',
+        version: '3.21',
+        packageManager: 'apk',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+
+    await (resolver as any).loadMetadata();
+    const bySo = await (resolver as any).findPackagesForDependency({ name: 'so:libcrypto.so.3' });
+    const byCmd = await (resolver as any).findPackagesForDependency({ name: 'cmd:sh' });
+
+    expect(bySo).toHaveLength(1);
+    expect(byCmd).toHaveLength(1);
+    expect(byCmd[0].architecture).toBe('x86_64');
+  });
+
+  it('YUM resolver는 primary 메타데이터가 없는 저장소를 건너뛰고 라이브러리 provides를 찾는다', async () => {
+    const parseRepomd = vi
+      .spyOn(YumMetadataParser.prototype, 'parseRepomd')
+      .mockResolvedValueOnce({
+        revision: '1',
+        primary: null,
+        filelists: null,
+        other: null,
+      })
+      .mockResolvedValueOnce({
+        revision: '2',
+        primary: {
+          location: 'repodata/primary.xml.gz',
+          checksum: { type: 'sha256', value: 'deadbeef' },
+        },
+        filelists: null,
+        other: null,
+      });
+    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary').mockResolvedValue([
+      createPackage('openssl-libs', '3.0.0', 'x86_64', ['libcrypto.so.3()(64bit)']),
+    ]);
+    const resolver = new YumDependencyResolver({
+      ...createOptions(repo),
+      repositories: [
+        { ...repo, id: 'empty', name: 'Empty Repo' },
+        { ...repo, id: 'full', name: 'Full Repo' },
+      ],
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+
+    await (resolver as any).loadMetadata();
+    const byLibrary = await (resolver as any).findPackagesForDependency({
+      name: 'libcrypto.so.3()(64bit)',
+    });
+
+    expect(parseRepomd).toHaveBeenCalledTimes(2);
+    expect(parsePrimary).toHaveBeenCalledTimes(1);
+    expect(byLibrary).toHaveLength(1);
+    expect(byLibrary[0].name).toBe('openssl-libs');
+  });
+});

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -72,7 +72,7 @@ describe('OS dependency resolvers', () => {
     };
     vi.spyOn(AptMetadataParser.prototype, 'parsePackages').mockResolvedValue([
       createPackage('libc6', '2.35', 'amd64'),
-      createPackage('mail-transport-agent', '1.0', 'amd64', ['mail-transport-agent']),
+      createPackage('postfix', '3.7.0', 'amd64', ['mail-transport-agent']),
       createPackage('libc6', '2.35', 'i386'),
     ]);
     const resolver = new AptDependencyResolver({
@@ -94,7 +94,7 @@ describe('OS dependency resolvers', () => {
     const byArchSuffix = await (resolver as any).findPackagesForDependency({ name: 'libc6:amd64' });
 
     expect(byProvides).toHaveLength(1);
-    expect(byProvides[0].name).toBe('mail-transport-agent');
+    expect(byProvides[0].name).toBe('postfix');
     expect(byArchSuffix).toHaveLength(1);
     expect(byArchSuffix[0].architecture).toBe('amd64');
   });

--- a/src/core/shared/version-fetcher.test.ts
+++ b/src/core/shared/version-fetcher.test.ts
@@ -1,0 +1,154 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+describe('version-fetcher', () => {
+  const fetchMock = vi.fn();
+  let storage: MemoryStorage;
+  let tempDir: string;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'depssmuggler-version-fetcher-'));
+    fetchMock.mockReset();
+    vi.resetModules();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('localStorage', storage);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('Python 버전은 유효한 로컬 스토리지 캐시를 우선 사용한다', async () => {
+    storage.setItem('python_versions_cache', JSON.stringify(['3.13', '3.12']));
+    storage.setItem('python_versions_cache_timestamp', String(Date.now()));
+    const { fetchPythonVersions } = await import('./version-fetcher');
+
+    const versions = await fetchPythonVersions();
+
+    expect(versions).toEqual(['3.13', '3.12']);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('Python 버전 응답을 필터링·중복 제거·정렬하고 캐시에 저장한다', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { name: 'Python 3.12.1', version: 3, pre_release: false, release_date: '2025-01-01', is_published: true },
+          { name: 'Python 3.13.0', version: 3, pre_release: false, release_date: '2025-10-01', is_published: true },
+          { name: 'Python 3.12.0', version: 3, pre_release: false, release_date: '2024-10-01', is_published: true },
+          { name: 'Python 3.8.18', version: 3, pre_release: false, release_date: '2024-01-01', is_published: true },
+          { name: 'Python 3.14.0b1', version: 3, pre_release: true, release_date: '2025-02-01', is_published: true },
+        ]),
+        { status: 200 }
+      )
+    );
+    const { fetchPythonVersions } = await import('./version-fetcher');
+
+    const versions = await fetchPythonVersions();
+
+    expect(versions).toEqual(['3.13', '3.12']);
+    expect(JSON.parse(storage.getItem('python_versions_cache') || '[]')).toEqual(['3.13', '3.12']);
+    expect(storage.getItem('python_versions_cache_timestamp')).not.toBeNull();
+  });
+
+  it('Python API 실패 시 만료된 캐시로 폴백한다', async () => {
+    storage.setItem('python_versions_cache', JSON.stringify(['3.11', '3.10']));
+    storage.setItem(
+      'python_versions_cache_timestamp',
+      String(Date.now() - (25 * 60 * 60 * 1000))
+    );
+    fetchMock.mockRejectedValue(new Error('offline'));
+    const { fetchPythonVersions } = await import('./version-fetcher');
+
+    const versions = await fetchPythonVersions();
+
+    expect(versions).toEqual(['3.11', '3.10']);
+  });
+
+  it('CUDA 버전은 conda repodata에서 추출 후 파일 캐시에 저장한다', async () => {
+    const axios = (await import('axios')).default;
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os');
+      return {
+        ...actual,
+        homedir: () => tempDir,
+      };
+    });
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        packages: {
+          a: { name: 'cuda-toolkit', version: '12.6.68' },
+          b: { name: 'cuda-runtime', version: '11.8.0' },
+        },
+        'packages.conda': {
+          c: { name: 'cuda-cudart', version: '12.4.1' },
+          d: { name: 'ignored', version: '1.0.0' },
+        },
+      },
+    } as never);
+    const { fetchCudaVersions } = await import('./version-fetcher');
+
+    const versions = await fetchCudaVersions();
+
+    expect(versions).toEqual(['12.6', '12.4', '11.8']);
+    const cachePath = path.join(tempDir, '.depssmuggler', 'cache', 'cuda-versions.json');
+    expect(JSON.parse(fs.readFileSync(cachePath, 'utf-8')).versions).toEqual(['12.6', '12.4', '11.8']);
+  });
+
+  it('CUDA API 실패 시 만료된 파일 캐시로 폴백한다', async () => {
+    const axios = (await import('axios')).default;
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os');
+      return {
+        ...actual,
+        homedir: () => tempDir,
+      };
+    });
+    const cacheDir = path.join(tempDir, '.depssmuggler', 'cache');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(cacheDir, 'cuda-versions.json'),
+      JSON.stringify({
+        versions: ['12.2', '11.8'],
+        timestamp: Date.now() - (8 * 24 * 60 * 60 * 1000),
+      })
+    );
+    vi.mocked(axios.get).mockRejectedValue(new Error('nvidia offline'));
+    const { fetchCudaVersions } = await import('./version-fetcher');
+
+    const versions = await fetchCudaVersions();
+
+    expect(versions).toEqual(['12.2', '11.8']);
+  });
+});

--- a/src/core/shared/version-preloader.test.ts
+++ b/src/core/shared/version-preloader.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class BrowserStorage {
+  private store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+describe('version-preloader', () => {
+  let storage: BrowserStorage;
+
+  beforeEach(() => {
+    storage = new BrowserStorage();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.doUnmock('./version-fetcher');
+  });
+
+  it('브라우저가 아니면 캐시가 항상 유효하지 않다', async () => {
+    const module = await import('./version-preloader');
+
+    expect(module.isCacheValid('python')).toBe(false);
+    expect(module.getCacheAge('python')).toBeUndefined();
+  });
+
+  it('preloadAllVersions는 fetch 실패 시에도 폴백으로 완료된다', async () => {
+    vi.doMock('./version-fetcher', () => ({
+      fetchPythonVersions: vi.fn().mockRejectedValue(new Error('python down')),
+      fetchCudaVersions: vi.fn().mockRejectedValue(new Error('cuda down')),
+    }));
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', storage);
+    const module = await import('./version-preloader');
+
+    const result = await module.preloadAllVersions();
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.status).toEqual({
+      python: 'success',
+      cuda: 'success',
+    });
+  });
+
+  it('refreshExpiredCaches는 만료된 소스만 새로고침한다', async () => {
+    const fetchPythonVersions = vi.fn().mockResolvedValue(['3.13']);
+    const fetchCudaVersions = vi.fn().mockResolvedValue(['12.6']);
+    vi.doMock('./version-fetcher', () => ({
+      fetchPythonVersions,
+      fetchCudaVersions,
+    }));
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', storage);
+    storage.setItem('depssmuggler:python-versions', JSON.stringify(['3.13']));
+    storage.setItem('depssmuggler:python-versions-timestamp', String(Date.now()));
+    storage.setItem('depssmuggler:cuda-versions-timestamp', String(Date.now() - (8 * 24 * 60 * 60 * 1000)));
+    const module = await import('./version-preloader');
+
+    await module.refreshExpiredCaches();
+
+    expect(fetchPythonVersions).not.toHaveBeenCalled();
+    expect(fetchCudaVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it('브라우저 환경에서는 캐시 나이와 유효성을 계산한다', async () => {
+    vi.doMock('./version-fetcher', () => ({
+      fetchPythonVersions: vi.fn().mockResolvedValue(['3.13']),
+      fetchCudaVersions: vi.fn().mockResolvedValue(['12.6']),
+    }));
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', storage);
+    storage.setItem('depssmuggler:python-versions-timestamp', String(Date.now() - 1000));
+    storage.setItem('depssmuggler:cuda-versions-timestamp', String(Date.now() - (8 * 24 * 60 * 60 * 1000)));
+    const module = await import('./version-preloader');
+
+    expect(module.isCacheValid('python')).toBe(true);
+    expect(module.isCacheValid('cuda')).toBe(false);
+    expect(module.getCacheAge('python')).toBeGreaterThanOrEqual(1000);
+  });
+});


### PR DESCRIPTION
## 요약
- 저커버리지였던 OS downloader/parser/resolver와 공통 base, version cache/preloader, GPG/distribution fetcher에 위험도 우선 회귀 테스트를 추가했습니다.
- retry/error/fallback/security branch를 중심으로 테스트를 고정해서 refactor 이후 회귀를 조기에 잡을 수 있게 했습니다.

## 배경
- refactor 이후 low coverage 영역이 apt/apk/yum downloader, os-shared base modules, distribution-fetcher, gpg-verifier, version-fetcher, version-preloader, resolver 계층에 집중돼 있었습니다.
- 전체 퍼센트만 올리는 대신 장애 가능성이 높은 branch를 우선 커버해야 했습니다.

## 변경 사항
- `distribution-fetcher`: 원격 파싱, 캐시 재사용, fallback 경로 테스트 추가
- `gpg-verifier`: key import retry, checksum mismatch, 공식 저장소/비활성 skip, signature fallback 테스트 추가
- `base-downloader`/`base-resolver`: abort, retry/skip, unreadable body, progress, conflict/missing/optional branch 테스트 추가
- `version-fetcher`/`version-preloader`: localStorage/file cache hit, 만료 캐시 fallback, preload/refresh branch 테스트 추가
- `apt/apk/yum` parser 및 `apt/apk/yum resolver`: metadata parse, provides lookup, architecture filtering, no-primary skip branch 테스트 추가

## 검증
- `npm test -- src/core/downloaders/os-shared/distribution-fetcher.test.ts src/core/downloaders/os-shared/gpg-verifier.test.ts src/core/downloaders/os-shared/base-downloader.test.ts src/core/downloaders/os-shared/base-resolver.test.ts src/core/shared/version-fetcher.test.ts src/core/shared/version-preloader.test.ts src/core/downloaders/os-metadata-parsers.test.ts src/core/resolver/os-resolvers.test.ts`
- `npx tsc --noEmit`
- `npm run test:coverage`
- `bash scripts/verify-worktree.sh`
- `git diff --check`

## coverage delta
- 전체 coverage: statements `40.79% -> 52.26%`, branches `31.60% -> 40.13%`, functions `43.01% -> 52.80%`, lines `41.75% -> 53.45%`
- 주요 대상 파일 예시
  - `distribution-fetcher.ts`: statements `0% -> 94.50%`, branches `0% -> 88.10%`
  - `base-resolver.ts`: statements `0% -> 89.78%`, branches `0% -> 67.11%`
  - `version-preloader.ts`: statements `0% -> 73.91%`, branches `0% -> 51.02%`
  - `apt-resolver.ts`: statements `1.31% -> 76.32%`, branches `0% -> 48.65%`
  - `apk-resolver.ts`: statements `1.36% -> 83.56%`, branches `0% -> 59.46%`
  - `yum-resolver.ts`: statements `1.36% -> 79.45%`, branches `0% -> 48.65%`
  - `apt.ts`: statements `0.88% -> 42.67%`
  - `apk.ts`: statements `1.10% -> 41.99%`
  - `yum.ts`: statements `6.93% -> 65.35%`
  - `gpg-verifier.ts`: statements `0% -> 70.11%`
  - `version-fetcher.ts`: statements `0% -> 46.97%`

## 문서
- 없음
