### PR TITLE
테스트 mock drift와 검증 커버리지를 보강합니다

### DIFF
--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -1,9 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs-extra';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerDownloadHandlers } from './download-handlers';
+import { createEmailSenderMock } from '../src/core/mailer/__mocks__/email-sender-mock';
 import type { OSPackageInfo, OSDistribution } from '../src/core/downloaders/os-shared/types';
+
+type CoreModule = typeof import('../src/core');
 
 const {
   ipcHandle,
@@ -24,6 +27,20 @@ const {
   archiveCreateArchive,
   repoCreateLocalRepo,
   generateDependencyOrderScriptMock,
+  getCondaDownloaderMock,
+  getMavenDownloaderMock,
+  getDockerDownloaderMock,
+  getNpmDownloaderMock,
+  getYumDownloaderMock,
+  getAptDownloaderMock,
+  getApkDownloaderMock,
+  getPipResolverMock,
+  getCondaResolverMock,
+  getMavenResolverMock,
+  getNpmResolverMock,
+  getYumResolverMock,
+  getAptResolverMock,
+  getApkResolverMock,
 } = vi.hoisted(() => ({
   ipcHandle: vi.fn(),
   webContentsSend: vi.fn(),
@@ -43,6 +60,20 @@ const {
   archiveCreateArchive: vi.fn(),
   repoCreateLocalRepo: vi.fn(),
   generateDependencyOrderScriptMock: vi.fn(),
+  getCondaDownloaderMock: vi.fn(),
+  getMavenDownloaderMock: vi.fn(),
+  getDockerDownloaderMock: vi.fn(),
+  getNpmDownloaderMock: vi.fn(),
+  getYumDownloaderMock: vi.fn(),
+  getAptDownloaderMock: vi.fn(),
+  getApkDownloaderMock: vi.fn(),
+  getPipResolverMock: vi.fn(),
+  getCondaResolverMock: vi.fn(),
+  getMavenResolverMock: vi.fn(),
+  getNpmResolverMock: vi.fn(),
+  getYumResolverMock: vi.fn(),
+  getAptResolverMock: vi.fn(),
+  getApkResolverMock: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -72,22 +103,24 @@ vi.mock('../src/core/shared', () => ({
   generateInstallScripts: generateInstallScriptsMock,
 }));
 
-vi.mock('../src/core', () => ({
-  getCondaDownloader: vi.fn(),
-  getMavenDownloader: vi.fn(),
-  getDockerDownloader: vi.fn(),
-  getNpmDownloader: vi.fn(),
-  getYumDownloader: vi.fn(() => ({
-    downloadPackage: yumDownloadPackage,
-  })),
-  getAptDownloader: vi.fn(),
-  getApkDownloader: vi.fn(),
-  getYumResolver: vi.fn(() => ({
-    resolveDependencies: yumResolveDependencies,
-  })),
-  getAptResolver: vi.fn(),
-  getApkResolver: vi.fn(),
-}));
+vi.mock('../src/core', () =>
+  ({
+    getCondaDownloader: getCondaDownloaderMock,
+    getMavenDownloader: getMavenDownloaderMock,
+    getDockerDownloader: getDockerDownloaderMock,
+    getNpmDownloader: getNpmDownloaderMock,
+    getYumDownloader: getYumDownloaderMock,
+    getAptDownloader: getAptDownloaderMock,
+    getApkDownloader: getApkDownloaderMock,
+    getPipResolver: getPipResolverMock,
+    getCondaResolver: getCondaResolverMock,
+    getMavenResolver: getMavenResolverMock,
+    getNpmResolver: getNpmResolverMock,
+    getYumResolver: getYumResolverMock,
+    getAptResolver: getAptResolverMock,
+    getApkResolver: getApkResolverMock,
+  }) satisfies Partial<CoreModule>
+);
 
 vi.mock('../src/core/packager/archive-packager', () => ({
   getArchivePackager: vi.fn(() => ({
@@ -222,10 +255,11 @@ describe('registerDownloadHandlers', () => {
       attachmentsSent: 1,
       splitApplied: false,
     });
-    initializeEmailSenderMock.mockReturnValue({
-      sendEmail: sendEmailMock,
-      testConnection: vi.fn(),
-    });
+    initializeEmailSenderMock.mockReturnValue(
+      createEmailSenderMock({
+        sendEmail: sendEmailMock,
+      })
+    );
     splitFileMock.mockResolvedValue({
       parts: [
         path.join(tempDir, 'bundle.tar.gz.part001'),
@@ -261,6 +295,48 @@ describe('registerDownloadHandlers', () => {
       unresolved: [],
       conflicts: [],
       warnings: [],
+    });
+    getCondaDownloaderMock.mockReturnValue({
+      getPackageMetadata: vi.fn(),
+    });
+    getMavenDownloaderMock.mockReturnValue({
+      downloadPackage: vi.fn(),
+    });
+    getDockerDownloaderMock.mockReturnValue({
+      downloadImage: vi.fn(),
+    });
+    getNpmDownloaderMock.mockReturnValue({
+      getPackageMetadata: vi.fn(),
+    });
+    getYumDownloaderMock.mockReturnValue({
+      downloadPackage: yumDownloadPackage,
+    });
+    getAptDownloaderMock.mockReturnValue({
+      downloadPackage: vi.fn(),
+    });
+    getApkDownloaderMock.mockReturnValue({
+      downloadPackage: vi.fn(),
+    });
+    getPipResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
+    });
+    getCondaResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
+    });
+    getMavenResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
+    });
+    getNpmResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
+    });
+    getYumResolverMock.mockReturnValue({
+      resolveDependencies: yumResolveDependencies,
+    });
+    getAptResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
+    });
+    getApkResolverMock.mockReturnValue({
+      resolveDependencies: vi.fn(),
     });
     archiveCreateArchive.mockResolvedValue(`${osOutputDir}/os-packages.zip`);
     repoCreateLocalRepo.mockImplementation(

--- a/electron/services/download-orchestrator.test.ts
+++ b/electron/services/download-orchestrator.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { describe, expect, it, vi } from 'vitest';
+import { createEmailSenderMock } from '../../src/core/mailer/__mocks__/email-sender-mock';
 
 const createDeferred = <T>() => {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -12,6 +13,12 @@ const createDeferred = <T>() => {
 };
 
 describe('createDownloadOrchestrator', () => {
+  const createArchivePackagerMock = () => ({
+    createArchiveFromDirectory: vi.fn().mockImplementation(
+      async (_sourceDir: string, outputPath: string) => outputPath
+    ),
+  });
+
   it('성공한 패키지만 패키징 대상으로 모아 완료 이벤트를 만든다', async () => {
     const { createDownloadOrchestrator } = await import('./download-orchestrator');
 
@@ -25,9 +32,7 @@ describe('createDownloadOrchestrator', () => {
       emitDownloadStatus: vi.fn(),
       emitAllComplete: vi.fn(),
     };
-    const archivePackager = {
-      createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.tar.gz'),
-    };
+    const archivePackager = createArchivePackagerMock();
     const generateInstallScripts = vi.fn();
     const ensureDir = vi.fn().mockResolvedValue(undefined);
 
@@ -109,6 +114,78 @@ describe('createDownloadOrchestrator', () => {
     );
   });
 
+  it('zip 출력 형식도 outputDir 기반 아카이브 경로로 패키징한다', async () => {
+    const { createDownloadOrchestrator } = await import('./download-orchestrator');
+
+    const router = {
+      downloadPackage: vi.fn().mockResolvedValue({
+        id: 'pip-requests-2.28.0',
+        success: true,
+      }),
+    };
+    const progressEmitter = {
+      emitDownloadStatus: vi.fn(),
+      emitAllComplete: vi.fn(),
+    };
+    const archivePackager = createArchivePackagerMock();
+    const outputDir = '/tmp/out-zip';
+    const expectedArchivePath = `${outputDir}.zip`;
+
+    const orchestrator = createDownloadOrchestrator({
+      getMainWindow: () => null,
+      ensureDir: vi.fn().mockResolvedValue(undefined),
+      scheduleTask: async (task: () => Promise<void>) => {
+        await task();
+      },
+      createLimiter: () => ((task: () => Promise<unknown>) => task()),
+      createPackageRouter: () => router,
+      createProgressEmitter: () => progressEmitter as never,
+      archivePackager,
+      generateInstallScripts: vi.fn(),
+    });
+
+    await orchestrator.startDownload({
+      sessionId: 111,
+      packages: [
+        {
+          id: 'pip-requests-2.28.0',
+          type: 'pip',
+          name: 'requests',
+          version: '2.28.0',
+        },
+      ],
+      options: {
+        outputDir,
+        outputFormat: 'zip',
+        includeScripts: false,
+        concurrency: 1,
+      },
+    });
+
+    expect(archivePackager.createArchiveFromDirectory).toHaveBeenCalledWith(
+      outputDir,
+      expectedArchivePath,
+      [
+        expect.objectContaining({
+          type: 'pip',
+          name: 'requests',
+          version: '2.28.0',
+        }),
+      ],
+      expect.objectContaining({
+        format: 'zip',
+      })
+    );
+    expect(progressEmitter.emitAllComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 111,
+        success: true,
+        outputPath: expectedArchivePath,
+        artifactPaths: [expectedArchivePath],
+      })
+    );
+  });
+
   it('이메일 전달 준비 중 취소되면 sendEmail 없이 cancelled 완료 이벤트를 만든다', async () => {
     const { createDownloadOrchestrator } = await import('./download-orchestrator');
 
@@ -123,9 +200,7 @@ describe('createDownloadOrchestrator', () => {
       emitAllComplete: vi.fn(),
       clearAllPackageProgress: vi.fn(),
     };
-    const archivePackager = {
-      createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.tar.gz'),
-    };
+    const archivePackager = createArchivePackagerMock();
     const generateInstallScripts = vi.fn();
     const ensureDir = vi.fn().mockResolvedValue(undefined);
     const statDeferred = createDeferred<{ size: number }>();
@@ -144,9 +219,7 @@ describe('createDownloadOrchestrator', () => {
       createProgressEmitter: () => progressEmitter as never,
       archivePackager,
       generateInstallScripts,
-      initializeEmailSender: vi.fn(() => ({
-        sendEmail,
-      })) as never,
+      initializeEmailSender: (vi.fn(() => createEmailSenderMock({ sendEmail }))) as never,
     });
 
     const result = await orchestrator.startDownload({
@@ -234,13 +307,13 @@ describe('createDownloadOrchestrator', () => {
       createLimiter: () => ((task: () => Promise<unknown>) => task()),
       createPackageRouter: () => router,
       createProgressEmitter: () => progressEmitter as never,
-      archivePackager: {
-        createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.tar.gz'),
-      } as never,
+      archivePackager: createArchivePackagerMock() as never,
       generateInstallScripts: vi.fn(),
-      initializeEmailSender: vi.fn(() => ({
-        sendEmail: vi.fn().mockImplementation(() => sendEmailDeferred.promise),
-      })) as never,
+      initializeEmailSender: (vi.fn(() =>
+        createEmailSenderMock({
+          sendEmail: vi.fn().mockImplementation(() => sendEmailDeferred.promise),
+        })
+      )) as never,
     });
 
     const result = await orchestrator.startDownload({

--- a/src/core/cache-manager.test.ts
+++ b/src/core/cache-manager.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getCacheManager, initializeCacheManager, CacheManager } from './cache-manager';
-import * as path from 'path';
+import * as crypto from 'crypto';
 import * as os from 'os';
+import * as path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheManager, getCacheManager, initializeCacheManager } from './cache-manager';
+import { sanitizeCacheKey } from './shared/filename-utils';
 
 // fs-extra 모킹
 vi.mock('fs-extra', () => ({
@@ -15,6 +17,27 @@ vi.mock('fs-extra', () => ({
   remove: vi.fn().mockResolvedValue(undefined),
   createReadStream: vi.fn(),
 }));
+
+const createCacheKeyForTest = (packageInfo: {
+  type: string;
+  name: string;
+  version: string;
+  arch?: string;
+}): string => {
+  const keyParts = [
+    packageInfo.type,
+    packageInfo.name,
+    packageInfo.version,
+    packageInfo.arch || 'noarch',
+  ];
+  const hash = crypto
+    .createHash('sha256')
+    .update(keyParts.join('-'))
+    .digest('hex')
+    .slice(0, 16);
+
+  return `${packageInfo.type}-${sanitizeCacheKey(packageInfo.name, 50)}-${hash}`;
+};
 
 describe('cacheManager', () => {
   describe('getCacheManager', () => {
@@ -269,6 +292,35 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       expect(fs.copy).toHaveBeenCalled();
       expect(fs.writeJson).toHaveBeenCalled();
     });
+
+    it('매니페스트 저장 실패를 호출자에게 그대로 전달', async () => {
+      const fs = await import('fs-extra');
+      const { EventEmitter } = await import('events');
+
+      const mockStream = new EventEmitter();
+      vi.mocked(fs.createReadStream).mockReturnValue(mockStream as never);
+      vi.mocked(fs.pathExists).mockResolvedValue(false as never);
+      vi.mocked(fs.stat).mockResolvedValue({ size: 2000 } as never);
+      vi.mocked(fs.writeJson).mockRejectedValueOnce(new Error('disk full') as never);
+
+      const manager = new CacheManager({
+        cacheDir: testCacheDir,
+        maxSizeGB: 1,
+        enabled: true,
+      });
+
+      const packageInfo = { type: 'pip' as const, name: 'requests', version: '2.28.0' };
+      const addPromise = manager.addToCache(packageInfo, '/tmp/test-file.whl');
+
+      setImmediate(() => {
+        mockStream.emit('data', Buffer.from('test data'));
+        mockStream.emit('end');
+      });
+
+      await expect(addPromise).rejects.toThrow('disk full');
+      expect(fs.copy).toHaveBeenCalled();
+      expect(fs.writeJson).toHaveBeenCalled();
+    });
   });
 
   describe('getCachedFile - 캐시 히트', () => {
@@ -423,6 +475,63 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       });
 
       expect(result).toBeNull();
+    });
+
+    it('캐시 삭제가 실패해도 매니페스트 엔트리는 정리한다', async () => {
+      const fs = await import('fs-extra');
+      const { EventEmitter } = await import('events');
+
+      const packageInfo = {
+        type: 'pip' as const,
+        name: 'requests',
+        version: '2.28.0',
+      };
+      const cachedFilePath = path.join(testCacheDir, 'pip-requests-test', 'file.whl');
+      const cacheKey = createCacheKeyForTest(packageInfo);
+      const existingManifest = {
+        version: '1.0',
+        entries: [
+          [
+            cacheKey,
+            {
+              packageInfo,
+              filePath: cachedFilePath,
+              checksum: 'expected_checksum_that_wont_match',
+              size: 1000,
+              cachedAt: '2024-01-01T00:00:00.000Z',
+              lastAccessedAt: '2024-01-01T00:00:00.000Z',
+            },
+          ],
+        ],
+        totalSize: 1000,
+        lastUpdated: '2024-01-01T00:00:00.000Z',
+      };
+
+      vi.mocked(fs.pathExists).mockImplementation(async (p) => {
+        if (String(p).includes('cache-manifest.json')) return true;
+        if (String(p) === cachedFilePath) return true;
+        return false;
+      });
+      vi.mocked(fs.readJson).mockResolvedValue(existingManifest as never);
+      vi.mocked(fs.remove).mockRejectedValueOnce(new Error('permission denied') as never);
+
+      const mockStream = new EventEmitter();
+      vi.mocked(fs.createReadStream).mockReturnValue(mockStream as never);
+
+      const manager = new CacheManager({ cacheDir: testCacheDir, enabled: true });
+      await manager.initialize();
+
+      const resultPromise = manager.getCachedFile(packageInfo);
+
+      setImmediate(() => {
+        mockStream.emit('data', Buffer.from('test'));
+        mockStream.emit('end');
+      });
+
+      await expect(resultPromise).resolves.toBeNull();
+      expect(fs.remove).toHaveBeenCalledWith(path.dirname(cachedFilePath));
+      await expect(manager.getCacheCount()).resolves.toBe(0);
+      expect(fs.writeJson).toHaveBeenCalled();
     });
   });
 

--- a/src/core/downloaders/docker-download.test.ts
+++ b/src/core/downloaders/docker-download.test.ts
@@ -304,6 +304,16 @@ describe('DockerDownloader - Download Methods', () => {
       ).rejects.toThrow('Download failed');
     });
 
+    it('should handle manifest timeout failure', async () => {
+      mockGetManifestForArchitecture.mockRejectedValueOnce(
+        new Error('manifest timeout')
+      );
+
+      await expect(
+        downloader.downloadImage('library/nginx', 'latest', 'x86_64', tmpDir)
+      ).rejects.toThrow('manifest timeout');
+    });
+
     it('should handle tar creation failure', async () => {
       mockCreateImageTar.mockRejectedValueOnce(
         new Error('Tar creation failed')

--- a/src/core/downloaders/maven-download.test.ts
+++ b/src/core/downloaders/maven-download.test.ts
@@ -249,6 +249,19 @@ describe('MavenDownloader downloadPackage 테스트', () => {
       ).rejects.toThrow('Network Error');
     });
 
+    it('타임아웃 오류를 그대로 전달', async () => {
+      mockAxiosGet.mockRejectedValue(new Error('Not found'));
+      mockAxiosDefault.mockRejectedValue(
+        Object.assign(new Error('timeout of 300000ms exceeded'), {
+          code: 'ECONNABORTED',
+        })
+      );
+
+      await expect(
+        downloader.downloadArtifact('com.example', 'test', '1.0.0', '/tmp/test', 'jar')
+      ).rejects.toThrow('timeout of 300000ms exceeded');
+    });
+
     it('writer 오류 처리', async () => {
       mockAxiosGet.mockRejectedValue(new Error('Not found'));
 

--- a/src/core/downloaders/npm-download.test.ts
+++ b/src/core/downloaders/npm-download.test.ts
@@ -318,6 +318,31 @@ describe('NpmDownloader downloadPackage 테스트', () => {
       await expect(downloader.downloadPackage(info, '/tmp/test')).rejects.toThrow('Network Error');
     });
 
+    it('401 응답 오류를 그대로 전달', async () => {
+      const mockGetPackageMetadata = vi.fn().mockResolvedValue({
+        name: 'test-pkg',
+        version: '1.0.0',
+        type: 'npm',
+        metadata: {
+          downloadUrl: 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz',
+        },
+      });
+      (downloader as any).getPackageMetadata = mockGetPackageMetadata;
+
+      mockAxiosDefault.mockRejectedValue(
+        Object.assign(new Error('Request failed with status code 401'), {
+          response: {
+            status: 401,
+          },
+        })
+      );
+
+      const info = { type: 'npm' as const, name: 'test-pkg', version: '1.0.0' };
+      await expect(downloader.downloadPackage(info, '/tmp/test')).rejects.toThrow(
+        'Request failed with status code 401'
+      );
+    });
+
     it('writer 오류 처리', async () => {
       const mockGetPackageMetadata = vi.fn().mockResolvedValue({
         name: 'test-pkg',

--- a/src/core/mailer/__mocks__/email-sender-mock.test.ts
+++ b/src/core/mailer/__mocks__/email-sender-mock.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createEmailSenderMock } from './email-sender-mock';
+
+describe('createEmailSenderMock', () => {
+  it('EmailSender의 public 메서드를 모두 제공한다', async () => {
+    const sender = createEmailSenderMock();
+
+    await expect(sender.testConnection()).resolves.toBe(true);
+    await expect(
+      sender.sendEmail({
+        to: 'offline@example.com',
+        subject: 'test',
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        emailsSent: 1,
+      })
+    );
+
+    sender.updateConfig({ host: 'smtp.example.com' });
+    sender.setMaxAttachmentSize(1024);
+    sender.close();
+
+    expect(sender.testConnection).toHaveBeenCalledTimes(1);
+    expect(sender.sendEmail).toHaveBeenCalledTimes(1);
+    expect(sender.updateConfig).toHaveBeenCalledWith({ host: 'smtp.example.com' });
+    expect(sender.setMaxAttachmentSize).toHaveBeenCalledWith(1024);
+    expect(sender.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/mailer/__mocks__/email-sender-mock.ts
+++ b/src/core/mailer/__mocks__/email-sender-mock.ts
@@ -1,0 +1,28 @@
+import { vi } from 'vitest';
+import type { EmailSender } from '../email-sender';
+
+type EmailSenderPublicMethods = Pick<
+  EmailSender,
+  'sendEmail' | 'testConnection' | 'updateConfig' | 'setMaxAttachmentSize' | 'close'
+>;
+
+export type EmailSenderMock = EmailSenderPublicMethods;
+
+export function createEmailSenderMock(
+  overrides: Partial<EmailSenderMock> = {}
+): EmailSenderMock {
+  return {
+    sendEmail: vi.fn().mockResolvedValue({
+      success: true,
+      messageId: 'mock-message-id',
+      emailsSent: 1,
+      attachmentsSent: 1,
+      splitApplied: false,
+    }),
+    testConnection: vi.fn().mockResolvedValue(true),
+    updateConfig: vi.fn(),
+    setMaxAttachmentSize: vi.fn(),
+    close: vi.fn(),
+    ...overrides,
+  } satisfies EmailSenderMock;
+}

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -7,6 +7,15 @@ import { AptDependencyResolver } from './apt-resolver';
 import { YumDependencyResolver } from './yum-resolver';
 import type { OSPackageInfo, Repository } from '../downloaders/os-shared/types';
 
+type ResolverTestAccess = {
+  loadMetadata(): Promise<void>;
+  findPackagesForDependency(dependency: { name: string }): Promise<OSPackageInfo[]>;
+};
+
+function accessResolverForTest<T>(resolver: T): T & ResolverTestAccess {
+  return resolver as T & ResolverTestAccess;
+}
+
 describe('OS dependency resolvers', () => {
   const repo: Repository = {
     id: 'repo',
@@ -88,10 +97,11 @@ describe('OS dependency resolvers', () => {
       },
       architecture: 'amd64',
     });
+    const testResolver = accessResolverForTest(resolver);
 
-    await (resolver as any).loadMetadata();
-    const byProvides = await (resolver as any).findPackagesForDependency({ name: 'mail-transport-agent' });
-    const byArchSuffix = await (resolver as any).findPackagesForDependency({ name: 'libc6:amd64' });
+    await testResolver.loadMetadata();
+    const byProvides = await testResolver.findPackagesForDependency({ name: 'mail-transport-agent' });
+    const byArchSuffix = await testResolver.findPackagesForDependency({ name: 'libc6:amd64' });
 
     expect(byProvides).toHaveLength(1);
     expect(byProvides[0].name).toBe('postfix');
@@ -116,10 +126,11 @@ describe('OS dependency resolvers', () => {
         extendedRepos: [],
       },
     });
+    const testResolver = accessResolverForTest(resolver);
 
-    await (resolver as any).loadMetadata();
-    const bySo = await (resolver as any).findPackagesForDependency({ name: 'so:libcrypto.so.3' });
-    const byCmd = await (resolver as any).findPackagesForDependency({ name: 'cmd:sh' });
+    await testResolver.loadMetadata();
+    const bySo = await testResolver.findPackagesForDependency({ name: 'so:libcrypto.so.3' });
+    const byCmd = await testResolver.findPackagesForDependency({ name: 'cmd:sh' });
 
     expect(bySo).toHaveLength(1);
     expect(byCmd).toHaveLength(1);
@@ -163,9 +174,10 @@ describe('OS dependency resolvers', () => {
         extendedRepos: [],
       },
     });
+    const testResolver = accessResolverForTest(resolver);
 
-    await (resolver as any).loadMetadata();
-    const byLibrary = await (resolver as any).findPackagesForDependency({
+    await testResolver.loadMetadata();
+    const byLibrary = await testResolver.findPackagesForDependency({
       name: 'libcrypto.so.3()(64bit)',
     });
 

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -62,6 +62,7 @@ function DownloadPage() {
         downloadItems={controller.downloadItems}
         logs={controller.logs}
         onRetry={controller.executeRetryDownload}
+        onRestartDownload={controller.handleStartDownload}
         onOpenFolder={controller.handleOpenFolder}
         onComplete={controller.handleComplete}
       />

--- a/src/renderer/pages/DownloadPage.tsx
+++ b/src/renderer/pages/DownloadPage.tsx
@@ -52,6 +52,7 @@ function DownloadPage() {
         completedCount={controller.completedCount}
         failedCount={controller.failedCount}
         skippedCount={controller.skippedCount}
+        isDownloading={controller.isDownloading}
         outputFormat={controller.outputFormat}
         deliveryMethod={controller.deliveryMethod}
         completedOutputPath={controller.completedOutputPath}

--- a/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
@@ -1,6 +1,7 @@
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
+  DownloadOutlined,
   FileZipOutlined,
   FolderOpenOutlined,
   ForwardOutlined,
@@ -29,6 +30,7 @@ interface DownloadOutcomeViewProps {
   downloadItems: DownloadItem[];
   logs: LogEntry[];
   onRetry: (item: DownloadItem) => void;
+  onRestartDownload: () => Promise<void> | void;
   onOpenFolder: () => Promise<void> | void;
   onComplete: () => void;
 }
@@ -48,11 +50,40 @@ export function DownloadOutcomeView({
   downloadItems,
   logs,
   onRetry,
+  onRestartDownload,
   onOpenFolder,
   onComplete,
 }: DownloadOutcomeViewProps) {
   const isCompleted = variant === 'completed';
   const hasCancelledDelivery = !isCompleted && Boolean(completedDeliveryResult?.emailSent);
+  const resultActions = [
+    <Button
+      key="open"
+      icon={<FolderOpenOutlined />}
+      onClick={onOpenFolder}
+    >
+      다운로드 폴더 열기
+    </Button>,
+  ];
+
+  if (!isCompleted) {
+    resultActions.unshift(
+      <Button
+        type="primary"
+        key="restart"
+        icon={<DownloadOutlined />}
+        onClick={onRestartDownload}
+      >
+        다운로드 시작
+      </Button>
+    );
+  }
+
+  resultActions.push(
+    <Button key="done" icon={<ReloadOutlined />} onClick={onComplete}>
+      새 다운로드
+    </Button>
+  );
 
   return (
     <div>
@@ -86,19 +117,7 @@ export function DownloadOutcomeView({
             ? '로컬 산출물은 생성되었습니다. 경로를 확인해 수동 전달을 진행할 수 있습니다.'
             : '패키징 또는 전달 중 오류가 발생했습니다.'
         }
-        extra={[
-          <Button
-            type="primary"
-            key="open"
-            icon={<FolderOpenOutlined />}
-            onClick={onOpenFolder}
-          >
-            다운로드 폴더 열기
-          </Button>,
-          <Button key="done" icon={<ReloadOutlined />} onClick={onComplete}>
-            새 다운로드
-          </Button>,
-        ]}
+        extra={resultActions}
       />
 
       <Card

--- a/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
@@ -20,6 +20,7 @@ interface DownloadOutcomeViewProps {
   completedCount: number;
   failedCount: number;
   skippedCount: number;
+  isDownloading: boolean;
   outputFormat: 'zip' | 'tar.gz';
   deliveryMethod: 'local' | 'email';
   completedOutputPath: string;
@@ -40,6 +41,7 @@ export function DownloadOutcomeView({
   completedCount,
   failedCount,
   skippedCount,
+  isDownloading,
   outputFormat,
   deliveryMethod,
   completedOutputPath,
@@ -73,6 +75,8 @@ export function DownloadOutcomeView({
         key="restart"
         icon={<DownloadOutlined />}
         onClick={onRestartDownload}
+        disabled={isDownloading}
+        loading={isDownloading}
       >
         다운로드 시작
       </Button>

--- a/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
@@ -84,7 +84,7 @@ export function DownloadOutcomeView({
   }
 
   resultActions.push(
-    <Button key="done" icon={<ReloadOutlined />} onClick={onComplete}>
+    <Button key="done" icon={<ReloadOutlined />} onClick={onComplete} disabled={isDownloading}>
       새 다운로드
     </Button>
   );

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
@@ -1598,6 +1598,10 @@ export function useDownloadPageController() {
   }, [addLog, cartItems, setDepsResolved, setItems]);
 
   const handleComplete = useCallback(() => {
+    if (isDownloading) {
+      return;
+    }
+
     reset();
     setDepsResolved(false);
     dependencyResolutionBypassedRef.current = false;
@@ -1613,7 +1617,7 @@ export function useDownloadPageController() {
     historyTrackedItemIdsRef.current = null;
     osFlow.resetOSFlow();
     navigate('/');
-  }, [navigate, osFlow, reset, setDepsResolved]);
+  }, [isDownloading, navigate, osFlow, reset, setDepsResolved]);
 
   const handleOpenFolder = useCallback(async () => {
     const targetPath = completedOutputPath || outputDir;

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
@@ -122,6 +122,7 @@ export function useDownloadPageController() {
   const downloadCancelledRef = useRef(false);
   const downloadPausedRef = useRef(false);
   const cancelledCompletionRetainedRef = useRef(false);
+  const outcomeRestartInFlightRef = useRef(false);
   const dependencyResolutionBypassedRef = useRef(false);
   const previousIncludeDependenciesRef = useRef(includeDependencies);
   const downloadItemsRef = useRef<DownloadItem[]>([]);
@@ -1091,167 +1092,189 @@ export function useDownloadPageController() {
   ]);
 
   const handleStartDownload = useCallback(async () => {
-    if (!outputDir) {
-      message.warning('출력 폴더를 선택하세요');
+    const isRestartingFromOutcome =
+      packagingStatus === 'failed'
+      && hasRecoverableArtifacts({
+        completedOutputPath,
+        completedArtifactPaths,
+        completedDeliveryResult,
+      });
+
+    if (isRestartingFromOutcome && outcomeRestartInFlightRef.current) {
       return;
     }
 
-    const emailDeliveryValidationError = getEmailDeliveryValidationError({
-      deliveryMethod,
-      smtpHost,
-      smtpPort,
-      smtpTo: effectiveSmtpTo,
-      smtpFrom,
-      smtpUser,
-    });
-
-    if (emailDeliveryValidationError) {
-      message.warning(emailDeliveryValidationError);
-      return;
-    }
-
-    if (includeDependencies && !depsResolved) {
-      message.warning('먼저 의존성 확인을 진행하세요');
-      return;
-    }
-
-    setIsDownloading(true);
-    setIsPaused(false);
-    setStartTime(Date.now());
-    const previousSessionState = {
-      sessionCounter: downloadSessionIdRef.current,
-      activeSession: activeDownloadSessionRef.current,
-      cartSnapshot: cartSnapshotRef.current,
-      historyTrackedItemIds: historyTrackedItemIdsRef.current,
-      historySettings: historySettingsSnapshotRef.current,
-      downloadCancelled: downloadCancelledRef.current,
-      downloadPaused: downloadPausedRef.current,
-      cancelledCompletionRetained: cancelledCompletionRetainedRef.current,
-      lastSpeedCalc: lastSpeedCalcRef.current,
-      speedHistory: [...speedHistoryRef.current],
-      startTime,
-      isDownloading,
-      isPaused,
-      packagingStatus,
-      packagingProgress,
-      completedOutputPath,
-      completedArtifactPaths: [...completedArtifactPaths],
-      completedDeliveryResult,
-      completedError,
-    };
-    const sessionSnapshot = createDownloadSessionSnapshot(
-      [...cartItems],
-      new Set(downloadItems.map((item) => item.id)),
-      buildHistorySettings({
-        outputFormat,
-        includeScripts: includeInstallScripts,
-        includeDependencies,
-        deliveryMethod,
-        smtpTo: effectiveSmtpTo,
-        fileSplitEnabled: enableFileSplit,
-        maxFileSizeMB: maxFileSize,
-      })
-    );
-    beginProvisionalDownloadSession(sessionSnapshot, previousSessionState.activeSession);
-    downloadCancelledRef.current = false;
-    downloadPausedRef.current = false;
-    cancelledCompletionRetainedRef.current = false;
-    lastSpeedCalcRef.current = { time: 0, bytes: 0 };
-    speedHistoryRef.current = [];
-
-    const restorePreviousSessionState = () => {
-      downloadSessionIdRef.current = previousSessionState.sessionCounter;
-      activeDownloadSessionRef.current = previousSessionState.activeSession;
-      cartSnapshotRef.current = previousSessionState.cartSnapshot;
-      historyTrackedItemIdsRef.current = previousSessionState.historyTrackedItemIds;
-      historySettingsSnapshotRef.current = previousSessionState.historySettings;
-      downloadCancelledRef.current = previousSessionState.downloadCancelled;
-      downloadPausedRef.current = previousSessionState.downloadPaused;
-      cancelledCompletionRetainedRef.current = previousSessionState.cancelledCompletionRetained;
-      lastSpeedCalcRef.current = previousSessionState.lastSpeedCalc;
-      speedHistoryRef.current = [...previousSessionState.speedHistory];
-      setStartTime(previousSessionState.startTime);
-      setIsDownloading(previousSessionState.isDownloading);
-      setIsPaused(previousSessionState.isPaused);
-      setPackagingStatus(previousSessionState.packagingStatus);
-      setPackagingProgress(previousSessionState.packagingProgress);
-      setCompletedOutputPath(previousSessionState.completedOutputPath);
-      setCompletedArtifactPaths([...previousSessionState.completedArtifactPaths]);
-      setCompletedDeliveryResult(previousSessionState.completedDeliveryResult);
-      setCompletedError(previousSessionState.completedError);
-
-      const queuedPreviousCompletion = takeQueuedPreviousCompletion(sessionSnapshot.id);
-      if (queuedPreviousCompletion) {
-        applyDownloadCompletion(queuedPreviousCompletion.data, queuedPreviousCompletion.sessionSnapshot, {
-          updatePackage: updateItem,
-          logMessage: addLog,
-        });
-      }
-    };
-
-    const canProceed = await checkOutputPath();
-    if (!canProceed) {
-      restorePreviousSessionState();
-      return;
-    }
-    setCompletedOutputPath('');
-    setCompletedArtifactPaths([]);
-    setCompletedDeliveryResult(undefined);
-    setCompletedError('');
-
-    addLog('info', '다운로드 시작', `총 ${downloadItems.length}개 패키지`);
-
-    if (!window.electronAPI?.download?.start) {
-      restorePreviousSessionState();
-      addLog('error', '다운로드 API를 사용할 수 없습니다');
-      return;
+    if (isRestartingFromOutcome) {
+      outcomeRestartInFlightRef.current = true;
     }
 
     try {
-      const packages = downloadItems.map((item) => ({
-        id: item.id,
-        type: item.type,
-        name: item.name,
-        version: item.version,
-        architecture: item.arch,
-        downloadUrl: item.downloadUrl,
-        metadata: item.metadata,
-        repository: item.repository,
-        location: item.location,
-        indexUrl: item.indexUrl,
-        extras: item.extras,
-        classifier: item.classifier,
-      }));
+      if (!outputDir) {
+        message.warning('출력 폴더를 선택하세요');
+        return;
+      }
 
-      const options = buildDownloadStartOptions({
-        outputDir,
-        outputFormat,
-        includeScripts: includeInstallScripts,
-        targetOS: defaultTargetOS,
-        architecture: defaultArchitecture,
-        includeDependencies,
-        pythonVersion: languageVersions.python,
-        concurrency: concurrentDownloads,
+      const emailDeliveryValidationError = getEmailDeliveryValidationError({
         deliveryMethod,
-        smtpTo: effectiveSmtpTo,
         smtpHost,
         smtpPort,
-        smtpUser,
-        smtpPassword,
+        smtpTo: effectiveSmtpTo,
         smtpFrom,
-        fileSplitEnabled: enableFileSplit,
-        maxFileSizeMB: maxFileSize,
+        smtpUser,
       });
 
-      await window.electronAPI.download.start({
-        sessionId: sessionSnapshot.id,
-        packages,
-        options,
-      });
-      clearProvisionalDownloadSession(sessionSnapshot.id);
-    } catch (error) {
-      restorePreviousSessionState();
-      addLog('error', '다운로드 시작 실패', String(error));
+      if (emailDeliveryValidationError) {
+        message.warning(emailDeliveryValidationError);
+        return;
+      }
+
+      if (includeDependencies && !depsResolved) {
+        message.warning('먼저 의존성 확인을 진행하세요');
+        return;
+      }
+
+      setIsDownloading(true);
+      setIsPaused(false);
+      setStartTime(Date.now());
+      const previousSessionState = {
+        sessionCounter: downloadSessionIdRef.current,
+        activeSession: activeDownloadSessionRef.current,
+        cartSnapshot: cartSnapshotRef.current,
+        historyTrackedItemIds: historyTrackedItemIdsRef.current,
+        historySettings: historySettingsSnapshotRef.current,
+        downloadCancelled: downloadCancelledRef.current,
+        downloadPaused: downloadPausedRef.current,
+        cancelledCompletionRetained: cancelledCompletionRetainedRef.current,
+        lastSpeedCalc: lastSpeedCalcRef.current,
+        speedHistory: [...speedHistoryRef.current],
+        startTime,
+        isDownloading,
+        isPaused,
+        packagingStatus,
+        packagingProgress,
+        completedOutputPath,
+        completedArtifactPaths: [...completedArtifactPaths],
+        completedDeliveryResult,
+        completedError,
+      };
+      const sessionSnapshot = createDownloadSessionSnapshot(
+        [...cartItems],
+        new Set(downloadItems.map((item) => item.id)),
+        buildHistorySettings({
+          outputFormat,
+          includeScripts: includeInstallScripts,
+          includeDependencies,
+          deliveryMethod,
+          smtpTo: effectiveSmtpTo,
+          fileSplitEnabled: enableFileSplit,
+          maxFileSizeMB: maxFileSize,
+        })
+      );
+      beginProvisionalDownloadSession(sessionSnapshot, previousSessionState.activeSession);
+      downloadCancelledRef.current = false;
+      downloadPausedRef.current = false;
+      cancelledCompletionRetainedRef.current = false;
+      lastSpeedCalcRef.current = { time: 0, bytes: 0 };
+      speedHistoryRef.current = [];
+
+      const restorePreviousSessionState = () => {
+        downloadSessionIdRef.current = previousSessionState.sessionCounter;
+        activeDownloadSessionRef.current = previousSessionState.activeSession;
+        cartSnapshotRef.current = previousSessionState.cartSnapshot;
+        historyTrackedItemIdsRef.current = previousSessionState.historyTrackedItemIds;
+        historySettingsSnapshotRef.current = previousSessionState.historySettings;
+        downloadCancelledRef.current = previousSessionState.downloadCancelled;
+        downloadPausedRef.current = previousSessionState.downloadPaused;
+        cancelledCompletionRetainedRef.current = previousSessionState.cancelledCompletionRetained;
+        lastSpeedCalcRef.current = previousSessionState.lastSpeedCalc;
+        speedHistoryRef.current = [...previousSessionState.speedHistory];
+        setStartTime(previousSessionState.startTime);
+        setIsDownloading(previousSessionState.isDownloading);
+        setIsPaused(previousSessionState.isPaused);
+        setPackagingStatus(previousSessionState.packagingStatus);
+        setPackagingProgress(previousSessionState.packagingProgress);
+        setCompletedOutputPath(previousSessionState.completedOutputPath);
+        setCompletedArtifactPaths([...previousSessionState.completedArtifactPaths]);
+        setCompletedDeliveryResult(previousSessionState.completedDeliveryResult);
+        setCompletedError(previousSessionState.completedError);
+
+        const queuedPreviousCompletion = takeQueuedPreviousCompletion(sessionSnapshot.id);
+        if (queuedPreviousCompletion) {
+          applyDownloadCompletion(queuedPreviousCompletion.data, queuedPreviousCompletion.sessionSnapshot, {
+            updatePackage: updateItem,
+            logMessage: addLog,
+          });
+        }
+      };
+
+      const canProceed = await checkOutputPath();
+      if (!canProceed) {
+        restorePreviousSessionState();
+        return;
+      }
+      setCompletedOutputPath('');
+      setCompletedArtifactPaths([]);
+      setCompletedDeliveryResult(undefined);
+      setCompletedError('');
+
+      addLog('info', '다운로드 시작', `총 ${downloadItems.length}개 패키지`);
+
+      if (!window.electronAPI?.download?.start) {
+        restorePreviousSessionState();
+        addLog('error', '다운로드 API를 사용할 수 없습니다');
+        return;
+      }
+
+      try {
+        const packages = downloadItems.map((item) => ({
+          id: item.id,
+          type: item.type,
+          name: item.name,
+          version: item.version,
+          architecture: item.arch,
+          downloadUrl: item.downloadUrl,
+          metadata: item.metadata,
+          repository: item.repository,
+          location: item.location,
+          indexUrl: item.indexUrl,
+          extras: item.extras,
+          classifier: item.classifier,
+        }));
+
+        const options = buildDownloadStartOptions({
+          outputDir,
+          outputFormat,
+          includeScripts: includeInstallScripts,
+          targetOS: defaultTargetOS,
+          architecture: defaultArchitecture,
+          includeDependencies,
+          pythonVersion: languageVersions.python,
+          concurrency: concurrentDownloads,
+          deliveryMethod,
+          smtpTo: effectiveSmtpTo,
+          smtpHost,
+          smtpPort,
+          smtpUser,
+          smtpPassword,
+          smtpFrom,
+          fileSplitEnabled: enableFileSplit,
+          maxFileSizeMB: maxFileSize,
+        });
+
+        await window.electronAPI.download.start({
+          sessionId: sessionSnapshot.id,
+          packages,
+          options,
+        });
+        clearProvisionalDownloadSession(sessionSnapshot.id);
+      } catch (error) {
+        restorePreviousSessionState();
+        addLog('error', '다운로드 시작 실패', String(error));
+      }
+    } finally {
+      if (isRestartingFromOutcome) {
+        outcomeRestartInFlightRef.current = false;
+      }
     }
   }, [
     addLog,

--- a/src/renderer/pages/settings/cache-stats-utils.ts
+++ b/src/renderer/pages/settings/cache-stats-utils.ts
@@ -7,6 +7,8 @@ export interface CacheDetailItemsInput {
   conda?: unknown;
 }
 
+export type CacheCategoryDetails = CacheDetailItemsInput;
+
 export interface CacheDetailItem {
   key: CacheDetailKey;
   label: string;

--- a/tests/e2e/fixtures/mock-electron-app.ts
+++ b/tests/e2e/fixtures/mock-electron-app.ts
@@ -1,6 +1,7 @@
-import type { Page } from '@playwright/test';
+import type { CacheCategoryDetails } from '../../../src/renderer/pages/settings/cache-stats-utils';
 import type { CartItem } from '../../../src/renderer/stores/cart-store';
 import type { DownloadHistory } from '../../../src/types';
+import type { Page } from '@playwright/test';
 
 interface MockDownloadScenario {
   mode?: 'success' | 'slow' | 'fail-once';
@@ -47,12 +48,7 @@ interface MockElectronAppOptions {
     excludes?: string[];
     totalSize?: number;
     entryCount?: number;
-    details?: {
-      pip?: unknown;
-      npm?: unknown;
-      maven?: unknown;
-      conda?: unknown;
-    };
+    details?: CacheCategoryDetails;
   };
 }
 


### PR DESCRIPTION
## 요약
- EmailSender public surface를 공용 mock helper로 고정했습니다.
- electron/download/cache/resolver/E2E fixture 테스트의 mock drift를 보강했습니다.
- Maven/NPM/Docker downloader error branch 테스트를 추가했습니다.

## 배경
- 계획문서 `~/.claude/plans/dreamy-strolling-rivest.md` 기준으로 테스트용 mock 표면이 실제 구현과 점점 어긋나고 있었습니다.
- 일부 테스트는 아카이브 경로를 하드코딩하거나, resolver/downloader public surface 변경을 즉시 감지하지 못했습니다.
- E2E fixture도 캐시 통계 detail shape를 수동으로 복제하고 있어 renderer 타입과 drift 가능성이 있었습니다.

## 변경 사항
- `src/core/mailer/__mocks__/email-sender-mock.ts` 추가 및 electron 테스트에서 공용 사용
- `electron/services/download-orchestrator.test.ts`에 outputDir 기반 archive path 검증 보강
- `electron/download-handlers.test.ts`의 core mock surface를 실제 getter 집합 기준으로 확장
- `src/core/cache-manager.test.ts` 실패 경로 보강
- `src/core/resolver/os-resolvers.test.ts`의 `any` 기반 protected 접근 제거
- `src/renderer/pages/settings/cache-stats-utils.ts`에서 cache detail 타입 export 추가
- `tests/e2e/fixtures/mock-electron-app.ts`가 renderer cache detail 타입을 공유하도록 정리
- Maven/NPM/Docker downloader의 timeout/401/manifest timeout error branch 테스트 추가

## 검증
- `npx vitest run electron/services/download-orchestrator.test.ts electron/download-handlers.test.ts src/core/resolver/os-resolvers.test.ts src/core/mailer/__mocks__/email-sender-mock.test.ts`
- `npx vitest run src/core/cache-manager.test.ts src/core/downloaders/maven-download.test.ts src/core/downloaders/npm-download.test.ts src/core/downloaders/docker-download.test.ts`
- `npm run test`
- `npm run test:coverage`
- `npm run build`
- `npm run lint` (0 errors, warnings only)
- `npm run test:e2e`
- `bash scripts/verify-worktree.sh`

## 문서
- 문서 변경 없음
- 내부 테스트/검증 보강 작업으로 사용자/운영 문서 영향이 없다고 판단했습니다.
