### PR TITLE
Phase 1 Characterization Test 보강

### DIFF
--- a/docs/electron-renderer.md
+++ b/docs/electron-renderer.md
@@ -137,6 +137,7 @@
 - `src/renderer/pages/settings/` 아래 `DeliverySettingsSection`, `CacheSettingsSection`, `UpdateSettingsSection`, `use-settings-form-actions.ts`가 `SettingsPage`의 세부 책임을 분리합니다.
 - SMTP 테스트 버튼은 `testSmtpConnection` IPC가 있으면 실제 연결 테스트를 실행하고, 브라우저 개발 환경에서는 시뮬레이션, IPC가 빠진 Electron 빌드에서는 경고와 비활성화 상태를 노출합니다.
 - 히스토리 store는 `window.electronAPI.history.*`를 통해 `~/.depssmuggler/history.json`과 직접 동기화되며, renderer localStorage persist를 source of truth로 사용하지 않습니다.
+- 다운로드 화면 오케스트레이션은 `use-download-page-controller.test.tsx`에서 jsdom + mocked `window.electronAPI` 조합으로 시작/일시정지/재개/취소/완료/오류 시나리오를 회귀 고정합니다.
 
 ## 사용자 흐름
 

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -99,6 +99,18 @@ PEP 508 환경 마커를 평가하여 플랫폼별 의존성 필터링:
 - implementation_name // 구현체 (예: 'cpython')
 ```
 
+### Characterization 회귀 고정
+
+`src/core/resolver/pip-resolver.characterization.test.ts`는 `resolveDependencies` 결과를 fixture별 JSON snapshot으로 고정합니다. 현재 유지하는 fixture는 다음 5종입니다.
+
+- `simple`: 기본 PyPI 의존성 트리
+- `extras`: extra marker가 켜진 의존성 포함 여부
+- `conflicts`: 버전 제약 충돌 시 fallback과 conflict 기록
+- `markers`: `sys_platform` / `platform_machine` 조건 필터링
+- `wheel-tags`: Simple API + wheel tag 선택 + `pythonVersion`/platform 매칭
+
+이 테스트는 BFS 트리 구조, flat list, conflict 목록을 함께 비교해 이후 구조 리팩터링에서 resolver 결과가 바뀌지 않았는지 확인하는 회귀 게이트 역할을 합니다.
+
 ### 사용 예시
 ```typescript
 import { getPipResolver } from './core/resolver/pip-resolver';

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,9 +37,11 @@ npm audit
 ### 1. 단위 테스트
 
 - 설정 파일: `vitest.config.ts`
-- 기본 include: `src/**/*.test.ts`, `tests/unit/**/*.test.ts`
+- 기본 include: `src/**/*.test.ts`, `src/**/*.test.tsx`, `tests/unit/**/*.test.ts`, `tests/unit/**/*.test.tsx`
 - 기본 exclude: `node_modules`, `dist`, `tests/e2e/**`
-- 실행 환경: `node`
+- 기본 실행 환경: `node`
+
+렌더러 훅처럼 DOM이 필요한 일부 테스트는 파일 상단 `// @vitest-environment jsdom` 주석으로 개별 override 합니다. 현재 `src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx`가 이 방식을 사용하며, Electron preload API/Ant Design modal/router hook을 mock한 상태에서 다운로드 시작·일시정지·재개·취소·완료·오류 플로우를 고정합니다.
 
 대상 예시:
 
@@ -48,6 +50,18 @@ npm audit
 - Electron `services/` 오케스트레이션과 package router/helper
 - 네트워크 호출을 모킹한 내부 동작
 - renderer form 계약 유틸리티 (`src/renderer/pages/settings/settings-form-utils.test.ts`)
+- renderer store / hook 오케스트레이션 (`cart-store`, `download-store`, `settings-store`, `use-download-page-controller`)
+
+Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스트는 다음과 같습니다.
+
+- `src/core/resolver/pip-resolver.characterization.test.ts`
+  - simple / extras / conflicts / markers / wheel-tags 5개 fixture를 JSON snapshot으로 고정
+- `electron/services/download-orchestrator.test.ts`
+  - 패키지 매니저별 happy path 매핑, 취소 경계, concurrency limiter, 진행률 이벤트 순서를 고정
+- `src/renderer/stores/cart-store.test.ts`
+- `src/renderer/stores/download-store.test.ts`
+- `src/renderer/stores/settings-store.test.ts`
+- `src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx`
 
 ### 2. 통합 테스트
 
@@ -139,6 +153,7 @@ UI 수동 검증과 E2E 전환 계획은 별도 문서로 관리합니다.
 - 새 기능을 추가할 때는 구현 파일 옆에 테스트를 두는 현재 관례를 따릅니다.
 - CLI/Electron 경계는 thin handler wiring 테스트와 service/helper 단위 테스트를 분리해 검증합니다.
 - Electron handler 테스트는 IPC 채널 등록과 service 위임만 확인하고, package type 분기/패키징/OS 전용 흐름은 `electron/services/*.test.ts`에서 검증합니다.
+- renderer 다운로드 흐름처럼 상태 전이가 많은 코드는 page 컴포넌트 전체보다 store/hook 단위 characterization test를 우선 추가합니다.
 
 ## 현재 문서화 포인트
 

--- a/electron/services/download-orchestrator.test.ts
+++ b/electron/services/download-orchestrator.test.ts
@@ -19,6 +19,183 @@ describe('createDownloadOrchestrator', () => {
     ),
   });
 
+  it('여러 패키지 매니저 결과를 모두 PackageInfo로 변환해 패키징한다', async () => {
+    const { createDownloadOrchestrator } = await import('./download-orchestrator');
+
+    const packages = [
+      { id: 'pip-1', type: 'pip', name: 'requests', version: '2.32.0' },
+      { id: 'conda-1', type: 'conda', name: 'numpy', version: '1.26.4', arch: 'linux-64' },
+      { id: 'maven-1', type: 'maven', name: 'org.junit:junit-bom', version: '5.10.2' },
+      { id: 'npm-1', type: 'npm', name: 'vite', version: '7.3.2' },
+      { id: 'yum-1', type: 'yum', name: 'bash', version: '5.2.26' },
+      { id: 'apt-1', type: 'apt', name: 'curl', version: '8.5.0' },
+      { id: 'apk-1', type: 'apk', name: 'busybox', version: '1.36.1-r20' },
+      { id: 'docker-1', type: 'docker', name: 'nginx', version: '1.27.0' },
+    ] as const;
+    const router = {
+      downloadPackage: vi.fn().mockImplementation(async (pkg: { id: string }) => ({
+        id: pkg.id,
+        success: true,
+      })),
+    };
+    const progressEmitter = {
+      emitDownloadStatus: vi.fn(),
+      emitAllComplete: vi.fn(),
+    };
+    const archivePackager = createArchivePackagerMock();
+
+    const orchestrator = createDownloadOrchestrator({
+      getMainWindow: () => null,
+      ensureDir: vi.fn().mockResolvedValue(undefined),
+      scheduleTask: async (task: () => Promise<void>) => {
+        await task();
+      },
+      createLimiter: () => ((task: () => Promise<unknown>) => task()),
+      createPackageRouter: () => router,
+      createProgressEmitter: () => progressEmitter as never,
+      archivePackager,
+      generateInstallScripts: vi.fn(),
+    });
+
+    await orchestrator.startDownload({
+      sessionId: 12,
+      packages: [...packages],
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'tar.gz',
+        includeScripts: false,
+        concurrency: 2,
+      },
+    });
+
+    expect(router.downloadPackage).toHaveBeenCalledTimes(packages.length);
+    expect(archivePackager.createArchiveFromDirectory).toHaveBeenCalledWith(
+      '/tmp/out',
+      '/tmp/out.tar.gz',
+      packages.map((pkg) =>
+        expect.objectContaining({
+          type: pkg.type,
+          name: pkg.name,
+          version: pkg.version,
+        })
+      ),
+      expect.objectContaining({
+        format: 'tar.gz',
+      })
+    );
+  });
+
+  it('설정된 concurrency로 limiter를 만들고 각 패키지를 limiter 경유로 내려받는다', async () => {
+    const { createDownloadOrchestrator } = await import('./download-orchestrator');
+
+    const limiterCalls: number[] = [];
+    const limit = vi.fn(async (task: () => Promise<unknown>) => task());
+    const createLimiter = vi.fn((concurrency: number) => {
+      limiterCalls.push(concurrency);
+      return limit;
+    });
+    const router = {
+      downloadPackage: vi.fn().mockImplementation(async (pkg: { id: string }) => ({
+        id: pkg.id,
+        success: true,
+      })),
+    };
+
+    const orchestrator = createDownloadOrchestrator({
+      getMainWindow: () => null,
+      ensureDir: vi.fn().mockResolvedValue(undefined),
+      scheduleTask: async (task: () => Promise<void>) => {
+        await task();
+      },
+      createLimiter,
+      createPackageRouter: () => router,
+      createProgressEmitter: () => ({
+        emitDownloadStatus: vi.fn(),
+        emitAllComplete: vi.fn(),
+      }) as never,
+      archivePackager: createArchivePackagerMock() as never,
+      generateInstallScripts: vi.fn(),
+    });
+
+    await orchestrator.startDownload({
+      sessionId: 13,
+      packages: [
+        { id: 'pip-1', type: 'pip', name: 'requests', version: '2.32.0' },
+        { id: 'npm-1', type: 'npm', name: 'vite', version: '7.3.2' },
+        { id: 'docker-1', type: 'docker', name: 'nginx', version: '1.27.0' },
+      ],
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'zip',
+        includeScripts: false,
+        concurrency: 4,
+      },
+    });
+
+    expect(limiterCalls).toEqual([4]);
+    expect(limit).toHaveBeenCalledTimes(3);
+    expect(router.downloadPackage).toHaveBeenCalledTimes(3);
+  });
+
+  it('다운로드 시작부터 패키징 완료까지 진행률 이벤트 순서를 유지한다', async () => {
+    const { createDownloadOrchestrator } = await import('./download-orchestrator');
+
+    const progressEmitter = {
+      emitDownloadStatus: vi.fn(),
+      emitAllComplete: vi.fn(),
+    };
+    const orchestrator = createDownloadOrchestrator({
+      getMainWindow: () => null,
+      ensureDir: vi.fn().mockResolvedValue(undefined),
+      scheduleTask: async (task: () => Promise<void>) => {
+        await task();
+      },
+      createLimiter: () => ((task: () => Promise<unknown>) => task()),
+      createPackageRouter: () => ({
+        downloadPackage: vi.fn().mockResolvedValue({
+          id: 'pip-requests-2.32.0',
+          success: true,
+        }),
+      }),
+      createProgressEmitter: () => progressEmitter as never,
+      archivePackager: createArchivePackagerMock() as never,
+      generateInstallScripts: vi.fn(),
+    });
+
+    await orchestrator.startDownload({
+      sessionId: 14,
+      packages: [
+        { id: 'pip-requests-2.32.0', type: 'pip', name: 'requests', version: '2.32.0' },
+      ],
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'zip',
+        includeScripts: false,
+        concurrency: 1,
+      },
+    });
+
+    expect(progressEmitter.emitDownloadStatus.mock.calls.map(([payload]) => payload)).toEqual([
+      expect.objectContaining({
+        sessionId: 14,
+        phase: 'downloading',
+        message: '다운로드 중...',
+      }),
+      expect.objectContaining({
+        sessionId: 14,
+        phase: 'packaging',
+        message: 'ZIP 패키징 중...',
+      }),
+    ]);
+    expect(progressEmitter.emitAllComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 14,
+        success: true,
+        outputPath: '/tmp/out.zip',
+      })
+    );
+  });
+
   it('성공한 패키지만 패키징 대상으로 모아 완료 이벤트를 만든다', async () => {
     const { createDownloadOrchestrator } = await import('./download-orchestrator');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
+        "@testing-library/react": "^16.3.2",
         "@types/cli-progress": "^3.11.6",
         "@types/fs-extra": "^11.0.4",
         "@types/js-yaml": "^4.0.9",
@@ -68,6 +69,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.0",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "jsdom": "^29.0.2",
         "nodemon": "^3.1.14",
         "playwright": "^1.57.0",
         "prettier": "^3.5.0",
@@ -170,6 +172,57 @@
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -510,6 +563,19 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -542,6 +608,146 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -1669,6 +1875,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3590,6 +3814,55 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -3626,6 +3899,14 @@
       "dependencies": {
         "@types/readdir-glob": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4770,6 +5051,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5115,6 +5407,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -6016,6 +6318,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -6148,6 +6464,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6224,6 +6554,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -6500,6 +6837,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "3.4.0",
@@ -6904,6 +7249,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -8528,6 +8886,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9025,6 +9396,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9365,6 +9743,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -9651,6 +10080,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9754,6 +10194,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -10661,6 +11108,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10939,6 +11399,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proc-log": {
       "version": "5.0.0",
@@ -11348,6 +11857,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -11726,6 +12245,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -12504,6 +13036,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -12774,6 +13313,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -12815,6 +13374,32 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -13080,6 +13665,16 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -13405,6 +14000,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -13422,6 +14030,41 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -13751,6 +14394,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -13760,6 +14413,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "homepage": "https://github.com/jonggeun2001/DepsSmuggler#readme",
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "@testing-library/react": "^16.3.2",
     "@types/cli-progress": "^3.11.6",
     "@types/fs-extra": "^11.0.4",
     "@types/js-yaml": "^4.0.9",
@@ -76,6 +77,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "jsdom": "^29.0.2",
     "nodemon": "^3.1.14",
     "playwright": "^1.57.0",
     "prettier": "^3.5.0",

--- a/src/core/resolver/__snapshots__/pip-resolver.characterization.test.ts.snap
+++ b/src/core/resolver/__snapshots__/pip-resolver.characterization.test.ts.snap
@@ -191,29 +191,19 @@ exports[`PipResolver characterization > simple fixture의 그래프를 고정한
 
 exports[`PipResolver characterization > wheel-tags fixture의 그래프를 고정한다 1`] = `
 {
-  "conflicts": [
-    {
-      "packageName": "typing_extensions",
-      "resolvedVersion": "4.12.2-py3-none-any",
-      "type": "version",
-      "versions": [
-        ">=4.12.2",
-        "4.12.2-py3-none-any",
-      ],
-    },
-  ],
+  "conflicts": [],
   "flatList": [
     {
       "filename": "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.whl",
       "indexUrl": "https://packages.example.com/simple",
       "name": "numpy",
-      "version": "1.26.4-cp311-cp311-manylinux_2_17_x86_64",
+      "version": "1.26.4",
     },
     {
       "filename": "typing_extensions-4.12.2-py3-none-any.whl",
       "indexUrl": "https://packages.example.com/simple",
       "name": "typing_extensions",
-      "version": "4.12.2-py3-none-any",
+      "version": "4.12.2",
     },
   ],
   "root": {
@@ -223,13 +213,13 @@ exports[`PipResolver characterization > wheel-tags fixture의 그래프를 고�
         "filename": "typing_extensions-4.12.2-py3-none-any.whl",
         "indexUrl": "https://packages.example.com/simple",
         "name": "typing_extensions",
-        "version": "4.12.2-py3-none-any",
+        "version": "4.12.2",
       },
     ],
     "filename": "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.whl",
     "indexUrl": "https://packages.example.com/simple",
     "name": "numpy",
-    "version": "1.26.4-cp311-cp311-manylinux_2_17_x86_64",
+    "version": "1.26.4",
   },
 }
 `;

--- a/src/core/resolver/__snapshots__/pip-resolver.characterization.test.ts.snap
+++ b/src/core/resolver/__snapshots__/pip-resolver.characterization.test.ts.snap
@@ -1,0 +1,235 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PipResolver characterization > conflicts fixture의 그래프를 고정한다 1`] = `
+{
+  "conflicts": [
+    {
+      "packageName": "urllib3",
+      "resolvedVersion": "2.2.1",
+      "type": "version",
+      "versions": [
+        "<1.0",
+        "2.2.1",
+      ],
+    },
+  ],
+  "flatList": [
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "rootpkg",
+      "version": "1.0.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "urllib3",
+      "version": "2.2.1",
+    },
+  ],
+  "root": {
+    "dependencies": [
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "urllib3",
+        "version": "2.2.1",
+      },
+    ],
+    "filename": null,
+    "indexUrl": null,
+    "name": "rootpkg",
+    "version": "1.0.0",
+  },
+}
+`;
+
+exports[`PipResolver characterization > extras fixture의 그래프를 고정한다 1`] = `
+{
+  "conflicts": [],
+  "flatList": [
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "anyio",
+      "version": "4.4.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "httpx_auth",
+      "version": "0.20.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "httpx",
+      "version": "0.27.0",
+    },
+  ],
+  "root": {
+    "dependencies": [
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "anyio",
+        "version": "4.4.0",
+      },
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "httpx_auth",
+        "version": "0.20.0",
+      },
+    ],
+    "filename": null,
+    "indexUrl": null,
+    "name": "httpx",
+    "version": "0.27.0",
+  },
+}
+`;
+
+exports[`PipResolver characterization > markers fixture의 그래프를 고정한다 1`] = `
+{
+  "conflicts": [],
+  "flatList": [
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "uvicorn",
+      "version": "0.30.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "uvloop",
+      "version": "0.19.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "watchfiles",
+      "version": "0.22.0",
+    },
+  ],
+  "root": {
+    "dependencies": [
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "uvloop",
+        "version": "0.19.0",
+      },
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "watchfiles",
+        "version": "0.22.0",
+      },
+    ],
+    "filename": null,
+    "indexUrl": null,
+    "name": "uvicorn",
+    "version": "0.30.0",
+  },
+}
+`;
+
+exports[`PipResolver characterization > simple fixture의 그래프를 고정한다 1`] = `
+{
+  "conflicts": [],
+  "flatList": [
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "certifi",
+      "version": "2024.2.2",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "requests",
+      "version": "2.32.0",
+    },
+    {
+      "filename": null,
+      "indexUrl": null,
+      "name": "urllib3",
+      "version": "2.1.0",
+    },
+  ],
+  "root": {
+    "dependencies": [
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "certifi",
+        "version": "2024.2.2",
+      },
+      {
+        "dependencies": [],
+        "filename": null,
+        "indexUrl": null,
+        "name": "urllib3",
+        "version": "2.1.0",
+      },
+    ],
+    "filename": null,
+    "indexUrl": null,
+    "name": "requests",
+    "version": "2.32.0",
+  },
+}
+`;
+
+exports[`PipResolver characterization > wheel-tags fixture의 그래프를 고정한다 1`] = `
+{
+  "conflicts": [
+    {
+      "packageName": "typing_extensions",
+      "resolvedVersion": "4.12.2-py3-none-any",
+      "type": "version",
+      "versions": [
+        ">=4.12.2",
+        "4.12.2-py3-none-any",
+      ],
+    },
+  ],
+  "flatList": [
+    {
+      "filename": "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.whl",
+      "indexUrl": "https://packages.example.com/simple",
+      "name": "numpy",
+      "version": "1.26.4-cp311-cp311-manylinux_2_17_x86_64",
+    },
+    {
+      "filename": "typing_extensions-4.12.2-py3-none-any.whl",
+      "indexUrl": "https://packages.example.com/simple",
+      "name": "typing_extensions",
+      "version": "4.12.2-py3-none-any",
+    },
+  ],
+  "root": {
+    "dependencies": [
+      {
+        "dependencies": [],
+        "filename": "typing_extensions-4.12.2-py3-none-any.whl",
+        "indexUrl": "https://packages.example.com/simple",
+        "name": "typing_extensions",
+        "version": "4.12.2-py3-none-any",
+      },
+    ],
+    "filename": "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.whl",
+    "indexUrl": "https://packages.example.com/simple",
+    "name": "numpy",
+    "version": "1.26.4-cp311-cp311-manylinux_2_17_x86_64",
+  },
+}
+`;

--- a/src/core/resolver/pip-resolver.characterization.test.ts
+++ b/src/core/resolver/pip-resolver.characterization.test.ts
@@ -33,20 +33,6 @@ const pipCacheMock = vi.hoisted(() => ({
 const simpleApiMock = vi.hoisted(() => ({
   fetchPackageFiles: vi.fn(),
   fetchWheelMetadata: vi.fn(),
-  extractVersionFromFilename: vi.fn((filename: string) => {
-    const match = filename.match(/-(\d+(?:\.\d+)+(?:[A-Za-z0-9._+-]*)?)(?=-|\.tar\.gz|\.whl)/);
-    if (!match) {
-      throw new Error(`version not found: ${filename}`);
-    }
-    return match[1];
-  }),
-  findLatestVersion: vi.fn((files: Array<{ filename: string }>) => {
-    const versions = files.map((file) => {
-      const match = file.filename.match(/-(\d+(?:\.\d+)+(?:[A-Za-z0-9._+-]*)?)(?=-|\.tar\.gz|\.whl)/);
-      return match?.[1] ?? '0.0.0';
-    });
-    return versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0] ?? null;
-  }),
 }));
 
 vi.mock('../shared/pip-cache', () => ({
@@ -54,12 +40,15 @@ vi.mock('../shared/pip-cache', () => ({
   clearMemoryCache: pipCacheMock.clearMemoryCache,
 }));
 
-vi.mock('./pip-simple-api', () => ({
-  fetchPackageFiles: simpleApiMock.fetchPackageFiles,
-  fetchWheelMetadata: simpleApiMock.fetchWheelMetadata,
-  extractVersionFromFilename: simpleApiMock.extractVersionFromFilename,
-  findLatestVersion: simpleApiMock.findLatestVersion,
-}));
+vi.mock('./pip-simple-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./pip-simple-api')>();
+
+  return {
+    ...actual,
+    fetchPackageFiles: simpleApiMock.fetchPackageFiles,
+    fetchWheelMetadata: simpleApiMock.fetchWheelMetadata,
+  };
+});
 
 import { PipResolver } from './pip-resolver';
 

--- a/src/core/resolver/pip-resolver.characterization.test.ts
+++ b/src/core/resolver/pip-resolver.characterization.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type PackageFixture = {
+  latest: string;
+  versions: Record<
+    string,
+    {
+      requiresDist?: string[];
+      urls?: Array<{
+        filename: string;
+        size?: number;
+        packagetype?: string;
+      }>;
+    }
+  >;
+};
+
+type SimpleApiFixture = Record<
+  string,
+  Array<{
+    filename: string;
+    url: string;
+    metadataHash?: string;
+    yanked?: boolean;
+  }>
+>;
+
+const pipCacheMock = vi.hoisted(() => ({
+  fetchPackageMetadata: vi.fn(),
+  clearMemoryCache: vi.fn(),
+}));
+
+const simpleApiMock = vi.hoisted(() => ({
+  fetchPackageFiles: vi.fn(),
+  fetchWheelMetadata: vi.fn(),
+  extractVersionFromFilename: vi.fn((filename: string) => {
+    const match = filename.match(/-(\d+(?:\.\d+)+(?:[A-Za-z0-9._+-]*)?)(?=-|\.tar\.gz|\.whl)/);
+    if (!match) {
+      throw new Error(`version not found: ${filename}`);
+    }
+    return match[1];
+  }),
+  findLatestVersion: vi.fn((files: Array<{ filename: string }>) => {
+    const versions = files.map((file) => {
+      const match = file.filename.match(/-(\d+(?:\.\d+)+(?:[A-Za-z0-9._+-]*)?)(?=-|\.tar\.gz|\.whl)/);
+      return match?.[1] ?? '0.0.0';
+    });
+    return versions.sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))[0] ?? null;
+  }),
+}));
+
+vi.mock('../shared/pip-cache', () => ({
+  fetchPackageMetadata: pipCacheMock.fetchPackageMetadata,
+  clearMemoryCache: pipCacheMock.clearMemoryCache,
+}));
+
+vi.mock('./pip-simple-api', () => ({
+  fetchPackageFiles: simpleApiMock.fetchPackageFiles,
+  fetchWheelMetadata: simpleApiMock.fetchWheelMetadata,
+  extractVersionFromFilename: simpleApiMock.extractVersionFromFilename,
+  findLatestVersion: simpleApiMock.findLatestVersion,
+}));
+
+import { PipResolver } from './pip-resolver';
+
+const createPyPIFixtureResponder = (packages: Record<string, PackageFixture>) =>
+  async (name: string, version?: string) => {
+    const fixture = packages[name];
+    if (!fixture) {
+      return null;
+    }
+
+    const resolvedVersion = version ?? fixture.latest;
+    const versionFixture = fixture.versions[resolvedVersion];
+
+    if (!versionFixture) {
+      return null;
+    }
+
+    if (version === undefined) {
+      return {
+        data: {
+          info: {
+            name,
+            version: fixture.latest,
+            requires_dist: fixture.versions[fixture.latest]?.requiresDist ?? [],
+          },
+          releases: Object.fromEntries(
+            Object.entries(fixture.versions).map(([currentVersion, currentFixture]) => [
+              currentVersion,
+              currentFixture.urls ?? [{ filename: `${name}-${currentVersion}.tar.gz` }],
+            ])
+          ),
+        },
+      };
+    }
+
+    return {
+      data: {
+        info: {
+          name,
+          version: resolvedVersion,
+          requires_dist: versionFixture.requiresDist ?? [],
+        },
+        urls: versionFixture.urls ?? [],
+      },
+    };
+  };
+
+const simplifyResult = (result: Awaited<ReturnType<PipResolver['resolveDependencies']>>) => {
+  const simplifyNode = (node: typeof result.root): Record<string, unknown> => ({
+    name: node.package.name,
+    version: node.package.version,
+    filename: node.package.metadata?.filename ?? null,
+    indexUrl: typeof node.package.metadata?.indexUrl === 'string'
+      ? node.package.metadata.indexUrl
+      : null,
+    dependencies: [...node.dependencies]
+      .sort((left, right) =>
+        `${left.package.name}@${left.package.version}`.localeCompare(
+          `${right.package.name}@${right.package.version}`
+        )
+      )
+      .map(simplifyNode),
+  });
+
+  return {
+    root: simplifyNode(result.root),
+    flatList: [...result.flatList]
+      .map((pkg) => ({
+        name: pkg.name,
+        version: pkg.version,
+        filename: pkg.metadata?.filename ?? null,
+        indexUrl: typeof pkg.metadata?.indexUrl === 'string' ? pkg.metadata.indexUrl : null,
+      }))
+      .sort((left, right) => `${left.name}@${left.version}`.localeCompare(`${right.name}@${right.version}`)),
+    conflicts: result.conflicts,
+  };
+};
+
+describe('PipResolver characterization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('simple fixture의 그래프를 고정한다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockImplementation(
+      createPyPIFixtureResponder({
+        requests: {
+          latest: '2.32.0',
+          versions: {
+            '2.32.0': {
+              requiresDist: ['urllib3>=2.1.0', 'certifi>=2024.2.2'],
+            },
+          },
+        },
+        urllib3: {
+          latest: '2.1.0',
+          versions: {
+            '2.1.0': {},
+          },
+        },
+        certifi: {
+          latest: '2024.2.2',
+          versions: {
+            '2024.2.2': {},
+          },
+        },
+      })
+    );
+
+    const resolver = new PipResolver();
+    const result = await resolver.resolveDependencies('requests', '2.32.0');
+
+    expect(simplifyResult(result)).toMatchSnapshot();
+  });
+
+  it('extras fixture의 그래프를 고정한다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockImplementation(
+      createPyPIFixtureResponder({
+        httpx: {
+          latest: '0.27.0',
+          versions: {
+            '0.27.0': {
+              requiresDist: [
+                'anyio>=4.0.0',
+                'httpx-auth>=0.20.0 ; extra == "auth"',
+                'rich>=13.0.0 ; extra == "cli"',
+              ],
+            },
+          },
+        },
+        anyio: {
+          latest: '4.4.0',
+          versions: {
+            '4.4.0': {},
+          },
+        },
+        httpx_auth: {
+          latest: '0.20.0',
+          versions: {
+            '0.20.0': {},
+          },
+        },
+      })
+    );
+
+    const resolver = new PipResolver();
+    resolver.setPipTargetPlatform({
+      os: 'linux',
+      arch: 'x86_64',
+      pythonVersion: '3.11',
+    });
+
+    const result = await resolver.resolveDependencies('httpx', '0.27.0', {
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+      pythonVersion: '3.11',
+      extras: ['auth'],
+    });
+
+    expect(simplifyResult(result)).toMatchSnapshot();
+  });
+
+  it('conflicts fixture의 그래프를 고정한다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockImplementation(
+      createPyPIFixtureResponder({
+        rootpkg: {
+          latest: '1.0.0',
+          versions: {
+            '1.0.0': {
+              requiresDist: ['urllib3<1.0'],
+            },
+          },
+        },
+        urllib3: {
+          latest: '2.2.1',
+          versions: {
+            '2.1.0': {},
+            '2.2.1': {},
+          },
+        },
+      })
+    );
+
+    const resolver = new PipResolver();
+    const result = await resolver.resolveDependencies('rootpkg', '1.0.0');
+
+    expect(simplifyResult(result)).toMatchSnapshot();
+  });
+
+  it('markers fixture의 그래프를 고정한다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockImplementation(
+      createPyPIFixtureResponder({
+        uvicorn: {
+          latest: '0.30.0',
+          versions: {
+            '0.30.0': {
+              requiresDist: [
+                'uvloop>=0.19.0 ; sys_platform == "linux"',
+                'colorama>=0.4.6 ; sys_platform == "win32"',
+                'watchfiles>=0.22.0 ; platform_machine == "x86_64"',
+              ],
+            },
+          },
+        },
+        uvloop: {
+          latest: '0.19.0',
+          versions: {
+            '0.19.0': {},
+          },
+        },
+        watchfiles: {
+          latest: '0.22.0',
+          versions: {
+            '0.22.0': {},
+          },
+        },
+      })
+    );
+
+    const resolver = new PipResolver();
+    const result = await resolver.resolveDependencies('uvicorn', '0.30.0', {
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+      pythonVersion: '3.11',
+    });
+
+    expect(simplifyResult(result)).toMatchSnapshot();
+  });
+
+  it('wheel-tags fixture의 그래프를 고정한다', async () => {
+    const filesByPackage: SimpleApiFixture = {
+      numpy: [
+        {
+          filename: 'numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.whl',
+          url: 'https://packages.example.com/numpy-1.26.4-cp310.whl',
+          metadataHash: 'sha256:cp310',
+        },
+        {
+          filename: 'numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.whl',
+          url: 'https://packages.example.com/numpy-1.26.4-cp311.whl',
+          metadataHash: 'sha256:cp311',
+        },
+        {
+          filename: 'numpy-1.26.4.tar.gz',
+          url: 'https://packages.example.com/numpy-1.26.4.tar.gz',
+        },
+      ],
+      typing_extensions: [
+        {
+          filename: 'typing_extensions-4.12.2-py3-none-any.whl',
+          url: 'https://packages.example.com/typing_extensions-4.12.2.whl',
+          metadataHash: 'sha256:typing',
+        },
+      ],
+    };
+
+    simpleApiMock.fetchPackageFiles.mockImplementation(async (_indexUrl: string, name: string) => {
+      return filesByPackage[name] ?? [];
+    });
+    simpleApiMock.fetchWheelMetadata.mockImplementation(async (file: { filename: string }) => {
+      if (file.filename.includes('numpy-1.26.4-cp311')) {
+        return ['typing-extensions>=4.12.2'];
+      }
+      return [];
+    });
+    pipCacheMock.fetchPackageMetadata.mockImplementation(async () => null);
+
+    const resolver = new PipResolver();
+    const result = await resolver.resolveDependencies('numpy', 'latest', {
+      indexUrl: 'https://packages.example.com/simple',
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+      pythonVersion: '3.11',
+    });
+
+    expect(simplifyResult(result)).toMatchSnapshot();
+  });
+});

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
@@ -1,0 +1,417 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const routerMock = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  location: { state: null as unknown },
+}));
+
+const antdMock = vi.hoisted(() => ({
+  message: {
+    warning: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+  confirm: vi.fn(({ onOk }: { onOk?: () => void | Promise<void> }) => onOk?.()),
+}));
+
+const osFlowMock = vi.hoisted(() => ({
+  value: {
+    isDedicatedOSFlow: false,
+    osDownloading: false,
+    osResult: null,
+    requiresOSCartReselection: false,
+    resetOSFlow: vi.fn(),
+  },
+}));
+
+vi.mock('@ant-design/icons', () => ({
+  ExclamationCircleOutlined: () => null,
+}));
+
+vi.mock('antd', () => ({
+  message: antdMock.message,
+  Modal: {
+    confirm: antdMock.confirm,
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => routerMock.navigate,
+  useLocation: () => routerMock.location,
+}));
+
+vi.mock('./use-os-download-flow', () => ({
+  useOSDownloadFlow: () => osFlowMock.value,
+}));
+
+type DownloadListenerMap = {
+  progress?: (payload: Record<string, unknown>) => void;
+  status?: (payload: Record<string, unknown>) => void;
+  depsResolved?: (payload: Record<string, unknown>) => void;
+  allComplete?: (payload: Record<string, unknown>) => void;
+};
+
+const createStorageMock = () => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createElectronApi = () => {
+  const listeners: DownloadListenerMap = {};
+
+  const electronAPI = {
+    config: {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockResolvedValue(undefined),
+    },
+    history: {
+      load: vi.fn().mockResolvedValue([]),
+      add: vi.fn().mockResolvedValue({ success: true }),
+      delete: vi.fn().mockResolvedValue({ success: true }),
+      clear: vi.fn().mockResolvedValue({ success: true }),
+    },
+    download: {
+      checkPath: vi.fn().mockResolvedValue({
+        exists: false,
+        fileCount: 0,
+        totalSize: 0,
+      }),
+      clearPath: vi.fn().mockResolvedValue({ success: true }),
+      start: vi.fn().mockResolvedValue(undefined),
+      pause: vi.fn().mockResolvedValue(undefined),
+      resume: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      onProgress: vi.fn((callback: DownloadListenerMap['progress']) => {
+        listeners.progress = callback;
+        return () => {
+          delete listeners.progress;
+        };
+      }),
+      onStatus: vi.fn((callback: DownloadListenerMap['status']) => {
+        listeners.status = callback;
+        return () => {
+          delete listeners.status;
+        };
+      }),
+      onDepsResolved: vi.fn((callback: DownloadListenerMap['depsResolved']) => {
+        listeners.depsResolved = callback;
+        return () => {
+          delete listeners.depsResolved;
+        };
+      }),
+      onAllComplete: vi.fn((callback: DownloadListenerMap['allComplete']) => {
+        listeners.allComplete = callback;
+        return () => {
+          delete listeners.allComplete;
+        };
+      }),
+    },
+    openFolder: vi.fn().mockResolvedValue(undefined),
+    selectFolder: vi.fn().mockResolvedValue('/tmp/selected'),
+  };
+
+  return { electronAPI, listeners };
+};
+
+const loadController = async (options?: {
+  cartItems?: Array<Record<string, unknown>>;
+  includeDependencies?: boolean;
+  downloadState?: Record<string, unknown>;
+  defaultDownloadPath?: string;
+}) => {
+  vi.resetModules();
+  const localStorage = createStorageMock();
+  const { electronAPI, listeners } = createElectronApi();
+  (window as typeof window & { electronAPI?: typeof electronAPI }).electronAPI = electronAPI;
+  vi.stubGlobal('localStorage', localStorage);
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: localStorage,
+  });
+
+  const [{ useCartStore }, { useDownloadStore }, { useSettingsStore }, { useHistoryStore }, hookModule] =
+    await Promise.all([
+      import('../../../stores/cart-store'),
+      import('../../../stores/download-store'),
+      import('../../../stores/settings-store'),
+      import('../../../stores/history-store'),
+      import('./use-download-page-controller'),
+    ]);
+
+  useCartStore.setState({
+    items: (options?.cartItems ?? [
+      {
+        id: 'pip-requests-2.32.0',
+        type: 'pip',
+        name: 'requests',
+        version: '2.32.0',
+        addedAt: Date.now(),
+      },
+    ]) as never,
+  });
+  useDownloadStore.getState().reset();
+  if (options?.downloadState) {
+    useDownloadStore.setState(options.downloadState as never);
+  }
+  useHistoryStore.setState({
+    histories: [],
+    initialized: true,
+    loading: false,
+  });
+  useSettingsStore.setState({
+    ...useSettingsStore.getState(),
+    _initialized: true,
+    includeDependencies: options?.includeDependencies ?? false,
+    defaultDownloadPath: options?.defaultDownloadPath ?? '/tmp/out',
+    downloadRenderInterval: 0,
+    smtpHost: 'smtp.example.com',
+    smtpPort: 587,
+    smtpUser: 'sender@example.com',
+    smtpFrom: 'sender@example.com',
+    smtpTo: 'offline@example.com',
+  });
+
+  const rendered = renderHook(() => hookModule.useDownloadPageController());
+
+  await waitFor(() => {
+    expect(rendered.result.current.downloadItems.length).toBeGreaterThan(0);
+  });
+
+  return {
+    electronAPI,
+    listeners,
+    localStorage,
+    rendered,
+    stores: {
+      useCartStore,
+      useDownloadStore,
+      useSettingsStore,
+      useHistoryStore,
+    },
+  };
+};
+
+describe('useDownloadPageController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routerMock.navigate.mockReset();
+    routerMock.location = { state: null };
+    osFlowMock.value.resetOSFlow.mockReset();
+  });
+
+  afterEach(() => {
+    delete (window as typeof window & { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('start 시 다운로드 API에 현재 장바구니와 옵션을 전달한다', async () => {
+    const { electronAPI, rendered } = await loadController();
+
+    await act(async () => {
+      await rendered.result.current.handleStartDownload();
+    });
+
+    expect(electronAPI.download.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 1,
+        packages: [
+          expect.objectContaining({
+            id: 'pip-requests-2.32.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.32.0',
+          }),
+        ],
+        options: expect.objectContaining({
+          outputDir: '/tmp/out',
+          outputFormat: 'zip',
+          includeDependencies: false,
+          concurrency: 3,
+        }),
+      })
+    );
+    expect(rendered.result.current.isDownloading).toBe(true);
+  });
+
+  it('pause 시 상태와 IPC 호출을 일시정지로 바꾼다', async () => {
+    const { electronAPI, rendered, stores } = await loadController({
+      downloadState: {
+        isDownloading: true,
+      },
+    });
+
+    await act(async () => {
+      await rendered.result.current.handlePauseResume();
+    });
+
+    expect(electronAPI.download.pause).toHaveBeenCalledTimes(1);
+    expect(stores.useDownloadStore.getState().isPaused).toBe(true);
+    expect(stores.useDownloadStore.getState().logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'info',
+          message: '다운로드 일시정지',
+        }),
+      ])
+    );
+  });
+
+  it('resume 시 상태와 IPC 호출을 재개로 바꾼다', async () => {
+    const { electronAPI, rendered, stores } = await loadController({
+      downloadState: {
+        isDownloading: true,
+        isPaused: true,
+      },
+    });
+
+    await act(async () => {
+      await rendered.result.current.handlePauseResume();
+    });
+
+    expect(electronAPI.download.resume).toHaveBeenCalledTimes(1);
+    expect(stores.useDownloadStore.getState().isPaused).toBe(false);
+    expect(stores.useDownloadStore.getState().logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'info',
+          message: '다운로드 재개',
+        }),
+      ])
+    );
+  });
+
+  it('cancel 시 진행 중 항목을 cancelled로 바꾸고 취소 IPC를 호출한다', async () => {
+    const { electronAPI, rendered, stores } = await loadController();
+
+    act(() => {
+      stores.useDownloadStore.setState({
+        isDownloading: true,
+        items: [
+          {
+            id: 'pip-requests-2.32.0',
+            name: 'requests',
+            version: '2.32.0',
+            type: 'pip',
+            status: 'downloading',
+            progress: 25,
+            downloadedBytes: 256,
+            totalBytes: 1024,
+            speed: 32,
+          },
+          {
+            id: 'pip-urllib3-2.1.0',
+            name: 'urllib3',
+            version: '2.1.0',
+            type: 'pip',
+            status: 'pending',
+            progress: 0,
+            downloadedBytes: 0,
+            totalBytes: 0,
+            speed: 0,
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(rendered.result.current.downloadItems).toHaveLength(2);
+    });
+
+    await act(async () => {
+      rendered.result.current.handleCancelDownload();
+      await flushMicrotasks();
+    });
+
+    await waitFor(() => {
+      expect(electronAPI.download.cancel).toHaveBeenCalledTimes(1);
+    });
+
+    expect(stores.useDownloadStore.getState().isDownloading).toBe(false);
+    expect(stores.useDownloadStore.getState().logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'info',
+          message: '다운로드 취소 요청 전송됨',
+        }),
+        expect.objectContaining({
+          level: 'warn',
+          message: '다운로드 취소됨',
+        }),
+      ])
+    );
+    expect(antdMock.message.warning).toHaveBeenCalledWith('다운로드가 취소되었습니다');
+  });
+
+  it('complete 이벤트를 받으면 완료 상태와 산출물 경로를 고정한다', async () => {
+    const { electronAPI, listeners, rendered, stores } = await loadController();
+
+    await act(async () => {
+      await rendered.result.current.handleStartDownload();
+    });
+
+    await act(async () => {
+      listeners.allComplete?.({
+        sessionId: 1,
+        success: true,
+        outputPath: '/tmp/out.zip',
+        artifactPaths: ['/tmp/out.zip'],
+        deliveryMethod: 'local',
+        results: [{ id: 'pip-requests-2.32.0', success: true }],
+      });
+      await flushMicrotasks();
+    });
+
+    await waitFor(() => {
+      expect(rendered.result.current.packagingStatus).toBe('completed');
+    });
+
+    expect(rendered.result.current.completedOutputPath).toBe('/tmp/out.zip');
+    expect(stores.useDownloadStore.getState().isDownloading).toBe(false);
+    expect(electronAPI.history.add).toHaveBeenCalledTimes(1);
+    expect(antdMock.message.success).toHaveBeenCalledWith('다운로드 및 패키징이 완료되었습니다');
+  });
+
+  it('start 실패 시 이전 세션 상태로 복구하고 오류 로그를 남긴다', async () => {
+    const { electronAPI, rendered, stores } = await loadController();
+    electronAPI.download.start.mockRejectedValueOnce(new Error('IPC unavailable'));
+
+    await act(async () => {
+      await rendered.result.current.handleStartDownload();
+    });
+
+    await waitFor(() => {
+      expect(stores.useDownloadStore.getState().isDownloading).toBe(false);
+    });
+
+    expect(stores.useDownloadStore.getState().logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'error',
+          message: '다운로드 시작 실패',
+          details: 'Error: IPC unavailable',
+        }),
+      ])
+    );
+  });
+});

--- a/src/renderer/stores/cart-store.test.ts
+++ b/src/renderer/stores/cart-store.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type StorageMock = {
+  getItem: ReturnType<typeof vi.fn>;
+  setItem: ReturnType<typeof vi.fn>;
+  removeItem: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+};
+
+const createStorageMock = (): StorageMock => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+};
+
+const loadCartStore = async () => {
+  vi.resetModules();
+  const localStorage = createStorageMock();
+  vi.stubGlobal('localStorage', localStorage);
+
+  const module = await import('./cart-store');
+  module.useCartStore.setState({ items: [] });
+  await module.useCartStore.persist.clearStorage();
+
+  return {
+    localStorage,
+    useCartStore: module.useCartStore,
+  };
+};
+
+describe('cart-store', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('addItem은 같은 type/name/version 조합의 중복 추가를 막는다', async () => {
+    const { useCartStore } = await loadCartStore();
+
+    useCartStore.getState().addItem({
+      type: 'pip',
+      name: 'requests',
+      version: '2.32.0',
+    });
+    useCartStore.getState().addItem({
+      type: 'pip',
+      name: 'requests',
+      version: '2.32.0',
+    });
+
+    expect(useCartStore.getState().items).toHaveLength(1);
+    expect(useCartStore.getState().items[0]).toEqual(
+      expect.objectContaining({
+        type: 'pip',
+        name: 'requests',
+        version: '2.32.0',
+      })
+    );
+  });
+
+  it('removeItem은 지정한 항목만 제거한다', async () => {
+    const { useCartStore } = await loadCartStore();
+
+    useCartStore.getState().addItem({
+      type: 'pip',
+      name: 'requests',
+      version: '2.32.0',
+    });
+    useCartStore.getState().addItem({
+      type: 'npm',
+      name: 'vite',
+      version: '7.3.2',
+    });
+
+    const [firstItem, secondItem] = useCartStore.getState().items;
+    useCartStore.getState().removeItem(firstItem.id);
+
+    expect(useCartStore.getState().items).toEqual([secondItem]);
+  });
+
+  it('clearCart는 전체 항목을 비운다', async () => {
+    const { useCartStore } = await loadCartStore();
+
+    useCartStore.getState().addItem({
+      type: 'pip',
+      name: 'requests',
+      version: '2.32.0',
+    });
+    useCartStore.getState().addItem({
+      type: 'apt',
+      name: 'curl',
+      version: '8.5.0',
+    });
+
+    useCartStore.getState().clearCart();
+
+    expect(useCartStore.getState().items).toEqual([]);
+  });
+});

--- a/src/renderer/stores/download-store.test.ts
+++ b/src/renderer/stores/download-store.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  useDownloadStore,
+  type DownloadItem,
+} from './download-store';
+
+const createItem = (overrides?: Partial<DownloadItem>): DownloadItem => ({
+  id: 'pkg-1',
+  name: 'requests',
+  version: '2.32.0',
+  type: 'pip',
+  status: 'pending',
+  progress: 0,
+  downloadedBytes: 0,
+  totalBytes: 0,
+  speed: 0,
+  ...overrides,
+});
+
+describe('download-store', () => {
+  beforeEach(() => {
+    useDownloadStore.getState().reset();
+  });
+
+  it('updateItemsBatch는 대상 아이템만 한 번에 갱신한다', () => {
+    useDownloadStore.getState().setItems([
+      createItem(),
+      createItem({
+        id: 'pkg-2',
+        name: 'urllib3',
+      }),
+    ]);
+
+    useDownloadStore.getState().updateItemsBatch(
+      new Map([
+        ['pkg-1', { status: 'downloading', progress: 50, downloadedBytes: 512 }],
+        ['pkg-2', { status: 'failed', error: 'network failed' }],
+      ])
+    );
+
+    expect(useDownloadStore.getState().items).toEqual([
+      expect.objectContaining({
+        id: 'pkg-1',
+        status: 'downloading',
+        progress: 50,
+        downloadedBytes: 512,
+      }),
+      expect.objectContaining({
+        id: 'pkg-2',
+        status: 'failed',
+        error: 'network failed',
+      }),
+    ]);
+  });
+
+  it('addLogsBatch는 로그를 순서대로 추가한다', () => {
+    useDownloadStore.getState().addLogsBatch([
+      { level: 'info', message: '다운로드 시작' },
+      { level: 'warn', message: '재시도 예정', details: 'timeout' },
+    ]);
+
+    expect(useDownloadStore.getState().logs).toEqual([
+      expect.objectContaining({
+        level: 'info',
+        message: '다운로드 시작',
+      }),
+      expect.objectContaining({
+        level: 'warn',
+        message: '재시도 예정',
+        details: 'timeout',
+      }),
+    ]);
+  });
+
+  it('retryItem은 실패 항목을 pending으로 되돌리고 진행 상태를 초기화한다', () => {
+    useDownloadStore.getState().setItems([
+      createItem({
+        status: 'failed',
+        progress: 90,
+        downloadedBytes: 900,
+        totalBytes: 1000,
+        error: 'checksum mismatch',
+      }),
+    ]);
+
+    useDownloadStore.getState().retryItem('pkg-1');
+
+    expect(useDownloadStore.getState().items[0]).toEqual(
+      expect.objectContaining({
+        id: 'pkg-1',
+        status: 'pending',
+        progress: 0,
+        error: undefined,
+      })
+    );
+  });
+
+  it('reset은 다운로드 세션 상태를 기본값으로 되돌린다', () => {
+    useDownloadStore.setState({
+      items: [createItem({ status: 'completed', progress: 100 })],
+      isDownloading: true,
+      isPaused: true,
+      outputPath: '/tmp/out.zip',
+      packagingStatus: 'completed',
+      packagingProgress: 100,
+      logs: [{ id: 'log-1', timestamp: 1, level: 'success', message: 'done' }],
+      startTime: 123,
+      currentItemIndex: 1,
+      depsResolved: true,
+    });
+
+    useDownloadStore.getState().reset();
+
+    expect(useDownloadStore.getState()).toMatchObject({
+      items: [],
+      isDownloading: false,
+      isPaused: false,
+      outputPath: '/tmp/out.zip',
+      packagingStatus: 'idle',
+      packagingProgress: 0,
+      logs: [],
+      startTime: null,
+      currentItemIndex: 0,
+      depsResolved: false,
+    });
+  });
+});

--- a/src/renderer/stores/settings-store.test.ts
+++ b/src/renderer/stores/settings-store.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type StorageMock = {
+  getItem: ReturnType<typeof vi.fn>;
+  setItem: ReturnType<typeof vi.fn>;
+  removeItem: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+};
+
+const createStorageMock = (): StorageMock => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+};
+
+const loadSettingsStore = async (fileConfig?: Record<string, unknown>) => {
+  vi.resetModules();
+  const localStorage = createStorageMock();
+  const electronAPI = {
+    config: {
+      get: vi.fn().mockResolvedValue(fileConfig ?? null),
+      set: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+
+  vi.stubGlobal('localStorage', localStorage);
+  vi.stubGlobal('window', { electronAPI, localStorage });
+
+  const module = await import('./settings-store');
+
+  return {
+    electronAPI,
+    localStorage,
+    useSettingsStore: module.useSettingsStore,
+  };
+};
+
+describe('settings-store', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('initializeFromFile은 레거시 output 설정을 현재 형식으로 마이그레이션한다', async () => {
+    const { useSettingsStore } = await loadSettingsStore({
+      defaultOutputFormat: 'withScript',
+      defaultArchiveType: 'tar.gz',
+      includeInstallScripts: undefined,
+      concurrentDownloads: 5,
+    });
+
+    await useSettingsStore.getState().initializeFromFile();
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      _initialized: true,
+      concurrentDownloads: 5,
+      defaultOutputFormat: 'tar.gz',
+      includeInstallScripts: true,
+    });
+  });
+
+  it('custom 채널과 pip index URL mutation은 중복 없이 관리된다', async () => {
+    const { useSettingsStore } = await loadSettingsStore();
+
+    useSettingsStore.getState().addCustomCondaChannel('pytorch');
+    useSettingsStore.getState().addCustomCondaChannel('pytorch');
+    useSettingsStore.getState().addCustomPipIndexUrl('Test', 'https://example.com/simple');
+    useSettingsStore.getState().addCustomPipIndexUrl('Duplicate', 'https://example.com/simple');
+    useSettingsStore.getState().removeCustomCondaChannel('pytorch');
+    useSettingsStore.getState().removeCustomPipIndexUrl('https://example.com/simple');
+
+    expect(useSettingsStore.getState().customCondaChannels).toEqual([]);
+    expect(
+      useSettingsStore.getState().customPipIndexUrls.some(
+        (item) => item.url === 'https://example.com/simple'
+      )
+    ).toBe(false);
+  });
+
+  it('resetSettings는 기본값으로 되돌리고 Electron 설정도 초기화한다', async () => {
+    const { electronAPI, useSettingsStore } = await loadSettingsStore();
+
+    useSettingsStore.getState().updateSettings({
+      concurrentDownloads: 9,
+      smtpHost: 'smtp.example.com',
+      dockerCustomRegistry: 'registry.example.com',
+    });
+
+    useSettingsStore.getState().resetSettings();
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      _initialized: true,
+      concurrentDownloads: 3,
+      smtpHost: '',
+      dockerCustomRegistry: '',
+    });
+    expect(electronAPI.config.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts', 'electron/**/*.test.ts', 'tests/unit/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+      'electron/**/*.test.ts',
+      'tests/unit/**/*.test.ts',
+      'tests/unit/**/*.test.tsx',
+    ],
     exclude: ['node_modules', 'dist', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## 요약
- Phase 1 범위에서 pip resolver, download orchestrator, renderer download controller/store의 characterization test를 추가했습니다.
- `vitest.config.ts`에 `*.test.tsx`를 포함해 jsdom 기반 renderer hook 테스트를 실행 가능하게 했습니다.
- 관련 테스트 전략 문서를 업데이트해 이번 회귀 게이트 범위를 명시했습니다.

## 배경
- `agent-federated-bachman` 계획의 구조 분해 이전에 핵심 동작을 테스트로 동결할 필요가 있습니다.
- 사용자 요청에 따라 이번 PR은 Phase 0 가드레일 작업을 제외하고, Phase 1 characterization test 보강만 진행했습니다.

## 변경 사항
- `src/core/resolver/pip-resolver.characterization.test.ts`
  - simple / extras / conflicts / markers / wheel-tags 5개 fixture를 JSON snapshot으로 고정
- `electron/services/download-orchestrator.test.ts`
  - 다중 package manager happy path 매핑, concurrency limiter, progress 이벤트 순서 보강
- `src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx`
  - 시작 / 일시정지 / 재개 / 취소 / 완료 / 오류 시나리오를 jsdom + mocked IPC로 고정
- `src/renderer/stores/{cart,download,settings}-store.test.ts`
  - store mutation 단위 회귀 테스트 추가
- `package.json`, `package-lock.json`
  - `@testing-library/react`, `jsdom` dev dependency 추가
- `docs/testing.md`, `docs/electron-renderer.md`, `docs/resolvers.md`
  - Phase 1 테스트 범위와 검증 방법 문서화

## 검증
- `bash scripts/verify-worktree.sh` 통과
- `npm run lint` 통과 (기존 저장소 경고 635건 유지, 신규 error 없음)
- `npx tsc --noEmit` 통과

## 문서
- `docs/testing.md`
- `docs/electron-renderer.md`
- `docs/resolvers.md`
