### PR TITLE
Phase 4: core package port 경계 도입

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -35,6 +35,7 @@ depssmuggler/
 │   ├── core/
 │   │   ├── downloaders/
 │   │   ├── downloaders/os-shared/
+│   │   ├── ports/
 │   │   ├── resolver/
 │   │   ├── packager/
 │   │   ├── mailer/
@@ -85,6 +86,7 @@ depssmuggler/
 
 - `downloaders/`: 패키지 타입별 검색/다운로드 구현
 - `downloaders/os-shared/`: YUM/APT/APK 공용 저장소, 캐시, 스크립트, 아카이브, 로컬 저장소 패키징
+- `ports/`: downloader와 resolver 사이에 두는 패키지 메타데이터/파일 fetch 경계. orchestration 계층이 구현체를 조합합니다.
 - `resolver/`: 타입별 의존성 계산
 - `packager/`: 일반 패키지용 아카이브/스크립트/분할 처리
 - `mailer/`: SMTP 발송
@@ -104,6 +106,7 @@ depssmuggler/
 |------|----------------|------|
 | 일반 다운로드 | `src/core/downloaders/*.ts` | `pip`, `conda`, `maven`, `npm`, `docker`, `yum`, `apt`, `apk` |
 | OS 공용 기능 | `src/core/downloaders/os-shared/*` | 저장소 프리셋, GPG, 로컬 repo 패키징 |
+| Core 경계 포트 | `src/core/ports/*` | package metadata 조회, package fetch 스트림 |
 | 의존성 해결 | `src/core/resolver/*.ts` | `pip`, `conda`, `maven`, `npm`, `yum`, `apt`, `apk` |
 | 공통 의존성 유틸 | `src/core/shared/dependency-resolver.ts` | 타입별 resolver orchestration |
 | 일반 패키징 | `src/core/packager/*` | archive, script, file splitter |

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -4,6 +4,7 @@
 - 목적: 각 패키지 관리자별 패키지 검색 및 다운로드 구현
 - 위치: `src/core/downloaders/`
 - 공통 체크섬 검증은 `src/core/shared/integrity/checksum.ts`를 통해 공유한다. `pip`, `conda`, `maven`, Docker blob 다운로드, 캐시 검증, OS GPG verifier가 이 유틸리티를 재사용한다.
+- Phase 4부터 downloader가 resolver 구현에 직접 기대지 않도록 `src/core/ports/package-metadata-port.ts`, `src/core/ports/package-fetch-port.ts` 경계를 기준으로 점진적으로 정리한다.
 
 ---
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -48,5 +48,8 @@ export { ArtifactCacheManager, CacheManager, getCacheManager } from './cache-man
 export { ConfigManager, getConfigManager } from './config';
 export type { Config, CLIConfig } from './config';
 
+// Ports
+export * from './ports';
+
 // Shared utilities
 export * from './shared';

--- a/src/core/ports/fetch-api-package-fetch-port.test.ts
+++ b/src/core/ports/fetch-api-package-fetch-port.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FetchApiPackageFetchPort } from './fetch-api-package-fetch-port';
+
+async function readStream(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+
+  return await new Promise((resolve, reject) => {
+    stream.on('data', (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    stream.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf-8'));
+    });
+    stream.on('error', reject);
+  });
+}
+
+describe('FetchApiPackageFetchPort', () => {
+  it('GET 응답 body를 Node readable stream으로 변환해야 함', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response('payload-data', {
+        status: 200,
+        headers: {
+          'content-type': 'application/octet-stream',
+        },
+      })
+    );
+
+    const port = new FetchApiPackageFetchPort({
+      fetchImpl,
+      defaultHeaders: {
+        'x-default-header': 'default-value',
+      },
+    });
+
+    const stream = await port.fetchPackageFile({
+      url: 'https://example.com/package.tgz',
+      headers: {
+        authorization: 'Bearer token',
+      },
+    });
+
+    await expect(readStream(stream)).resolves.toBe('payload-data');
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.com/package.tgz', {
+      method: 'GET',
+      headers: {
+        'x-default-header': 'default-value',
+        authorization: 'Bearer token',
+      },
+    });
+  });
+
+  it('HEAD 응답 헤더를 표준 PackageHead로 매핑해야 함', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: {
+          'content-length': '42',
+          'content-type': 'application/gzip',
+          etag: '"abc123"',
+          'last-modified': 'Mon, 21 Apr 2026 10:00:00 GMT',
+        },
+      })
+    );
+
+    const port = new FetchApiPackageFetchPort({ fetchImpl });
+
+    await expect(
+      port.headPackage({
+        url: 'https://example.com/packages/pkg.tar.gz',
+      })
+    ).resolves.toEqual({
+      url: 'https://example.com/packages/pkg.tar.gz',
+      status: 200,
+      contentLength: 42,
+      contentType: 'application/gzip',
+      etag: '"abc123"',
+      lastModified: 'Mon, 21 Apr 2026 10:00:00 GMT',
+      headers: {
+        'content-length': '42',
+        'content-type': 'application/gzip',
+        etag: '"abc123"',
+        'last-modified': 'Mon, 21 Apr 2026 10:00:00 GMT',
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith('https://example.com/packages/pkg.tar.gz', {
+      method: 'HEAD',
+      headers: {},
+    });
+  });
+
+  it('비정상 HTTP 응답이면 에러를 던져야 함', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 404,
+        statusText: 'Not Found',
+      })
+    );
+
+    const port = new FetchApiPackageFetchPort({ fetchImpl });
+
+    await expect(
+      port.fetchPackageFile({
+        url: 'https://example.com/missing.tar.gz',
+      })
+    ).rejects.toThrow('패키지 다운로드 스트림 조회 실패');
+  });
+});

--- a/src/core/ports/fetch-api-package-fetch-port.test.ts
+++ b/src/core/ports/fetch-api-package-fetch-port.test.ts
@@ -17,6 +17,7 @@ async function readStream(stream: NodeJS.ReadableStream): Promise<string> {
 
 describe('FetchApiPackageFetchPort', () => {
   it('GET 응답 body를 Node readable stream으로 변환해야 함', async () => {
+    const controller = new AbortController();
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response('payload-data', {
         status: 200,
@@ -38,6 +39,7 @@ describe('FetchApiPackageFetchPort', () => {
       headers: {
         authorization: 'Bearer token',
       },
+      signal: controller.signal,
     });
 
     await expect(readStream(stream)).resolves.toBe('payload-data');
@@ -47,10 +49,12 @@ describe('FetchApiPackageFetchPort', () => {
         'x-default-header': 'default-value',
         authorization: 'Bearer token',
       },
+      signal: controller.signal,
     });
   });
 
   it('HEAD 응답 헤더를 표준 PackageHead로 매핑해야 함', async () => {
+    const controller = new AbortController();
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(null, {
         status: 200,
@@ -68,6 +72,7 @@ describe('FetchApiPackageFetchPort', () => {
     await expect(
       port.headPackage({
         url: 'https://example.com/packages/pkg.tar.gz',
+        signal: controller.signal,
       })
     ).resolves.toEqual({
       url: 'https://example.com/packages/pkg.tar.gz',
@@ -86,6 +91,7 @@ describe('FetchApiPackageFetchPort', () => {
     expect(fetchImpl).toHaveBeenCalledWith('https://example.com/packages/pkg.tar.gz', {
       method: 'HEAD',
       headers: {},
+      signal: controller.signal,
     });
   });
 

--- a/src/core/ports/fetch-api-package-fetch-port.ts
+++ b/src/core/ports/fetch-api-package-fetch-port.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import { PackageFetchPort, PackageHead, PackageRef } from './package-fetch-port';
+import type { ReadableStream as WebReadableStream } from 'stream/web';
 
 type FetchLike = typeof fetch;
 
@@ -32,7 +33,7 @@ export class FetchApiPackageFetchPort implements PackageFetchPort {
       throw new Error(`패키지 다운로드 스트림이 비어 있습니다: ${ref.url}`);
     }
 
-    return Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>);
+    return Readable.fromWeb(response.body as WebReadableStream<Uint8Array>);
   }
 
   async headPackage(ref: PackageRef): Promise<PackageHead> {
@@ -74,6 +75,12 @@ export class FetchApiPackageFetchPort implements PackageFetchPort {
   }
 
   private toHeaderMap(headers: Headers): Record<string, string> {
-    return Object.fromEntries(headers.entries());
+    const mapped: Record<string, string> = {};
+
+    headers.forEach((value, key) => {
+      mapped[key] = value;
+    });
+
+    return mapped;
   }
 }

--- a/src/core/ports/fetch-api-package-fetch-port.ts
+++ b/src/core/ports/fetch-api-package-fetch-port.ts
@@ -21,6 +21,7 @@ export class FetchApiPackageFetchPort implements PackageFetchPort {
     const response = await this.fetchImpl(ref.url, {
       method: 'GET',
       headers: this.createHeaders(ref.headers),
+      signal: ref.signal,
     });
 
     if (!response.ok) {
@@ -38,6 +39,7 @@ export class FetchApiPackageFetchPort implements PackageFetchPort {
     const response = await this.fetchImpl(ref.url, {
       method: 'HEAD',
       headers: this.createHeaders(ref.headers),
+      signal: ref.signal,
     });
 
     if (!response.ok) {

--- a/src/core/ports/fetch-api-package-fetch-port.ts
+++ b/src/core/ports/fetch-api-package-fetch-port.ts
@@ -1,0 +1,77 @@
+import { Readable } from 'stream';
+import { PackageFetchPort, PackageHead, PackageRef } from './package-fetch-port';
+
+type FetchLike = typeof fetch;
+
+export interface FetchApiPackageFetchPortOptions {
+  fetchImpl?: FetchLike;
+  defaultHeaders?: Record<string, string>;
+}
+
+export class FetchApiPackageFetchPort implements PackageFetchPort {
+  private readonly fetchImpl: FetchLike;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(options: FetchApiPackageFetchPortOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultHeaders = options.defaultHeaders ?? {};
+  }
+
+  async fetchPackageFile(ref: PackageRef): Promise<NodeJS.ReadableStream> {
+    const response = await this.fetchImpl(ref.url, {
+      method: 'GET',
+      headers: this.createHeaders(ref.headers),
+    });
+
+    if (!response.ok) {
+      throw new Error(`패키지 다운로드 스트림 조회 실패: ${response.status} ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error(`패키지 다운로드 스트림이 비어 있습니다: ${ref.url}`);
+    }
+
+    return Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>);
+  }
+
+  async headPackage(ref: PackageRef): Promise<PackageHead> {
+    const response = await this.fetchImpl(ref.url, {
+      method: 'HEAD',
+      headers: this.createHeaders(ref.headers),
+    });
+
+    if (!response.ok) {
+      throw new Error(`패키지 HEAD 조회 실패: ${response.status} ${response.statusText}`);
+    }
+
+    return {
+      url: ref.url,
+      status: response.status,
+      contentLength: this.parseContentLength(response.headers.get('content-length')),
+      contentType: response.headers.get('content-type') ?? undefined,
+      etag: response.headers.get('etag') ?? undefined,
+      lastModified: response.headers.get('last-modified') ?? undefined,
+      headers: this.toHeaderMap(response.headers),
+    };
+  }
+
+  private createHeaders(headers?: Record<string, string>): Record<string, string> {
+    return {
+      ...this.defaultHeaders,
+      ...(headers ?? {}),
+    };
+  }
+
+  private parseContentLength(value: string | null): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  private toHeaderMap(headers: Headers): Record<string, string> {
+    return Object.fromEntries(headers.entries());
+  }
+}

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -1,0 +1,3 @@
+export * from './fetch-api-package-fetch-port';
+export * from './package-fetch-port';
+export * from './package-metadata-port';

--- a/src/core/ports/package-fetch-port.ts
+++ b/src/core/ports/package-fetch-port.ts
@@ -2,6 +2,7 @@ export interface PackageRef {
   url: string;
   filename?: string;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/core/ports/package-fetch-port.ts
+++ b/src/core/ports/package-fetch-port.ts
@@ -1,0 +1,21 @@
+export interface PackageRef {
+  url: string;
+  filename?: string;
+  headers?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PackageHead {
+  url: string;
+  status: number;
+  contentLength?: number;
+  contentType?: string;
+  etag?: string;
+  lastModified?: string;
+  headers: Record<string, string>;
+}
+
+export interface PackageFetchPort {
+  fetchPackageFile(ref: PackageRef): Promise<NodeJS.ReadableStream>;
+  headPackage(ref: PackageRef): Promise<PackageHead>;
+}

--- a/src/core/ports/package-metadata-port.ts
+++ b/src/core/ports/package-metadata-port.ts
@@ -21,7 +21,7 @@ export interface PackageArtifact {
   metadata?: Record<string, unknown>;
 }
 
-export interface PackageManifest {
+export interface PackageMetadataManifest {
   name: string;
   version: string;
   summary?: string;
@@ -46,5 +46,5 @@ export interface PackageMetadataPort {
     name: string,
     version: string,
     request?: PackageMetadataRequest
-  ): Promise<PackageManifest>;
+  ): Promise<PackageMetadataManifest>;
 }

--- a/src/core/ports/package-metadata-port.ts
+++ b/src/core/ports/package-metadata-port.ts
@@ -1,0 +1,50 @@
+export interface PackageChecksum {
+  algorithm: string;
+  digest: string;
+}
+
+export interface VersionInfo {
+  version: string;
+  publishedAt?: string;
+  yanked?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PackageArtifact {
+  filename: string;
+  url: string;
+  kind: 'archive' | 'binary' | 'metadata' | 'package' | 'sdist' | 'wheel';
+  size?: number;
+  checksums?: PackageChecksum[];
+  requiresPython?: string;
+  yanked?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PackageManifest {
+  name: string;
+  version: string;
+  summary?: string;
+  description?: string;
+  author?: string;
+  license?: string;
+  homepage?: string;
+  artifacts: PackageArtifact[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface PackageMetadataRequest {
+  registryUrl?: string;
+  indexUrl?: string;
+  headers?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PackageMetadataPort {
+  fetchVersions(name: string, request?: PackageMetadataRequest): Promise<VersionInfo[]>;
+  fetchManifest(
+    name: string,
+    version: string,
+    request?: PackageMetadataRequest
+  ): Promise<PackageManifest>;
+}

--- a/src/core/ports/package-metadata-port.ts
+++ b/src/core/ports/package-metadata-port.ts
@@ -37,6 +37,7 @@ export interface PackageMetadataRequest {
   registryUrl?: string;
   indexUrl?: string;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## 요약
- `src/core/ports/`에 package metadata/package fetch 경계 타입을 추가했습니다.
- 기본 HTTP 기반 `FetchApiPackageFetchPort`와 회귀 테스트를 추가했습니다.
- 아키텍처/다운로더 문서에 새 경계 레이어를 반영했습니다.

## 배경
- Phase 4에서 downloader와 resolver 사이의 직접 import를 제거하려면 먼저 공통 포트 타입과 기본 fetch adapter가 필요합니다.
- 기존 호출 경로를 바로 바꾸기 전에 타입 경계를 먼저 고정해 두어 다음 PR들의 영향 범위를 줄이려는 목적입니다.

## 변경 사항
- `PackageMetadataPort`, `PackageFetchPort`, 관련 canonical 타입 추가
- `FetchApiPackageFetchPort` 추가 및 stream/head 동작 테스트 추가
- `src/core/index.ts`에서 ports export 추가
- 관련 문서 업데이트

## 검증
- `bash scripts/verify-worktree.sh src/core/ports/fetch-api-package-fetch-port.test.ts`
- `npx tsc --noEmit -p tsconfig.electron.json`
- `npx eslint src/core/ports src/core/index.ts`

## 문서
- `docs/architecture-overview.md`
- `docs/downloaders.md`
