### PR TITLE
Phase 5: downloader registry 단일화

### DIFF
--- a/docs/downloader-factory.md
+++ b/docs/downloader-factory.md
@@ -3,6 +3,7 @@
 ## 개요
 - 목적: 패키지 타입별 다운로더 인스턴스를 중앙에서 관리하는 레지스트리 패턴 구현
 - 위치: `src/core/downloaders/factory.ts`
+- 기본 downloader 정의 위치: `src/core/downloaders/registry.ts`
 
 ---
 
@@ -11,7 +12,7 @@
 기존에는 각 다운로더가 개별 싱글톤 패턴으로 구현되어 있었으나, 테스트 시 모킹이 어렵고 인스턴스 관리가 분산되어 있었음. Factory 패턴을 도입하여:
 - 중앙 집중식 다운로더 관리
 - 테스트 시 쉬운 모킹/오버라이드 지원
-- 지연 초기화(lazy initialization) 지원
+- downloader 등록의 단일 진실 유지
 
 ---
 
@@ -59,6 +60,14 @@
 | `registerDownloader(type, creator)` | 다운로더 생성자 등록 |
 | `initializeDownloaders()` | 모든 기본 다운로더 등록 |
 | `resetDownloaderRegistry()` | 레지스트리 초기화 |
+
+### 기본 downloader registry
+
+`src/core/downloaders/registry.ts`는 기본 downloader 타입과 creator를 한 곳에서 정의합니다.
+
+- `getRegisteredDownloaderTypes()`는 등록 대상 타입 목록을 반환합니다.
+- `createRegisteredDownloader(type)`는 registry에 정의된 creator로 downloader를 생성합니다.
+- `registerDefaultDownloaderCreators(register)`는 factory가 기본 creator를 내부 레지스트리에 복사할 때 사용합니다.
 
 ### 테스트 헬퍼 함수
 
@@ -131,7 +140,7 @@ const downloader = await getDownloaderAsync('npm');
 
 ## 등록되는 기본 다운로더
 
-`initializeDownloaders()` 호출 시 등록되는 다운로더:
+`initializeDownloaders()` 호출 시 `registry.ts`를 통해 등록되는 다운로더:
 
 | 타입 | 다운로더 클래스 | 설명 |
 |------|----------------|------|
@@ -140,9 +149,8 @@ const downloader = await getDownloaderAsync('npm');
 | `maven` | MavenDownloader | Maven Central 아티팩트 |
 | `npm` | NpmDownloader | npm 패키지 |
 | `docker` | DockerDownloader | Docker 이미지 |
-| `yum` | YumDownloader | YUM/RPM 패키지 |
-| `apt` | AptDownloader | APT/DEB 패키지 |
-| `apk` | ApkDownloader | Alpine APK 패키지 |
+
+`yum`, `apt`, `apk`는 별도의 OS 패키지 downloader 경로에서 옵션과 함께 생성되므로 이 기본 registry에는 포함되지 않습니다.
 
 ---
 

--- a/src/core/download-manager.test.ts
+++ b/src/core/download-manager.test.ts
@@ -30,7 +30,7 @@ interface DownloadManagerTestable {
   speedCalculator: SpeedCalculator;
   createResult: () => DownloadManagerResult;
   updateItemProgress: (id: string, event: DownloadProgressEvent) => void;
-  initDownloaders: () => Promise<void>;
+  initDownloaders: () => void;
 }
 
 /**
@@ -582,10 +582,9 @@ describe('DownloadManager 단위 테스트', () => {
   });
 
   describe('initDownloaders', () => {
-    it('다운로더 초기화 호출', async () => {
+    it('다운로더 초기화 호출', () => {
       const manager = createManager();
-      // initDownloaders는 private async 메서드이므로 직접 호출
-      await asTestable(manager).initDownloaders();
+      asTestable(manager).initDownloaders();
 
       // 다운로더가 설정되었는지 확인 (에러 없이 완료)
       expect(asTestable(manager).downloaders).toBeDefined();

--- a/src/core/download-manager.ts
+++ b/src/core/download-manager.ts
@@ -3,12 +3,7 @@ import * as fs from 'fs-extra';
 import PQueue from 'p-queue';
 import logger from '../utils/logger';
 import { DOWNLOAD_CONSTANTS } from './constants/download';
-// 다운로더 가져오기
-import { getCondaDownloader } from './downloaders/conda';
-import { getDockerDownloader } from './downloaders/docker';
-import { getMavenDownloader } from './downloaders/maven';
-import { getNpmDownloader } from './downloaders/npm';
-import { getPipDownloader } from './downloaders/pip';
+import { createRegisteredDownloader, getRegisteredDownloaderTypes } from './downloaders/registry';
 import { SpeedCalculator } from './speed-calculator';
 import type {
   PackageInfo,
@@ -105,12 +100,9 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
    * 다운로더 초기화
    */
   private initDownloaders(): void {
-    this.downloaders.set('pip', getPipDownloader());
-    this.downloaders.set('conda', getCondaDownloader());
-    this.downloaders.set('maven', getMavenDownloader());
-    // yum, apt, apk는 별도의 OS 패키지 다운로더로 처리됨
-    this.downloaders.set('docker', getDockerDownloader());
-    this.downloaders.set('npm', getNpmDownloader());
+    for (const type of getRegisteredDownloaderTypes()) {
+      this.downloaders.set(type, createRegisteredDownloader(type));
+    }
   }
 
   /**

--- a/src/core/downloaders/factory.test.ts
+++ b/src/core/downloaders/factory.test.ts
@@ -14,7 +14,8 @@ import {
   initializeDownloaders,
   getDownloaderAsync,
 } from './factory';
-import { IDownloader, PackageType, PackageInfo, DownloadProgressEvent } from '../../types';
+import { getRegisteredDownloaderTypes } from './registry';
+import { IDownloader, PackageType, PackageInfo } from '../../types';
 
 // 테스트용 Mock 다운로더 생성
 function createMockDownloader(type: PackageType): IDownloader {
@@ -231,12 +232,7 @@ describe('initializeDownloaders & getDownloaderAsync', () => {
     const registry = getDownloaderRegistry();
     const types = registry.getRegisteredTypes();
 
-    expect(types).toContain('pip');
-    expect(types).toContain('conda');
-    expect(types).toContain('maven');
-    expect(types).toContain('npm');
-    expect(types).toContain('docker');
-    // yum, apt, apk는 별도의 OS 패키지 다운로더로 처리되므로 factory에 등록되지 않음
+    expect(types).toEqual(getRegisteredDownloaderTypes());
   });
 
   it('getDownloaderAsync가 자동으로 초기화해야 함', async () => {
@@ -245,6 +241,15 @@ describe('initializeDownloaders & getDownloaderAsync', () => {
 
     expect(downloader).toBeDefined();
     expect(downloader.type).toBe('pip');
+  });
+
+  it('수동 등록된 creator가 있으면 기본 registry로 덮어쓰지 않아야 함', async () => {
+    const customPip = createMockDownloader('pip');
+    registerDownloader('pip', () => customPip);
+
+    const downloader = await getDownloaderAsync('pip');
+
+    expect(downloader).toBe(customPip);
   });
 
   it('이미 초기화된 경우 다시 초기화하지 않아야 함', async () => {

--- a/src/core/downloaders/factory.ts
+++ b/src/core/downloaders/factory.ts
@@ -3,10 +3,12 @@
  * 테스트 용이성을 위해 의존성 주입을 지원하는 팩토리 패턴 구현
  */
 
+import {
+  type DownloaderCreator,
+  isRegisteredDownloaderType,
+  registerDefaultDownloaderCreators,
+} from './registry';
 import { IDownloader, PackageType } from '../../types';
-
-// 다운로더 생성 함수 타입
-type DownloaderCreator = () => IDownloader;
 
 /**
  * 다운로더 레지스트리
@@ -204,33 +206,17 @@ export function resetDownloaderRegistry(): void {
 }
 
 /**
- * 모든 다운로더 등록 (지연 로딩)
- * 앱 시작 시 또는 첫 다운로더 요청 시 호출
+ * 기본 다운로더 등록
+ * downloader registry를 단일 진실로 사용한다.
  */
 export async function initializeDownloaders(): Promise<void> {
   if (initialized) return;
 
-  // 동적 import로 순환 참조 방지
-  const [
-    { PipDownloader },
-    { CondaDownloader },
-    { MavenDownloader },
-    { NpmDownloader },
-    { DockerDownloader },
-  ] = await Promise.all([
-    import('./pip'),
-    import('./conda'),
-    import('./maven'),
-    import('./npm'),
-    import('./docker'),
-  ]);
-
-  registry.registerCreator('pip', () => new PipDownloader());
-  registry.registerCreator('conda', () => new CondaDownloader());
-  registry.registerCreator('maven', () => new MavenDownloader());
-  registry.registerCreator('npm', () => new NpmDownloader());
-  registry.registerCreator('docker', () => new DockerDownloader());
-  // yum, apt, apk는 별도의 OS 패키지 다운로더로 처리됨
+  registerDefaultDownloaderCreators((type, creator) => {
+    if (!registry.has(type)) {
+      registry.registerCreator(type, creator);
+    }
+  });
 
   initialized = true;
 }
@@ -240,7 +226,7 @@ export async function initializeDownloaders(): Promise<void> {
  * 초기화되지 않았으면 자동으로 초기화 후 반환
  */
 export async function getDownloaderAsync(type: PackageType): Promise<IDownloader> {
-  if (!initialized && !registry.has(type)) {
+  if (!initialized && isRegisteredDownloaderType(type) && !registry.has(type)) {
     await initializeDownloaders();
   }
   return registry.get(type);

--- a/src/core/downloaders/registry.test.ts
+++ b/src/core/downloaders/registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRegisteredDownloader,
+  getRegisteredDownloaderTypes,
+  isRegisteredDownloaderType,
+} from './registry';
+
+describe('downloaders registry', () => {
+  it('기본 downloader 타입 목록을 단일 진실로 제공해야 함', () => {
+    expect(getRegisteredDownloaderTypes()).toEqual([
+      'pip',
+      'conda',
+      'maven',
+      'npm',
+      'docker',
+    ]);
+  });
+
+  it.each(getRegisteredDownloaderTypes())(
+    '%s creator가 해당 타입의 downloader를 생성해야 함',
+    (type) => {
+      const downloader = createRegisteredDownloader(type);
+
+      expect(downloader.type).toBe(type);
+    }
+  );
+
+  it('등록 여부를 타입 가드로 확인할 수 있어야 함', () => {
+    expect(isRegisteredDownloaderType('pip')).toBe(true);
+    expect(isRegisteredDownloaderType('apt')).toBe(false);
+  });
+});

--- a/src/core/downloaders/registry.ts
+++ b/src/core/downloaders/registry.ts
@@ -1,0 +1,50 @@
+import { getCondaDownloader } from './conda';
+import { getDockerDownloader } from './docker';
+import { getMavenDownloader } from './maven';
+import { getNpmDownloader } from './npm';
+import { getPipDownloader } from './pip';
+import type { IDownloader, PackageType } from '../../types';
+
+export type DownloaderCreator = () => IDownloader;
+
+export type RegisteredDownloaderType = Extract<
+  PackageType,
+  'pip' | 'conda' | 'maven' | 'npm' | 'docker'
+>;
+
+const defaultDownloaderCreators = new Map<RegisteredDownloaderType, DownloaderCreator>([
+  ['pip', getPipDownloader],
+  ['conda', getCondaDownloader],
+  ['maven', getMavenDownloader],
+  ['npm', getNpmDownloader],
+  ['docker', getDockerDownloader],
+]);
+
+export function getRegisteredDownloaderTypes(): RegisteredDownloaderType[] {
+  return Array.from(defaultDownloaderCreators.keys());
+}
+
+export function isRegisteredDownloaderType(type: PackageType): type is RegisteredDownloaderType {
+  return defaultDownloaderCreators.has(type as RegisteredDownloaderType);
+}
+
+export function getRegisteredDownloaderCreator(type: RegisteredDownloaderType): DownloaderCreator {
+  const creator = defaultDownloaderCreators.get(type);
+  if (!creator) {
+    throw new Error(`기본 다운로더가 등록되지 않았습니다: ${type}`);
+  }
+
+  return creator;
+}
+
+export function createRegisteredDownloader(type: RegisteredDownloaderType): IDownloader {
+  return getRegisteredDownloaderCreator(type)();
+}
+
+export function registerDefaultDownloaderCreators(
+  register: (type: RegisteredDownloaderType, creator: DownloaderCreator) => void
+): void {
+  for (const [type, creator] of defaultDownloaderCreators) {
+    register(type, creator);
+  }
+}


### PR DESCRIPTION
## 요약
- `src/core/downloaders/registry.ts`를 추가해 기본 downloader 타입과 creator를 한 곳에 모았습니다.
- `factory.ts`가 동적 import 하드코딩 대신 registry를 통해 기본 creator를 등록하도록 바꿨습니다.
- `download-manager.ts`가 개별 `getXDownloader()` import 대신 registry 기반 초기화를 사용하도록 정리했습니다.
- downloader factory 문서를 현재 구조에 맞게 갱신했습니다.

## 검증
- `bash scripts/verify-worktree.sh src/core/downloaders/registry.test.ts src/core/downloaders/factory.test.ts src/core/download-manager.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/core/downloaders/registry.ts src/core/downloaders/registry.test.ts src/core/downloaders/factory.ts src/core/downloaders/factory.test.ts src/core/download-manager.ts src/core/download-manager.test.ts`
