### PR TITLE
Phase 3: 공통 checksum 유틸리티로 검증 로직 통합

### DIFF
--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -3,6 +3,7 @@
 ## 개요
 - 목적: 각 패키지 관리자별 패키지 검색 및 다운로드 구현
 - 위치: `src/core/downloaders/`
+- 공통 체크섬 검증은 `src/core/shared/integrity/checksum.ts`를 통해 공유한다. `pip`, `conda`, `maven`, Docker blob 다운로드, 캐시 검증, OS GPG verifier가 이 유틸리티를 재사용한다.
 
 ---
 
@@ -21,7 +22,7 @@
 | `getPackageMetadata` | name: string, version?: string | Promise<PackageMetadata> | 패키지 상세 메타데이터 조회 |
 | `downloadPackage` | name: string, version: string, destDir: string, options? | Promise<DownloadResult> | 패키지 파일 다운로드 |
 | `getReleasesForArch` | releases: PyPIRelease[], arch?: string | PyPIRelease[] | 특정 아키텍처용 릴리즈 필터링 |
-| `verifyChecksum` | filePath: string, expectedHash: string | Promise<boolean> | SHA256 체크섬 검증 |
+| `verifyChecksum` | filePath: string, expectedHash: string | Promise<boolean> | shared checksum 유틸리티를 통한 SHA256 체크섬 검증 |
 
 ### 내부 메서드
 
@@ -81,7 +82,7 @@ const result = await downloader.downloadPackage('numpy', '1.26.0', '/tmp/downloa
 | `getPackageMetadata` | name: string, version?: string | Promise<PackageMetadata> | 패키지 메타데이터 조회 |
 | `downloadPackage` | name: string, version: string, destDir: string, options? | Promise<DownloadResult> | 패키지 다운로드 |
 | `getPackageFiles` | name: string, version: string, channel?: string | Promise<CondaPackageFile[]> | 패키지 파일 목록 조회 |
-| `verifyChecksum` | filePath: string, expectedHash: string | Promise<boolean> | SHA256/MD5 체크섬 검증 |
+| `verifyChecksum` | filePath: string, expectedHash: string | Promise<boolean> | shared checksum 유틸리티를 통한 SHA256/MD5 체크섬 검증 |
 | `clearCache` | - | void | repodata 캐시 초기화 |
 
 ### 내부 메서드
@@ -213,7 +214,7 @@ const valid = await downloader.verifyChecksum(result.filePath, result.sha256);
 | `downloadPom` | artifact: MavenArtifact, destDir: string | Promise<DownloadResult> | POM 파일 다운로드 |
 | `downloadSources` | artifact: MavenArtifact, destDir: string | Promise<DownloadResult> | 소스 JAR 다운로드 |
 | `downloadJavadoc` | artifact: MavenArtifact, destDir: string | Promise<DownloadResult> | Javadoc JAR 다운로드 |
-| `verifyChecksum` | filePath: string, checksumUrl: string | Promise<boolean> | SHA1 체크섬 검증 |
+| `verifyChecksum` | filePath: string, checksumUrl: string | Promise<boolean> | shared checksum 유틸리티를 통한 SHA1 체크섬 검증 |
 
 ### 내부 메서드
 

--- a/docs/shared-utilities.md
+++ b/docs/shared-utilities.md
@@ -30,6 +30,10 @@ src/core/shared/
 ├── axios-http-client.ts          # Axios 기반 구현체
 ├── mock-http-client.ts           # 테스트용 Mock 구현체
 │
+│   # 무결성 검사 유틸리티
+├── integrity/
+│   └── checksum.ts               # 파일 체크섬 계산/검증 공통 모듈
+│
 │   # 공유 캐시 모듈
 ├── cache-utils.ts                # 캐시 공통 유틸리티
 ├── cache-manager.ts              # 범용 캐시 매니저
@@ -136,7 +140,41 @@ export type {
   ResolvedPackageList,
   DependencyResolverOptions,
 } from './dependency-resolver';
+
+// 무결성 검사 유틸리티
+export {
+  SUPPORTED_CHECKSUM_ALGORITHMS,
+  calculateFileChecksum,
+  isChecksumAlgorithm,
+  normalizeChecksum,
+  verifyFileChecksum,
+} from './integrity/checksum';
+export type { ChecksumAlgorithm } from './integrity/checksum';
 ```
+
+---
+
+## 무결성 검사 유틸리티 (`integrity/checksum.ts`)
+
+파일 기반 체크섬 계산과 검증을 공통 모듈로 통합했습니다.
+
+### 제공 함수
+
+| 함수 | 설명 |
+|------|------|
+| `calculateFileChecksum(filePath, algorithm?)` | 파일의 체크섬을 계산합니다. 기본 알고리즘은 `sha256`입니다. |
+| `verifyFileChecksum(filePath, expectedChecksum, algorithm?)` | 파일 체크섬이 기대값과 일치하는지 검증합니다. |
+| `normalizeChecksum(checksum)` | 대소문자/`sha256:` 같은 알고리즘 프리픽스를 정규화합니다. |
+| `isChecksumAlgorithm(value)` | 지원하는 알고리즘(`md5`, `sha1`, `sha256`, `sha512`) 여부를 확인합니다. |
+
+### 주요 사용처
+
+- `src/core/downloaders/pip.ts`
+- `src/core/downloaders/conda.ts`
+- `src/core/downloaders/maven.ts`
+- `src/core/downloaders/docker-utils.ts`
+- `src/core/cache-manager.ts`
+- `src/core/downloaders/os-shared/gpg-verifier.ts`
 
 ---
 

--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -3,13 +3,14 @@
  * 다운로드한 패키지를 로컬 캐시에 저장하여 재사용
  */
 
-import * as fs from 'fs-extra';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import { PackageInfo } from '../types';
 import logger from '../utils/logger';
 import { sanitizeCacheKey } from './shared/filename-utils';
+import { calculateFileChecksum, verifyFileChecksum } from './shared/integrity/checksum';
 
 export interface CacheOptions {
   cacheDir?: string;
@@ -306,14 +307,7 @@ export class CacheManager {
    * 체크섬 계산
    */
   private async calculateChecksum(filePath: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const hash = crypto.createHash('sha256');
-      const stream = fs.createReadStream(filePath);
-
-      stream.on('data', (data) => hash.update(data));
-      stream.on('end', () => resolve(hash.digest('hex')));
-      stream.on('error', reject);
-    });
+    return calculateFileChecksum(filePath, 'sha256');
   }
 
   /**
@@ -321,8 +315,7 @@ export class CacheManager {
    */
   private async verifyChecksum(filePath: string, expectedChecksum: string): Promise<boolean> {
     try {
-      const actualChecksum = await this.calculateChecksum(filePath);
-      return actualChecksum === expectedChecksum;
+      return await verifyFileChecksum(filePath, expectedChecksum, 'sha256');
     } catch {
       return false;
     }

--- a/src/core/downloaders/conda.ts
+++ b/src/core/downloaders/conda.ts
@@ -1,7 +1,6 @@
+import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as crypto from 'crypto';
 import {
   IDownloader,
   PackageInfo,
@@ -10,14 +9,15 @@ import {
   Architecture,
 } from '../../types';
 import logger from '../../utils/logger';
+import { compareVersions, getCondaSubdir } from '../shared';
+import { fetchRepodata } from '../shared/conda-cache';
 import {
   RepoData,
   RepoDataPackage,
   CondaSearchResult,
   CondaPackageFile,
 } from '../shared/conda-types';
-import { compareVersions, getCondaSubdir } from '../shared';
-import { fetchRepodata } from '../shared/conda-cache';
+import { verifyFileChecksum } from '../shared/integrity/checksum';
 
 // CondaPackageInfo는 downloader 전용 (files, versions 등 추가 필드 포함)
 interface CondaPackageInfo {
@@ -467,17 +467,7 @@ export class CondaDownloader implements IDownloader {
     expected: string,
     algorithm: 'md5' | 'sha256' = 'md5'
   ): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      const hash = crypto.createHash(algorithm);
-      const stream = fs.createReadStream(filePath);
-
-      stream.on('data', (data) => hash.update(data));
-      stream.on('end', () => {
-        const actual = hash.digest('hex').toLowerCase();
-        resolve(actual === expected.toLowerCase());
-      });
-      stream.on('error', reject);
-    });
+    return verifyFileChecksum(filePath, expected, algorithm);
   }
 
   /**

--- a/src/core/downloaders/docker-utils.ts
+++ b/src/core/downloaders/docker-utils.ts
@@ -1,6 +1,5 @@
-import * as fsNative from 'fs';
-import * as crypto from 'crypto';
 import { Architecture } from '../../types';
+import { calculateFileChecksum } from '../shared/integrity/checksum';
 
 /**
  * Docker 플랫폼 정보 인터페이스
@@ -148,12 +147,5 @@ export function parseImageName(name: string): [string, string] {
  * 파일의 SHA256 해시 계산
  */
 export function calculateSha256(filePath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const hash = crypto.createHash('sha256');
-    const stream = fsNative.createReadStream(filePath);
-
-    stream.on('data', (data) => hash.update(data));
-    stream.on('end', () => resolve(hash.digest('hex')));
-    stream.on('error', reject);
-  });
+  return calculateFileChecksum(filePath, 'sha256');
 }

--- a/src/core/downloaders/maven.ts
+++ b/src/core/downloaders/maven.ts
@@ -1,7 +1,6 @@
+import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as crypto from 'crypto';
 import {
   IDownloader,
   PackageInfo,
@@ -9,8 +8,9 @@ import {
   DownloadProgressEvent,
 } from '../../types';
 import logger from '../../utils/logger';
-import { sanitizePath } from '../shared/path-utils';
+import { verifyFileChecksum } from '../shared/integrity/checksum';
 import { isNativeArtifact } from '../shared/maven-utils';
+import { sanitizePath } from '../shared/path-utils';
 import {
   retryWithExponentialBackoff,
   isRetryableHttpError,
@@ -683,17 +683,7 @@ export class MavenDownloader implements IDownloader {
    * 체크섬 검증 (SHA-1)
    */
   async verifyChecksum(filePath: string, expected: string): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      const hash = crypto.createHash('sha1');
-      const stream = fs.createReadStream(filePath);
-
-      stream.on('data', (data) => hash.update(data));
-      stream.on('end', () => {
-        const actual = hash.digest('hex').toLowerCase();
-        resolve(actual === expected.toLowerCase());
-      });
-      stream.on('error', reject);
-    });
+    return verifyFileChecksum(filePath, expected, 'sha1');
   }
 
   /**

--- a/src/core/downloaders/os-shared/gpg-verifier.ts
+++ b/src/core/downloaders/os-shared/gpg-verifier.ts
@@ -4,7 +4,11 @@
  */
 
 import * as crypto from 'crypto';
-import * as fs from 'fs';
+import {
+  calculateFileChecksum,
+  isChecksumAlgorithm,
+  normalizeChecksum,
+} from '../../shared/integrity/checksum';
 import type { OSPackageInfo, Repository, OSPackageManager } from './types';
 
 /**
@@ -168,31 +172,14 @@ export class GPGVerifier {
     }
 
     try {
-      const fileBuffer = fs.readFileSync(filePath);
-      const hashType = pkg.checksum.type.toLowerCase() as 'md5' | 'sha1' | 'sha256' | 'sha512';
-
-      let hash: crypto.Hash;
-      switch (hashType) {
-        case 'md5':
-          hash = crypto.createHash('md5');
-          break;
-        case 'sha1':
-          hash = crypto.createHash('sha1');
-          break;
-        case 'sha256':
-          hash = crypto.createHash('sha256');
-          break;
-        case 'sha512':
-          hash = crypto.createHash('sha512');
-          break;
-        default:
-          return { verified: true, skipped: true };
+      const hashType = pkg.checksum.type.toLowerCase();
+      if (!isChecksumAlgorithm(hashType)) {
+        return { verified: true, skipped: true };
       }
 
-      hash.update(fileBuffer);
-      const calculated = hash.digest('hex');
+      const calculated = await calculateFileChecksum(filePath, hashType);
 
-      if (calculated.toLowerCase() === pkg.checksum.value.toLowerCase()) {
+      if (normalizeChecksum(calculated) === normalizeChecksum(pkg.checksum.value)) {
         return { verified: true, skipped: false };
       } else {
         return {

--- a/src/core/downloaders/pip.ts
+++ b/src/core/downloaders/pip.ts
@@ -1,7 +1,6 @@
+import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as crypto from 'crypto';
 import {
   IDownloader,
   PackageInfo,
@@ -11,20 +10,19 @@ import {
 } from '../../types';
 import logger from '../../utils/logger';
 import {
-  PyPIRelease,
-  PyPIInfo,
-  PyPIResponse,
-  PyPISearchResult,
-} from '../shared/pip-types';
-import { compareVersions } from '../shared';
-import { sanitizePath } from '../shared/path-utils';
-import type { PipTargetPlatform } from '../../types/pip-target-platform';
-import {
   fetchPackageFiles,
   extractVersionFromFilename,
   findLatestVersion as findLatestVersionFromSimpleApi,
   SimpleApiPackageFile,
 } from '../resolver/pip-simple-api';
+import { compareVersions } from '../shared';
+import { verifyFileChecksum } from '../shared/integrity/checksum';
+import { sanitizePath } from '../shared/path-utils';
+import {
+  PyPIRelease,
+  PyPIResponse,
+} from '../shared/pip-types';
+import type { PipTargetPlatform } from '../../types/pip-target-platform';
 
 export class PipDownloader implements IDownloader {
   readonly type = 'pip' as const;
@@ -340,17 +338,7 @@ export class PipDownloader implements IDownloader {
    * 체크섬 검증
    */
   async verifyChecksum(filePath: string, expected: string): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      const hash = crypto.createHash('sha256');
-      const stream = fs.createReadStream(filePath);
-
-      stream.on('data', (data) => hash.update(data));
-      stream.on('end', () => {
-        const actual = hash.digest('hex').toLowerCase();
-        resolve(actual === expected.toLowerCase());
-      });
-      stream.on('error', reject);
-    });
+    return verifyFileChecksum(filePath, expected, 'sha256');
   }
 
   /**

--- a/src/core/shared/index.ts
+++ b/src/core/shared/index.ts
@@ -219,6 +219,16 @@ export type {
 } from './http-client';
 export { HttpError } from './http-client';
 
+// 무결성 검사 유틸리티
+export {
+  SUPPORTED_CHECKSUM_ALGORITHMS,
+  calculateFileChecksum,
+  isChecksumAlgorithm,
+  normalizeChecksum,
+  verifyFileChecksum,
+} from './integrity/checksum';
+export type { ChecksumAlgorithm } from './integrity/checksum';
+
 // Axios HTTP 클라이언트 (axios-http-client.ts)
 export {
   AxiosHttpClient,

--- a/src/core/shared/integrity/checksum.test.ts
+++ b/src/core/shared/integrity/checksum.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  calculateFileChecksum,
+  verifyFileChecksum,
+  type ChecksumAlgorithm,
+} from './checksum';
+
+const FIXTURE_CONTENT = 'deps-smuggler checksum fixture\n';
+const FIXTURE_CHECKSUMS: Record<ChecksumAlgorithm, string> = {
+  md5: '16e6f9310fa69758a96f5dd05778fa19',
+  sha1: '348bd352241058a79755b0f417b257e6e38044df',
+  sha256: '4ec14962517fa49187d107ff8c257417112e55d844fe89b82a5d5e94a639c62e',
+  sha512:
+    'e28ed65313ceb650cc4366bda1e3814430d5cf88487b5ae9ea382db8a96426725a23debd58dd650d31cf12eacf504cd054a1b676628a3a0009565787c687e8c3',
+};
+
+const tempDirs: string[] = [];
+
+async function createFixtureFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'depssmuggler-checksum-'));
+  const filePath = join(dir, 'fixture.txt');
+
+  tempDirs.push(dir);
+  await writeFile(filePath, FIXTURE_CONTENT, 'utf8');
+
+  return filePath;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('checksum', () => {
+  it('기본값으로 sha256 체크섬을 계산한다', async () => {
+    const filePath = await createFixtureFile();
+
+    await expect(calculateFileChecksum(filePath)).resolves.toBe(FIXTURE_CHECKSUMS.sha256);
+  });
+
+  it.each([
+    ['md5', FIXTURE_CHECKSUMS.md5],
+    ['sha1', FIXTURE_CHECKSUMS.sha1],
+    ['sha256', FIXTURE_CHECKSUMS.sha256],
+    ['sha512', FIXTURE_CHECKSUMS.sha512],
+  ] as const)('%s 알고리즘 계산을 지원한다', async (algorithm, expected) => {
+    const filePath = await createFixtureFile();
+
+    await expect(calculateFileChecksum(filePath, algorithm)).resolves.toBe(expected);
+  });
+
+  it('대소문자와 sha256: 프리픽스를 무시하고 체크섬을 검증한다', async () => {
+    const filePath = await createFixtureFile();
+
+    await expect(
+      verifyFileChecksum(filePath, `sha256:${FIXTURE_CHECKSUMS.sha256.toUpperCase()}`)
+    ).resolves.toBe(true);
+  });
+
+  it('체크섬이 다르면 false를 반환한다', async () => {
+    const filePath = await createFixtureFile();
+
+    await expect(verifyFileChecksum(filePath, 'sha256:deadbeef')).resolves.toBe(false);
+  });
+});

--- a/src/core/shared/integrity/checksum.ts
+++ b/src/core/shared/integrity/checksum.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'fs-extra';
+
+export const SUPPORTED_CHECKSUM_ALGORITHMS = ['md5', 'sha1', 'sha256', 'sha512'] as const;
+
+export type ChecksumAlgorithm = (typeof SUPPORTED_CHECKSUM_ALGORITHMS)[number];
+
+const CHECKSUM_PREFIX_PATTERN = /^(md5|sha1|sha256|sha512):/i;
+
+export function isChecksumAlgorithm(value: string): value is ChecksumAlgorithm {
+  return (SUPPORTED_CHECKSUM_ALGORITHMS as readonly string[]).includes(value);
+}
+
+export function normalizeChecksum(checksum: string): string {
+  return checksum.trim().replace(CHECKSUM_PREFIX_PATTERN, '').toLowerCase();
+}
+
+export function calculateFileChecksum(
+  filePath: string,
+  algorithm: ChecksumAlgorithm = 'sha256'
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash(algorithm);
+    const stream = fs.createReadStream(filePath);
+
+    stream.on('data', (data) => hash.update(data));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', reject);
+  });
+}
+
+export async function verifyFileChecksum(
+  filePath: string,
+  expectedChecksum: string,
+  algorithm: ChecksumAlgorithm = 'sha256'
+): Promise<boolean> {
+  const actualChecksum = await calculateFileChecksum(filePath, algorithm);
+  return normalizeChecksum(actualChecksum) === normalizeChecksum(expectedChecksum);
+}


### PR DESCRIPTION
## 요약
- Phase 3 첫 slice로 공통 checksum 유틸리티를 추가하고 downloader/cache/GPG verifier의 중복 구현을 통합했습니다.
- checksum 계산/검증 테스트를 새로 추가하고 shared barrel 및 문서를 동기화했습니다.

## 배경
- 계획서 `agent-federated-bachman.md`의 Phase 3은 checksum/http/retry/progress 공통화가 목표입니다.
- 현재는 pip/conda/maven/cache/docker/GPG verifier가 각각 파일 체크섬 로직을 중복 구현하고 있어 유지보수 비용이 컸습니다.

## 변경 사항
- `src/core/shared/integrity/checksum.ts`에 공통 checksum 계산/검증/정규화 유틸리티를 추가했습니다.
- `pip`, `conda`, `maven`, `docker-utils`, `cache-manager`, `os-shared/gpg-verifier`가 shared checksum 유틸리티를 사용하도록 치환했습니다.
- `src/core/shared/integrity/checksum.test.ts`를 추가하고 shared export 및 관련 문서를 갱신했습니다.

## 검증
- `npm test -- src/core/shared/integrity/checksum.test.ts src/core/cache-manager.test.ts src/core/downloaders/os-shared/gpg-verifier.test.ts src/core/downloaders/pip.test.ts src/core/downloaders/conda.test.ts src/core/downloaders/maven.test.ts src/core/downloaders/docker.test.ts` ✅ (372 passed, 8 skipped)
- `npx tsc --noEmit -p tsconfig.json` ✅
- `bash scripts/verify-worktree.sh` ⚠️ 전체 Vitest는 1525 passed / 186 skipped까지 진행됐지만, 로컬 `node_modules`에 `jsdom`이 누락되어 마지막에 `ERR_MODULE_NOT_FOUND`로 실패했습니다. `package.json`/`package-lock.json`에는 `jsdom` 선언이 있어 환경 drift로 판단했습니다.

## 문서
- `docs/shared-utilities.md`
- `docs/downloaders.md`
