### PR TITLE
Phase 2: 다운로드 타입 모듈 정규화 2차 적용

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -90,6 +90,7 @@ depssmuggler/
 - `mailer/`: SMTP 발송
 - `shared/`: HTTP, 캐시, 버전 비교, 플랫폼 매핑, 버전 프리로드, 마스킹 등 공통 유틸리티
 - `types/`: `src/types/index.ts` barrel과 `download/`, `manifest/`, `package-manager/`, `platform/`, `resolver/` 하위 canonical module로 분리된 공용 타입 정의
+  `download/options.ts`, `download/progress.ts`, `download/error.ts`, `platform/os-target.ts`가 Phase 2 기준 canonical entry입니다.
 
 ### 5. CLI (`src/cli`)
 

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -94,7 +94,7 @@ if (isUserConfig(data)) {
 ```typescript
 // Good: 테스트에서 private 멤버 접근 시 Testable 인터페이스 사용
 interface DownloadManagerTestable {
-  items: Map<string, DownloadItem>;
+  items: Map<string, DownloadManagerItem>;
   isRunning: boolean;
   queue: PQueue;
 }

--- a/docs/shared-file-path.md
+++ b/docs/shared-file-path.md
@@ -29,7 +29,7 @@ async function downloadFile(
   url: string,
   destPath: string,
   onProgress: (downloaded: number, total: number) => void,
-  options?: DownloadOptions
+  options?: FileDownloadOptions
 ): Promise<void>
 ```
 
@@ -38,10 +38,10 @@ async function downloadFile(
 - AbortSignal을 통한 다운로드 취소
 - shouldPause 콜백을 통한 일시정지/재개
 
-### DownloadOptions
+### FileDownloadOptions
 
 ```typescript
-interface DownloadOptions {
+interface FileDownloadOptions {
   signal?: AbortSignal;           // 취소 시그널 (AbortController.signal)
   shouldPause?: () => boolean;    // 일시정지 여부 콜백 (true면 pause)
 }

--- a/docs/shared-types.md
+++ b/docs/shared-types.md
@@ -2,7 +2,7 @@
 
 ## 개요
 - 목적: 모든 모듈에서 공통으로 사용하는 타입 정의
-- 위치: `src/core/shared/types.ts`, `*-types.ts`
+- 위치: `src/core/shared/types.ts`, `src/types/download/*.ts`, `src/types/platform/*.ts`, `*-types.ts`
 
 ---
 
@@ -40,6 +40,9 @@ interface DownloadPackage {
 
 다운로드 옵션
 
+- canonical 정의: `src/types/download/options.ts`
+- `src/core/shared/types.ts`는 위 canonical 모듈을 그대로 re-export 하는 shim입니다.
+
 ```typescript
 interface DownloadOptions {
   outputDir: string;                       // 출력 디렉토리
@@ -50,6 +53,10 @@ interface DownloadOptions {
   includeDependencies?: boolean;           // false면 의존성 해결 단계를 생략하고 원본만 사용
   pythonVersion?: string;                  // Python 버전 (pip/conda용)
   concurrency?: number;                    // 동시 다운로드 수 (기본: 3)
+  deliveryMethod?: 'local' | 'email';
+  email?: { to: string; from?: string; subject?: string };
+  fileSplit?: { enabled: boolean; maxSizeMB: number };
+  smtp?: { host: string; port: number; user?: string; password?: string; from?: string; secure?: boolean };
 }
 ```
 
@@ -57,14 +64,28 @@ interface DownloadOptions {
 
 다운로드 진행 상태
 
+- canonical 정의: `src/types/download/progress.ts`
+
 ```typescript
 interface DownloadProgress {
   packageId: string;
-  status: 'pending' | 'downloading' | 'completed' | 'failed';
+  status: 'pending' | 'downloading' | 'completed' | 'failed' | 'paused';
   progress: number;         // 0-100
   downloadedBytes: number;
   totalBytes: number;
   speed: number;            // bytes/sec
+  error?: string;
+}
+```
+
+### DownloadPackageResult
+
+개별 패키지 다운로드 처리 결과
+
+```typescript
+interface DownloadPackageResult {
+  id: string;
+  success: boolean;
   error?: string;
 }
 ```

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -1,15 +1,15 @@
-import cliProgress from 'cli-progress';
-import chalk from 'chalk';
 import * as path from 'path';
+import chalk from 'chalk';
+import cliProgress from 'cli-progress';
 import * as fs from 'fs-extra';
-import { PackageInfo, PackageType, Architecture } from '../../types';
 import { getDownloadManager, OverallProgress } from '../../core/download-manager';
 import { getArchivePackager, ArchiveFormat } from '../../core/packager/archive-packager';
 import { getScriptGenerator } from '../../core/packager/script-generator';
 import { DownloadPackage, resolveAllDependencies } from '../../core/shared';
+import { PackageInfo, PackageType, Architecture } from '../../types';
 
 // 다운로드 옵션
-interface DownloadOptions {
+interface DownloadCommandOptions {
   type: PackageType;
   package?: string;
   pkgVersion: string;
@@ -79,7 +79,7 @@ function toPackageInfo(pkg: DownloadPackage): PackageInfo {
 
 async function preparePackagesForDownload(
   packages: PackageInfo[],
-  options: Pick<DownloadOptions, 'arch' | 'deps'>
+  options: Pick<DownloadCommandOptions, 'arch' | 'deps'>
 ): Promise<PreparedPackagesResult> {
   if (!options.deps) {
     return {
@@ -118,7 +118,7 @@ async function preparePackagesForDownload(
 /**
  * download 명령어 핸들러
  */
-export async function downloadCommand(options: DownloadOptions): Promise<void> {
+export async function downloadCommand(options: DownloadCommandOptions): Promise<void> {
   console.log(chalk.cyan('다운로드 준비 중...'));
 
   try {
@@ -226,8 +226,9 @@ export async function downloadCommand(options: DownloadOptions): Promise<void> {
 
       // 패키징 처리
       const files = result.items
-        .filter((item) => item.status === 'completed' && item.filePath)
-        .map((item) => item.filePath!);
+        .flatMap((item) => (
+          item.status === 'completed' && item.filePath ? [item.filePath] : []
+        ));
 
       // 압축 파일 생성
       console.log(chalk.cyan('\n압축 파일 생성 중...'));

--- a/src/core/cache-manager.test.ts
+++ b/src/core/cache-manager.test.ts
@@ -285,6 +285,7 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       setImmediate(() => {
         mockStream.emit('data', Buffer.from('test data'));
         mockStream.emit('end');
+        mockStream.emit('close');
       });
 
       await addPromise;
@@ -315,6 +316,7 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       setImmediate(() => {
         mockStream.emit('data', Buffer.from('test data'));
         mockStream.emit('end');
+        mockStream.emit('close');
       });
 
       await expect(addPromise).rejects.toThrow('disk full');
@@ -377,6 +379,7 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       setImmediate(() => {
         mockStream.emit('data', Buffer.from('test'));
         mockStream.emit('end');
+        mockStream.emit('close');
       });
 
       const result = await resultPromise;
@@ -526,6 +529,7 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       setImmediate(() => {
         mockStream.emit('data', Buffer.from('test'));
         mockStream.emit('end');
+        mockStream.emit('close');
       });
 
       await expect(resultPromise).resolves.toBeNull();
@@ -566,6 +570,7 @@ describe('CacheManager 매니페스트 및 캐시 조작', () => {
       setImmediate(() => {
         mockStream.emit('data', Buffer.from('data'));
         mockStream.emit('end');
+        mockStream.emit('close');
       });
 
       await addPromise;

--- a/src/core/download-manager.test.ts
+++ b/src/core/download-manager.test.ts
@@ -4,26 +4,31 @@
  * 네트워크 호출 없이 DownloadManager의 핵심 로직을 테스트합니다.
  */
 
+import PQueue from 'p-queue';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { DownloadManager, DownloadItem, OverallProgress, DownloadOptions, DownloadResult } from './download-manager';
+import {
+  DownloadManager,
+  type DownloadManagerItem,
+  type DownloadManagerOptions,
+  type DownloadManagerResult,
+} from './download-manager';
 import { IDownloader, PackageType, DownloadProgressEvent } from '../types';
 import { SpeedCalculator } from './speed-calculator';
-import PQueue from 'p-queue';
 
 /**
  * 테스트용 DownloadManager 인터페이스
  * private 멤버에 타입 안전하게 접근하기 위한 인터페이스
  */
 interface DownloadManagerTestable {
-  items: Map<string, DownloadItem>;
+  items: Map<string, DownloadManagerItem>;
   isRunning: boolean;
   isCancelled: boolean;
   startTime: number;
-  options: DownloadOptions;
+  options: DownloadManagerOptions;
   downloaders: Map<PackageType, IDownloader>;
   queue: PQueue;
   speedCalculator: SpeedCalculator;
-  createResult: () => DownloadResult;
+  createResult: () => DownloadManagerResult;
   updateItemProgress: (id: string, event: DownloadProgressEvent) => void;
   initDownloaders: () => Promise<void>;
 }
@@ -322,7 +327,7 @@ describe('DownloadManager 단위 테스트', () => {
   });
 
   describe('createResult', () => {
-    const callCreateResult = (manager: DownloadManager): DownloadResult => {
+    const callCreateResult = (manager: DownloadManager): DownloadManagerResult => {
       return asTestable(manager).createResult();
     };
 
@@ -720,7 +725,7 @@ describe('DownloadManager 단위 테스트', () => {
       const itemsArray = Array.from(items.values());
       itemsArray[0].status = 'completed';
 
-      const result = await manager.startDownload({
+      await manager.startDownload({
         outputPath: '/test/output',
         concurrency: 5,
         maxRetries: 2,

--- a/src/core/download-manager.ts
+++ b/src/core/download-manager.ts
@@ -1,77 +1,71 @@
-import PQueue from 'p-queue';
 import { EventEmitter } from 'eventemitter3';
-import * as path from 'path';
 import * as fs from 'fs-extra';
-import {
+import PQueue from 'p-queue';
+import logger from '../utils/logger';
+import { DOWNLOAD_CONSTANTS } from './constants/download';
+// 다운로더 가져오기
+import { getCondaDownloader } from './downloaders/conda';
+import { getDockerDownloader } from './downloaders/docker';
+import { getMavenDownloader } from './downloaders/maven';
+import { getNpmDownloader } from './downloaders/npm';
+import { getPipDownloader } from './downloaders/pip';
+import { SpeedCalculator } from './speed-calculator';
+import type {
   PackageInfo,
   PackageType,
   DownloadProgressEvent,
   IDownloader,
+  DownloadItem as CanonicalDownloadItem,
+  DownloadStatus as CanonicalDownloadStatus,
 } from '../types';
-import logger from '../utils/logger';
-import { DOWNLOAD_CONSTANTS } from './constants/download';
-import { SpeedCalculator } from './speed-calculator';
-
-// 다운로더 가져오기
-import { getPipDownloader } from './downloaders/pip';
-import { getCondaDownloader } from './downloaders/conda';
-import { getMavenDownloader } from './downloaders/maven';
-import { getDockerDownloader } from './downloaders/docker';
-import { getNpmDownloader } from './downloaders/npm';
 
 // 다운로드 아이템 상태
-export type DownloadItemStatus =
-  | 'pending'
-  | 'downloading'
-  | 'completed'
-  | 'failed'
-  | 'skipped'
-  | 'cancelled';
+export type DownloadManagerItemStatus = CanonicalDownloadStatus;
 
 // 다운로드 아이템
-export interface DownloadItem {
-  id: string;
-  package: PackageInfo;
-  status: DownloadItemStatus;
-  progress: number;
+export interface DownloadManagerItem extends CanonicalDownloadItem {
   downloadedBytes: number;
   totalBytes: number;
   speed: number;
-  filePath?: string;
-  error?: string;
   retryCount: number;
 }
 
 // 다운로드 결과
-export interface DownloadResult {
+export interface DownloadManagerResult {
   success: boolean;
-  items: DownloadItem[];
+  items: DownloadManagerItem[];
   totalSize: number;
   duration: number;
   outputPath: string;
 }
 
 // 다운로드 옵션
-export interface DownloadOptions {
+export interface DownloadManagerOptions {
   outputPath: string;
   concurrency?: number;
   maxRetries?: number;
   onUserDecision?: (
-    item: DownloadItem,
+    item: DownloadManagerItem,
     error: Error
   ) => Promise<'retry' | 'skip' | 'cancel'>;
 }
 
 // 이벤트 타입
 export interface DownloadManagerEvents {
-  progress: (item: DownloadItem, overall: OverallProgress) => void;
-  itemStart: (item: DownloadItem) => void;
-  itemComplete: (item: DownloadItem) => void;
-  itemFailed: (item: DownloadItem, error: Error) => void;
-  itemSkipped: (item: DownloadItem) => void;
-  allComplete: (result: DownloadResult) => void;
+  progress: (item: DownloadManagerItem, overall: OverallProgress) => void;
+  itemStart: (item: DownloadManagerItem) => void;
+  itemComplete: (item: DownloadManagerItem) => void;
+  itemFailed: (item: DownloadManagerItem, error: Error) => void;
+  itemSkipped: (item: DownloadManagerItem) => void;
+  allComplete: (result: DownloadManagerResult) => void;
   cancelled: () => void;
 }
+
+// Backward-compatible aliases while callers migrate to explicit manager types.
+export type DownloadItemStatus = DownloadManagerItemStatus;
+export type DownloadItem = DownloadManagerItem;
+export type DownloadOptions = DownloadManagerOptions;
+export type DownloadResult = DownloadManagerResult;
 
 // 전체 진행률
 export interface OverallProgress {
@@ -93,12 +87,12 @@ const generateId = (): string => {
 
 export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
   private queue: PQueue;
-  private items: Map<string, DownloadItem> = new Map();
+  private items: Map<string, DownloadManagerItem> = new Map();
   private downloaders: Map<PackageType, IDownloader> = new Map();
   private isRunning = false;
   private isCancelled = false;
   private startTime = 0;
-  private options: DownloadOptions = { outputPath: '' };
+  private options: DownloadManagerOptions = { outputPath: '' };
   private speedCalculator = new SpeedCalculator();
 
   constructor() {
@@ -125,7 +119,7 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
   addToQueue(packages: PackageInfo[]): void {
     for (const pkg of packages) {
       const id = generateId();
-      const item: DownloadItem = {
+      const item: DownloadManagerItem = {
         id,
         package: pkg,
         status: 'pending',
@@ -144,7 +138,7 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
   /**
    * 다운로드 시작
    */
-  async startDownload(options: DownloadOptions): Promise<DownloadResult> {
+  async startDownload(options: DownloadManagerOptions): Promise<DownloadManagerResult> {
     if (this.isRunning) {
       throw new Error('다운로드가 이미 진행 중입니다');
     }
@@ -409,7 +403,7 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
   /**
    * 결과 생성
    */
-  private createResult(): DownloadResult {
+  private createResult(): DownloadManagerResult {
     const items = Array.from(this.items.values());
     const totalSize = items.reduce(
       (sum, item) => sum + (item.downloadedBytes || 0),
@@ -468,7 +462,7 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
   /**
    * 아이템 목록 조회
    */
-  getItems(): DownloadItem[] {
+  getItems(): DownloadManagerItem[] {
     return Array.from(this.items.values());
   }
 

--- a/src/core/downloaders/os-shared/base-downloader.ts
+++ b/src/core/downloaders/os-shared/base-downloader.ts
@@ -5,6 +5,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { GPGVerifier, type VerificationResult } from './gpg-verifier';
+import { getDownloadedFileKey } from './package-file-utils';
 import type {
   OSPackageInfo,
   Repository,
@@ -14,13 +16,11 @@ import type {
   OSDownloadError,
   OSErrorAction,
 } from './types';
-import { GPGVerifier, type VerificationResult } from './gpg-verifier';
-import { getDownloadedFileKey } from './package-file-utils';
 
 /**
  * 다운로드 결과
  */
-export interface DownloadResult {
+export interface OSPackageDownloadResult {
   /** 성공 여부 */
   success: boolean;
   /** 저장된 파일 경로 */
@@ -110,7 +110,7 @@ export abstract class BaseOSDownloader {
   /**
    * 단일 패키지 다운로드
    */
-  async downloadPackage(pkg: OSPackageInfo): Promise<DownloadResult> {
+  async downloadPackage(pkg: OSPackageInfo): Promise<OSPackageDownloadResult> {
     if (this.options.abortSignal?.aborted) {
       return {
         success: false,
@@ -283,7 +283,10 @@ export abstract class BaseOSDownloader {
     const processNext = async (): Promise<void> => {
       if (queue.length === 0) return;
 
-      const pkg = queue.shift()!;
+      const pkg = queue.shift();
+      if (!pkg) {
+        return;
+      }
       const result = await this.downloadPackage(pkg);
 
       if (result.success) {
@@ -292,7 +295,7 @@ export abstract class BaseOSDownloader {
           downloadedFiles.set(getDownloadedFileKey(pkg), result.filePath);
         }
       } else {
-        failed.push({ package: pkg, error: result.error! });
+        failed.push({ package: pkg, error: result.error ?? new Error('Download failed') });
       }
 
       // 진행률 업데이트

--- a/src/core/downloaders/os-shared/index.ts
+++ b/src/core/downloaders/os-shared/index.ts
@@ -5,7 +5,7 @@
 
 // Base classes
 export { BaseOSDownloader } from './base-downloader';
-export type { BaseDownloaderOptions, DownloadResult } from './base-downloader';
+export type { BaseDownloaderOptions, OSPackageDownloadResult } from './base-downloader';
 export { BaseOSDependencyResolver } from './base-resolver';
 export type { DependencyResolverOptions, PackageMetadataCache } from './base-resolver';
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -22,7 +22,15 @@ export { FileSplitter, getFileSplitter } from './packager/file-splitter';
 
 // Download Manager
 export { DownloadManager, getDownloadManager } from './download-manager';
-export type { DownloadItem, DownloadOptions, DownloadResult, OverallProgress, DownloadManagerEvents } from './download-manager';
+export type {
+  DownloadManagerItem,
+  DownloadManagerItemStatus,
+  DownloadManagerOptions,
+  DownloadManagerResult,
+  OverallProgress,
+  DownloadManagerEvents,
+} from './download-manager';
+export type { DownloadItem, DownloadItemStatus, DownloadOptions, DownloadResult } from './download-manager';
 
 // Resolvers
 export { PipResolver, getPipResolver } from './resolver/pip-resolver';

--- a/src/core/shared/file-utils.ts
+++ b/src/core/shared/file-utils.ts
@@ -1,13 +1,13 @@
 // 파일 다운로드 및 압축 유틸리티
 import * as fs from 'fs';
-import * as https from 'https';
 import * as http from 'http';
+import * as https from 'https';
 import archiver from 'archiver';
 import logger from '../../utils/logger';
 
 export type ProgressCallback = (downloaded: number, total: number) => void;
 
-export interface DownloadOptions {
+export interface FileDownloadOptions {
   signal?: AbortSignal;
   shouldPause?: () => boolean;  // 일시정지 여부를 체크하는 콜백
 }
@@ -20,7 +20,7 @@ export async function downloadFile(
   url: string,
   destPath: string,
   onProgress: ProgressCallback,
-  options?: DownloadOptions
+  options?: FileDownloadOptions
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(destPath);

--- a/src/core/shared/integrity/checksum.test.ts
+++ b/src/core/shared/integrity/checksum.test.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   calculateFileChecksum,
   verifyFileChecksum,
@@ -63,5 +65,41 @@ describe('checksum', () => {
     const filePath = await createFixtureFile();
 
     await expect(verifyFileChecksum(filePath, 'sha256:deadbeef')).resolves.toBe(false);
+  });
+
+  it('파일 스트림 close 이후에만 체크섬 계산을 완료한다', async () => {
+    vi.resetModules();
+
+    const stream = new EventEmitter();
+    const createReadStream = vi.fn(() => stream);
+
+    vi.doMock('fs-extra', () => ({
+      createReadStream,
+    }));
+
+    try {
+      const { calculateFileChecksum: mockedCalculateFileChecksum } = await import('./checksum');
+      const checksumPromise = mockedCalculateFileChecksum('/tmp/mock-fixture.txt');
+      let settled = false;
+
+      void checksumPromise.then(() => {
+        settled = true;
+      });
+
+      stream.emit('data', Buffer.from('checksum-fixture'));
+      stream.emit('end');
+      await Promise.resolve();
+
+      expect(settled).toBe(false);
+
+      stream.emit('close');
+
+      await expect(checksumPromise).resolves.toBe(
+        createHash('sha256').update('checksum-fixture').digest('hex')
+      );
+    } finally {
+      vi.doUnmock('fs-extra');
+      vi.resetModules();
+    }
   });
 });

--- a/src/core/shared/integrity/checksum.ts
+++ b/src/core/shared/integrity/checksum.ts
@@ -22,10 +22,34 @@ export function calculateFileChecksum(
   return new Promise((resolve, reject) => {
     const hash = createHash(algorithm);
     const stream = fs.createReadStream(filePath);
+    let digest: string | null = null;
+    let settled = false;
 
     stream.on('data', (data) => hash.update(data));
-    stream.on('end', () => resolve(hash.digest('hex')));
-    stream.on('error', reject);
+    stream.on('end', () => {
+      digest = hash.digest('hex');
+    });
+    stream.on('close', () => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      if (digest === null) {
+        reject(new Error('Checksum stream closed before completion'));
+        return;
+      }
+
+      resolve(digest);
+    });
+    stream.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      reject(error);
+    });
   });
 }
 

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -1,4 +1,8 @@
 // 공통 타입 정의
+import type { DownloadOptions as CanonicalDownloadOptions } from '../../types/download/options';
+import type { DownloadProgress as CanonicalDownloadProgress } from '../../types/download/progress';
+import type { Architecture as CanonicalArchitecture } from '../../types/platform/architecture';
+import type { TargetOS as CanonicalTargetOS } from '../../types/platform/os-target';
 
 export interface DownloadPackage {
   id: string;
@@ -26,37 +30,9 @@ export interface DownloadPackage {
   metadata?: Record<string, unknown>;
 }
 
-export type TargetOS = 'windows' | 'macos' | 'linux' | 'any';
-export type Architecture = 'x86_64' | 'amd64' | 'arm64' | 'aarch64' | 'noarch';
-
-export interface DownloadOptions {
-  outputDir: string;
-  outputFormat: 'zip' | 'tar.gz';
-  includeScripts: boolean;
-  targetOS?: TargetOS;
-  architecture?: Architecture;
-  includeDependencies?: boolean;
-  pythonVersion?: string;
-  concurrency?: number;
-  deliveryMethod?: 'local' | 'email';
-  email?: {
-    to: string;
-    from?: string;
-    subject?: string;
-  };
-  fileSplit?: {
-    enabled: boolean;
-    maxSizeMB: number;
-  };
-  smtp?: {
-    host: string;
-    port: number;
-    user?: string;
-    password?: string;
-    from?: string;
-    secure?: boolean;
-  };
-}
+export type TargetOS = CanonicalTargetOS;
+export type Architecture = CanonicalArchitecture;
+export type DownloadOptions = CanonicalDownloadOptions;
 
 export interface DownloadUrlResult {
   url: string;
@@ -64,18 +40,12 @@ export interface DownloadUrlResult {
   size?: number;
 }
 
-export interface DownloadProgress {
-  packageId: string;
-  status: 'pending' | 'downloading' | 'completed' | 'failed';
-  progress: number;
-  downloadedBytes: number;
-  totalBytes: number;
-  speed: number;
-  error?: string;
-}
+export type DownloadProgress = CanonicalDownloadProgress;
 
-export interface DownloadResult {
+export interface DownloadPackageResult {
   id: string;
   success: boolean;
   error?: string;
 }
+
+export type DownloadResult = DownloadPackageResult;

--- a/src/renderer/pages/download-page/components/DownloadItemsTable.tsx
+++ b/src/renderer/pages/download-page/components/DownloadItemsTable.tsx
@@ -3,15 +3,15 @@ import { Button, Collapse, List, Progress, Space, Table, Tag, Typography } from 
 import { useMemo } from 'react';
 import { statusColors, statusIcons, statusLabels } from '../presentation';
 import { formatBytes, getPackageDependencies, getPackageGroupStatus } from '../utils';
-import type { DownloadItem, DownloadStatus } from '../../../stores/download-store';
+import type { DownloadStoreItem, DownloadStoreStatus } from '../../../stores/download-store';
 
 const { Panel } = Collapse;
 const { Text } = Typography;
 
 interface DownloadItemsTableProps {
-  downloadItems: DownloadItem[];
+  downloadItems: DownloadStoreItem[];
   showDependenciesTree: boolean;
-  onRetry: (item: DownloadItem) => void;
+  onRetry: (item: DownloadStoreItem) => void;
   paginate?: boolean;
 }
 
@@ -28,7 +28,7 @@ export function DownloadItemsTable({
         dataIndex: 'status',
         key: 'status',
         width: 120,
-        render: (status: DownloadStatus) => (
+        render: (status: DownloadStoreStatus) => (
           <Space>
             {statusIcons[status]}
             <Tag color={statusColors[status]}>{statusLabels[status]}</Tag>
@@ -39,7 +39,7 @@ export function DownloadItemsTable({
         title: '패키지',
         dataIndex: 'name',
         key: 'name',
-        render: (name: string, record: DownloadItem) => (
+        render: (name: string, record: DownloadStoreItem) => (
           <div>
             <div>
               <Text strong>{name}</Text>
@@ -68,7 +68,7 @@ export function DownloadItemsTable({
         dataIndex: 'progress',
         key: 'progress',
         width: 200,
-        render: (progress: number, record: DownloadItem) => (
+        render: (progress: number, record: DownloadStoreItem) => (
           <Progress
             percent={Math.round(progress)}
             size="small"
@@ -95,7 +95,7 @@ export function DownloadItemsTable({
         title: '액션',
         key: 'action',
         width: 100,
-        render: (_: unknown, record: DownloadItem) => (
+        render: (_: unknown, record: DownloadStoreItem) => (
           <Space>
             {record.status === 'failed' && (
               <Button

--- a/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadOutcomeView.tsx
@@ -11,7 +11,7 @@ import { Alert, Button, Card, Col, Divider, Result, Row, Statistic, Typography }
 import { DownloadItemsTable } from './DownloadItemsTable';
 import { DownloadLogsCard } from './DownloadLogsCard';
 import type { HistoryDeliveryResult } from '../../../../types';
-import type { DownloadItem, LogEntry } from '../../../stores/download-store';
+import type { DownloadStoreItem, LogEntry } from '../../../stores/download-store';
 
 const { Text, Paragraph } = Typography;
 
@@ -28,9 +28,9 @@ interface DownloadOutcomeViewProps {
   completedArtifactPaths: string[];
   completedDeliveryResult?: HistoryDeliveryResult;
   completedError: string;
-  downloadItems: DownloadItem[];
+  downloadItems: DownloadStoreItem[];
   logs: LogEntry[];
-  onRetry: (item: DownloadItem) => void;
+  onRetry: (item: DownloadStoreItem) => void;
   onRestartDownload: () => Promise<void> | void;
   onOpenFolder: () => Promise<void> | void;
   onComplete: () => void;

--- a/src/renderer/pages/download-page/components/DownloadStandardView.tsx
+++ b/src/renderer/pages/download-page/components/DownloadStandardView.tsx
@@ -25,7 +25,7 @@ import {
 import { DownloadItemsTable } from './DownloadItemsTable';
 import { DownloadLogsCard } from './DownloadLogsCard';
 import { formatBytes } from '../utils';
-import type { DownloadItem, LogEntry, PackagingStatus } from '../../../stores/download-store';
+import type { DownloadStoreItem, LogEntry, PackagingStatus } from '../../../stores/download-store';
 
 const { Title, Text } = Typography;
 
@@ -40,7 +40,7 @@ interface DownloadStandardViewProps {
   maxFileSizeMB: number;
   isDownloading: boolean;
   onSelectFolder: () => Promise<void> | void;
-  downloadItems: DownloadItem[];
+  downloadItems: DownloadStoreItem[];
   completedCount: number;
   failedCount: number;
   skippedCount: number;
@@ -57,7 +57,7 @@ interface DownloadStandardViewProps {
   isResolvingDeps: boolean;
   allCompleted: boolean;
   logs: LogEntry[];
-  onRetry: (item: DownloadItem) => void;
+  onRetry: (item: DownloadStoreItem) => void;
   onResolveDependencies: () => Promise<void> | void;
   onResetDependencies: () => void;
   onStartDownload: () => Promise<void> | void;

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
@@ -5,8 +5,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useCartStore } from '../../../stores/cart-store';
 import {
   useDownloadStore,
-  type DownloadItem,
-  type DownloadStatus,
+  type DownloadStoreItem,
+  type DownloadStoreStatus,
 } from '../../../stores/download-store';
 import { useHistoryStore } from '../../../stores/history-store';
 import { useSettingsStore } from '../../../stores/settings-store';
@@ -125,14 +125,14 @@ export function useDownloadPageController() {
   const outcomeRestartInFlightRef = useRef(false);
   const dependencyResolutionBypassedRef = useRef(false);
   const previousIncludeDependenciesRef = useRef(includeDependencies);
-  const downloadItemsRef = useRef<DownloadItem[]>([]);
+  const downloadItemsRef = useRef<DownloadStoreItem[]>([]);
   const cartSnapshotRef = useRef<typeof cartItems>([]);
   const historySettingsSnapshotRef = useRef<HistorySettings | null>(null);
   const historyTrackedItemIdsRef = useRef<Set<string> | null>(null);
   const downloadSessionIdRef = useRef(0);
   const activeDownloadSessionRef = useRef<DownloadSessionSnapshot | null>(null);
   const provisionalDownloadSessionRef = useRef<ProvisionalDownloadSession | null>(null);
-  const pendingUpdatesRef = useRef<Map<string, Partial<DownloadItem>>>(new Map());
+  const pendingUpdatesRef = useRef<Map<string, Partial<DownloadStoreItem>>>(new Map());
   const pendingLogsRef = useRef<Array<{ level: 'info' | 'warn' | 'error' | 'success'; message: string; details?: string }>>([]);
   const batchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSpeedCalcRef = useRef<{ time: number; bytes: number }>({ time: 0, bytes: 0 });
@@ -450,7 +450,7 @@ export function useDownloadPageController() {
     data: AllCompleteData,
     completionSessionSnapshot: DownloadSessionSnapshot | null,
     handlers: {
-      updatePackage: (packageId: string, update: Partial<DownloadItem>) => void;
+      updatePackage: (packageId: string, update: Partial<DownloadStoreItem>) => void;
       logMessage: (
         level: 'info' | 'warn' | 'error' | 'success',
         messageText: string,
@@ -608,7 +608,7 @@ export function useDownloadPageController() {
       batchTimerRef.current = null;
     };
 
-    const scheduleBatchUpdate = (packageId: string, update: Partial<DownloadItem>) => {
+    const scheduleBatchUpdate = (packageId: string, update: Partial<DownloadStoreItem>) => {
       pendingUpdatesRef.current.set(packageId, update);
       if (batchTimerRef.current === null) {
         batchTimerRef.current = setTimeout(flushPendingUpdates, downloadRenderInterval);
@@ -752,7 +752,7 @@ export function useDownloadPageController() {
         });
       }
 
-      const newItems: DownloadItem[] = allPackages.map((pkg) => {
+      const newItems: DownloadStoreItem[] = allPackages.map((pkg) => {
         const depInfo = dependencyMap.get(pkg.id);
         const isOriginal = originalIds.has(pkg.id);
 
@@ -761,7 +761,7 @@ export function useDownloadPageController() {
           name: pkg.name,
           version: pkg.version,
           type: pkg.type,
-          status: 'pending' as DownloadStatus,
+          status: 'pending' as DownloadStoreStatus,
           progress: 0,
           downloadedBytes: 0,
           totalBytes: 0,
@@ -1030,7 +1030,7 @@ export function useDownloadPageController() {
         });
       }
 
-      const newItems: DownloadItem[] = data.allPackages.map((pkg) => {
+      const newItems: DownloadStoreItem[] = data.allPackages.map((pkg) => {
         const pkgKey = `${pkg.name}-${pkg.version}`;
         const depInfo = dependencyMap.get(pkgKey);
         const isOriginal = originalNames.has(pkgKey);
@@ -1040,7 +1040,7 @@ export function useDownloadPageController() {
           name: pkg.name,
           version: pkg.version,
           type: pkg.type,
-          status: 'pending' as DownloadStatus,
+          status: 'pending' as DownloadStoreStatus,
           progress: 0,
           downloadedBytes: 0,
           totalBytes: pkg.size || 0,
@@ -1371,7 +1371,7 @@ export function useDownloadPageController() {
     });
   }, [addLog, downloadItems, setIsDownloading, setIsPaused, setPackagingStatus, updateItem]);
 
-  const executeRetryDownload = useCallback(async (item: DownloadItem) => {
+  const executeRetryDownload = useCallback(async (item: DownloadStoreItem) => {
     if (!window.electronAPI?.download?.start) {
       addLog('error', '다운로드 API를 사용할 수 없습니다');
       return;

--- a/src/renderer/pages/download-page/presentation.tsx
+++ b/src/renderer/pages/download-page/presentation.tsx
@@ -10,12 +10,12 @@ import {
   WarningOutlined,
 } from '@ant-design/icons';
 import type {
-  DownloadStatus,
+  DownloadStoreStatus,
   LogEntry,
 } from '../../stores/download-store';
 import type { ReactNode } from 'react';
 
-export const statusIcons: Record<DownloadStatus, ReactNode> = {
+export const statusIcons: Record<DownloadStoreStatus, ReactNode> = {
   pending: <ClockCircleOutlined style={{ color: '#8c8c8c' }} />,
   downloading: <LoadingOutlined spin style={{ color: '#1890ff' }} />,
   completed: <CheckCircleOutlined style={{ color: '#52c41a' }} />,
@@ -25,7 +25,7 @@ export const statusIcons: Record<DownloadStatus, ReactNode> = {
   paused: <PauseOutlined style={{ color: '#1890ff' }} />,
 };
 
-export const statusLabels: Record<DownloadStatus, string> = {
+export const statusLabels: Record<DownloadStoreStatus, string> = {
   pending: '대기',
   downloading: '다운로드 중',
   completed: '완료',
@@ -35,7 +35,7 @@ export const statusLabels: Record<DownloadStatus, string> = {
   paused: '일시정지',
 };
 
-export const statusColors: Record<DownloadStatus, string> = {
+export const statusColors: Record<DownloadStoreStatus, string> = {
   pending: 'default',
   downloading: 'processing',
   completed: 'success',

--- a/src/renderer/pages/download-page/utils.ts
+++ b/src/renderer/pages/download-page/utils.ts
@@ -11,8 +11,8 @@ import type {
 } from '../../../core/downloaders/os-shared/types';
 import type { CartItem } from '../../stores/cart-store';
 import type {
-  DownloadItem,
-  DownloadStatus,
+  DownloadStoreItem,
+  DownloadStoreStatus,
 } from '../../stores/download-store';
 
 export function isOSCartItem(item: CartItem): item is CartItem & { type: SupportedOSPackageManager } {
@@ -127,14 +127,14 @@ export function buildOSDependencyIssueMessage(
   return sections.join('\n\n');
 }
 
-export function createPendingDownloadItems(items: PendingDownloadSource[]): DownloadItem[] {
+export function createPendingDownloadItems(items: PendingDownloadSource[]): DownloadStoreItem[] {
   return items.map((item) => ({
     id: item.id,
     name: item.name,
     version: item.version,
     type: item.type,
     arch: item.arch,
-    status: 'pending' as DownloadStatus,
+    status: 'pending' as DownloadStoreStatus,
     progress: 0,
     downloadedBytes: 0,
     totalBytes: 0,
@@ -184,11 +184,11 @@ export function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
-export function getPackageDependencies(items: DownloadItem[], parentId: string): DownloadItem[] {
+export function getPackageDependencies(items: DownloadStoreItem[], parentId: string): DownloadStoreItem[] {
   return items.filter((item) => item.isDependency && item.parentId === parentId);
 }
 
-export function getPackageGroupStatus(items: DownloadItem[], parentItem: DownloadItem) {
+export function getPackageGroupStatus(items: DownloadStoreItem[], parentItem: DownloadStoreItem) {
   const deps = getPackageDependencies(items, parentItem.id);
   const allItems = [parentItem, ...deps];
   const completed = allItems.filter((item) => item.status === 'completed').length;

--- a/src/renderer/pages/download-page/view-state.test.ts
+++ b/src/renderer/pages/download-page/view-state.test.ts
@@ -4,9 +4,9 @@ import {
   getDownloadCounts,
   hasRecoverableArtifacts,
 } from './view-state';
-import type { DownloadStatus } from '../../stores/download-store';
+import type { DownloadStoreStatus } from '../../stores/download-store';
 
-function createItem(status: DownloadStatus) {
+function createItem(status: DownloadStoreStatus) {
   return {
     id: `${status}-1`,
     name: 'pkg',

--- a/src/renderer/pages/download-page/view-state.ts
+++ b/src/renderer/pages/download-page/view-state.ts
@@ -1,6 +1,6 @@
 import type { HistoryDeliveryResult } from '../../../types';
 import type {
-  DownloadItem,
+  DownloadStoreItem,
   PackagingStatus,
 } from '../../stores/download-store';
 
@@ -64,7 +64,7 @@ export function deriveDownloadPageMode(input: DeriveDownloadPageModeInput): Down
   return 'active';
 }
 
-export function getDownloadCounts(items: DownloadItem[]) {
+export function getDownloadCounts(items: DownloadStoreItem[]) {
   const completedCount = items.filter((item) => item.status === 'completed').length;
   const failedCount = items.filter((item) => item.status === 'failed').length;
   const skippedCount = items.filter((item) => item.status === 'skipped').length;

--- a/src/renderer/stores/download-store.test.ts
+++ b/src/renderer/stores/download-store.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   useDownloadStore,
-  type DownloadItem,
+  type DownloadStoreItem,
 } from './download-store';
 
-const createItem = (overrides?: Partial<DownloadItem>): DownloadItem => ({
+const createItem = (overrides?: Partial<DownloadStoreItem>): DownloadStoreItem => ({
   id: 'pkg-1',
   name: 'requests',
   version: '2.32.0',

--- a/src/renderer/stores/download-store.ts
+++ b/src/renderer/stores/download-store.ts
@@ -1,7 +1,14 @@
 import { create } from 'zustand';
 
 // 다운로드 상태
-export type DownloadStatus = 'pending' | 'downloading' | 'completed' | 'failed' | 'cancelled' | 'skipped' | 'paused';
+export type DownloadStoreStatus =
+  | 'pending'
+  | 'downloading'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'skipped'
+  | 'paused';
 
 // 패키징 상태
 export type PackagingStatus = 'idle' | 'packaging' | 'completed' | 'failed';
@@ -16,13 +23,13 @@ export interface LogEntry {
 }
 
 // 다운로드 아이템
-export interface DownloadItem {
+export interface DownloadStoreItem {
   id: string;
   name: string;
   version: string;
   type?: string;
   arch?: string;
-  status: DownloadStatus;
+  status: DownloadStoreStatus;
   progress: number;
   downloadedBytes: number;
   totalBytes: number;
@@ -49,7 +56,7 @@ export interface DownloadItem {
 
 // 다운로드 상태
 interface DownloadState {
-  items: DownloadItem[];
+  items: DownloadStoreItem[];
   isDownloading: boolean;
   isPaused: boolean;
   outputPath: string;
@@ -62,9 +69,9 @@ interface DownloadState {
   depsResolved: boolean;
 
   // Actions
-  setItems: (items: DownloadItem[]) => void;
-  updateItem: (id: string, updates: Partial<DownloadItem>) => void;
-  updateItemsBatch: (updates: Map<string, Partial<DownloadItem>>) => void;
+  setItems: (items: DownloadStoreItem[]) => void;
+  updateItem: (id: string, updates: Partial<DownloadStoreItem>) => void;
+  updateItemsBatch: (updates: Map<string, Partial<DownloadStoreItem>>) => void;
   addLogsBatch: (logs: Array<{ level: LogEntry['level']; message: string; details?: string }>) => void;
   setIsDownloading: (isDownloading: boolean) => void;
   setIsPaused: (isPaused: boolean) => void;
@@ -87,7 +94,7 @@ const generateLogId = (): string => {
   return `log-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 };
 
-export const useDownloadStore = create<DownloadState>()((set, get) => ({
+export const useDownloadStore = create<DownloadState>()((set) => ({
   items: [],
   isDownloading: false,
   isPaused: false,
@@ -168,7 +175,7 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
   skipItem: (id) =>
     set((state) => ({
       items: state.items.map((item) =>
-        item.id === id ? { ...item, status: 'skipped' as DownloadStatus } : item
+        item.id === id ? { ...item, status: 'skipped' as DownloadStoreStatus } : item
       ),
     })),
 
@@ -176,7 +183,7 @@ export const useDownloadStore = create<DownloadState>()((set, get) => ({
     set((state) => ({
       items: state.items.map((item) =>
         item.id === id
-          ? { ...item, status: 'pending' as DownloadStatus, progress: 0, error: undefined }
+          ? { ...item, status: 'pending' as DownloadStoreStatus, progress: 0, error: undefined }
           : item
       ),
     })),

--- a/src/types/download/error.ts
+++ b/src/types/download/error.ts
@@ -1,0 +1,14 @@
+export type DownloadErrorCode =
+  | 'network'
+  | 'checksum'
+  | 'verification'
+  | 'cancelled'
+  | 'unknown';
+
+export interface DownloadError {
+  code: DownloadErrorCode;
+  message: string;
+  packageId?: string;
+  retryable?: boolean;
+  cause?: unknown;
+}

--- a/src/types/download/item.ts
+++ b/src/types/download/item.ts
@@ -22,10 +22,4 @@ export interface DownloadItem {
   completedAt?: Date;
 }
 
-export interface DownloadProgressEvent {
-  itemId: string;
-  progress: number;
-  downloadedBytes: number;
-  totalBytes: number;
-  speed: number;
-}
+export type { DownloadProgressEvent } from './progress';

--- a/src/types/download/options.ts
+++ b/src/types/download/options.ts
@@ -1,0 +1,44 @@
+import type { Architecture } from '../platform/architecture';
+import type { TargetOS } from '../platform/os-target';
+
+export type DownloadOutputFormat = 'zip' | 'tar.gz';
+export type DownloadDeliveryMethod = 'local' | 'email';
+
+export interface DownloadEmailOptions {
+  to: string;
+  from?: string;
+  subject?: string;
+}
+
+export interface DownloadFileSplitOptions {
+  enabled: boolean;
+  maxSizeMB: number;
+}
+
+export interface DownloadSmtpOptions {
+  host: string;
+  port: number;
+  user?: string;
+  password?: string;
+  from?: string;
+  secure?: boolean;
+}
+
+export interface DownloadOptions {
+  outputDir: string;
+  outputFormat: DownloadOutputFormat;
+  includeScripts: boolean;
+  targetOS?: TargetOS;
+  architecture?: Architecture;
+  includeDependencies?: boolean;
+  pythonVersion?: string;
+  concurrency?: number;
+  deliveryMethod?: DownloadDeliveryMethod;
+  email?: DownloadEmailOptions;
+  fileSplit?: DownloadFileSplitOptions;
+  smtp?: DownloadSmtpOptions;
+}
+
+export interface PipDownloadOptions extends DownloadOptions {
+  pythonVersion?: string;
+}

--- a/src/types/download/progress.ts
+++ b/src/types/download/progress.ts
@@ -1,0 +1,24 @@
+export type DownloadProgressStatus =
+  | 'pending'
+  | 'downloading'
+  | 'completed'
+  | 'failed'
+  | 'paused';
+
+export interface DownloadProgress {
+  packageId: string;
+  status: DownloadProgressStatus;
+  progress: number;
+  downloadedBytes: number;
+  totalBytes: number;
+  speed: number;
+  error?: string;
+}
+
+export interface DownloadProgressEvent {
+  itemId: string;
+  progress: number;
+  downloadedBytes: number;
+  totalBytes: number;
+  speed: number;
+}

--- a/src/types/index.test.ts
+++ b/src/types/index.test.ts
@@ -19,9 +19,13 @@ describe('Phase 2 type module structure', () => {
       'src/types/package-manager/package-manager.ts',
       'src/types/packaging.ts',
       'src/types/platform/architecture.ts',
+      'src/types/platform/os-target.ts',
       'src/types/platform/pip-target-platform.ts',
       'src/types/resolver/dependency-graph.ts',
+      'src/types/download/error.ts',
       'src/types/download/item.ts',
+      'src/types/download/options.ts',
+      'src/types/download/progress.ts',
       'src/types/download/result.ts',
     ];
 
@@ -37,6 +41,9 @@ describe('Phase 2 type module structure', () => {
     expect(indexSource).not.toContain('export type ');
     expect(indexSource).toContain("export * from './package-manager/package-manager';");
     expect(indexSource).toContain("export * from './manifest/package-manifest';");
+    expect(indexSource).toContain("export * from './download/options';");
+    expect(indexSource).toContain("export * from './download/progress';");
+    expect(indexSource).toContain("export * from './platform/os-target';");
     expect(indexSource).toContain("export * from './platform/pip-target-platform';");
   });
 
@@ -64,5 +71,14 @@ describe('Phase 2 type module structure', () => {
     expect(archivePackagerSource).not.toContain('export interface PackageManifest');
     expect(archivePackagerSource).toContain("import type { ArchivePackageManifest } from '../../types/manifest/package-manifest';");
     expect(archivePackagerSource).toContain('ArchivePackageManifest as PackageManifest');
+  });
+
+  it('shared download options/progress는 canonical download type module을 재사용해야 한다', () => {
+    const sharedTypesSource = readFile('src/core/shared/types.ts');
+
+    expect(sharedTypesSource).toContain("from '../../types/download/options';");
+    expect(sharedTypesSource).toContain("from '../../types/download/progress';");
+    expect(sharedTypesSource).toContain('export type DownloadOptions = CanonicalDownloadOptions;');
+    expect(sharedTypesSource).toContain('export type DownloadProgress = CanonicalDownloadProgress;');
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,7 @@
+export * from './download/error';
 export * from './download/item';
+export * from './download/options';
+export * from './download/progress';
 export * from './download/result';
 export * from './history';
 export * from './interfaces';
@@ -7,5 +10,6 @@ export * from './package-manager/metadata';
 export * from './package-manager/package-manager';
 export * from './packaging';
 export * from './platform/architecture';
+export * from './platform/os-target';
 export * from './platform/pip-target-platform';
 export * from './resolver/dependency-graph';

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,4 +1,5 @@
-import type { DownloadProgressEvent, DownloadItem } from './download/item';
+import type { DownloadItem } from './download/item';
+import type { DownloadProgressEvent } from './download/progress';
 import type { PackageInfo } from './package-manager/metadata';
 import type { PackageType } from './package-manager/package-manager';
 import type { PackagingOptions, PackagingResult } from './packaging';

--- a/src/types/platform/os-target.ts
+++ b/src/types/platform/os-target.ts
@@ -1,0 +1,2 @@
+export type TargetOS = 'windows' | 'macos' | 'linux' | 'any';
+export type OsTarget = TargetOS;


### PR DESCRIPTION
## 요약
- canonical download 타입 모듈(`options`, `progress`, `error`, `os-target`)을 추가했습니다.
- 역할이 다른 `Download*` 타입을 CLI, DownloadManager, renderer store, OS base downloader 기준으로 명시적 이름으로 분리했습니다.
- 공유 타입/문서를 canonical 모듈 기준으로 정리하고 legacy alias는 필요한 범위만 유지했습니다.

## 배경
- Phase 2 1차 적용 이후에도 `DownloadOptions`, `DownloadItem`, `DownloadResult`가 서로 다른 의미로 여러 위치에 중복되어 있었습니다.
- 이름 충돌 때문에 호출부 맥락을 읽지 않으면 타입 책임을 구분하기 어려웠고, `src/types` 쪽 canonical surface도 `options/progress/error/os-target` 모듈이 비어 있었습니다.

## 변경 사항
- `src/types/download/{options,progress,error}.ts`, `src/types/platform/os-target.ts`를 추가하고 `src/types/index.ts` barrel에 연결했습니다.
- `src/core/shared/types.ts`가 canonical `DownloadOptions`/`DownloadProgress`를 re-export 하도록 바꿨습니다.
- `src/core/download-manager.ts`는 `DownloadManagerItem/Options/Result`를 기본 이름으로 사용하고, 기존 이름은 호환 alias로만 남겼습니다.
- `src/renderer/stores/download-store.ts`와 다운로드 페이지 컴포넌트는 `DownloadStoreItem/DownloadStoreStatus`로 명확히 분리했습니다.
- `src/cli/commands/download.ts`는 `DownloadCommandOptions`, `src/core/shared/file-utils.ts`는 `FileDownloadOptions`, `src/core/downloaders/os-shared/base-downloader.ts`는 `OSPackageDownloadResult`를 사용하도록 정리했습니다.
- 관련 테스트와 문서를 함께 갱신했습니다.

## 검증
- `npx tsc --noEmit`
- `npm run lint` (`0 error`, 기존 전역 경고 `601`건 유지)
- `bash scripts/verify-worktree.sh` (`1537 passed`, `186 skipped`)

## 문서
- `docs/architecture-overview.md`
- `docs/coding-conventions.md`
- `docs/shared-file-path.md`
- `docs/shared-types.md`
