### PR TITLE
Phase 6: 언어 패키지 공통 다운로드 레이어 1차 추출

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -34,6 +34,7 @@ depssmuggler/
 │   │   └── commands/
 │   ├── core/
 │   │   ├── downloaders/
+│   │   ├── downloaders/lang-shared/
 │   │   ├── downloaders/os-shared/
 │   │   ├── ports/
 │   │   ├── resolver/
@@ -85,6 +86,7 @@ depssmuggler/
 ### 4. Core (`src/core`)
 
 - `downloaders/`: 패키지 타입별 검색/다운로드 구현
+- `downloaders/lang-shared/`: 언어 패키지 downloader가 공유하는 스트림 저장, 진행률 계산, 파일명 정규화, 검증 실패 정리 계층
 - `downloaders/os-shared/`: YUM/APT/APK 공용 저장소, 캐시, 스크립트, 아카이브, 로컬 저장소 패키징
 - `ports/`: downloader와 resolver 사이에 두는 패키지 메타데이터/파일 fetch 경계. orchestration 계층이 구현체를 조합합니다.
 - `resolver/`: 타입별 의존성 계산
@@ -105,6 +107,7 @@ depssmuggler/
 | 영역 | 현재 구현 위치 | 비고 |
 |------|----------------|------|
 | 일반 다운로드 | `src/core/downloaders/*.ts` | `pip`, `conda`, `maven`, `npm`, `docker`, `yum`, `apt`, `apk` |
+| 언어 downloader 공용 레이어 | `src/core/downloaders/lang-shared/*` | 현재 `pip`, `conda`, `npm`이 공통 artifact 저장 로직을 재사용 |
 | OS 공용 기능 | `src/core/downloaders/os-shared/*` | 저장소 프리셋, GPG, 로컬 repo 패키징 |
 | Core 경계 포트 | `src/core/ports/*` | package metadata 조회, package fetch 스트림 |
 | 의존성 해결 | `src/core/resolver/*.ts` | `pip`, `conda`, `maven`, `npm`, `yum`, `apt`, `apk` |

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -4,6 +4,7 @@
 - 목적: 각 패키지 관리자별 패키지 검색 및 다운로드 구현
 - 위치: `src/core/downloaders/`
 - 공통 체크섬 검증은 `src/core/shared/integrity/checksum.ts`를 통해 공유한다. `pip`, `conda`, `maven`, Docker blob 다운로드, 캐시 검증, OS GPG verifier가 이 유틸리티를 재사용한다.
+- Phase 6부터 `src/core/downloaders/lang-shared/base-language-downloader.ts`가 언어 패키지 공통 다운로드 레이어를 제공한다. 현재 `pip`, `conda`, `npm`이 스트림 저장, 진행률 계산, 파일명 정규화, 검증 실패 시 정리 로직을 공유하고, `maven`은 후속 slice에서 정렬한다.
 - Phase 4부터 downloader가 resolver 구현에 직접 기대지 않도록 `src/core/ports/package-metadata-port.ts`, `src/core/ports/package-fetch-port.ts` 경계를 기준으로 점진적으로 정리한다.
 
 ---
@@ -14,6 +15,7 @@
 - 목적: PyPI 패키지 검색 및 다운로드
 - 위치: `src/core/downloaders/pip.ts`
 - 커스텀 인덱스용 Simple API 조회는 `src/core/shared/pip-simple-api-client.ts`를 재사용한다.
+- 파일 저장과 진행률 이벤트 생성은 `BaseLanguageDownloader`가 담당하고, `PipDownloader`는 release 선택과 SHA256 검증 기준을 제공한다.
 
 ### 클래스 구조
 
@@ -74,6 +76,7 @@ const result = await downloader.downloadPackage('numpy', '1.26.0', '/tmp/downloa
 ### 개요
 - 목적: Anaconda/Conda-forge 패키지 검색 및 다운로드
 - 위치: `src/core/downloaders/conda.ts`
+- 파일 저장과 진행률 이벤트 생성은 `BaseLanguageDownloader`가 담당하고, `CondaDownloader`는 repodata 기반 파일 선택과 MD5/SHA256 검증 기준을 제공한다.
 
 ### 클래스 구조
 
@@ -202,6 +205,7 @@ const valid = await downloader.verifyChecksum(result.filePath, result.sha256);
 ### 개요
 - 목적: Maven Central 아티팩트 검색 및 다운로드
 - 위치: `src/core/downloaders/maven.ts`
+- 현재는 jar/pom/checksum을 함께 내려받는 Maven 전용 흐름을 유지한다. 공통 artifact 저장 로직 정리는 후속 Phase 6 slice에서 진행한다.
 
 ### 클래스 구조
 
@@ -580,6 +584,7 @@ const versions = await downloader.getVersions('nginx');
 - 목적: npm 패키지 검색 및 다운로드
 - 위치: `src/core/downloaders/npm.ts`
 - 버전 스펙 해석과 packument 조회는 `src/core/shared/npm-version-resolver.ts`를 재사용한다.
+- tarball 저장과 진행률 이벤트 생성은 `BaseLanguageDownloader`가 담당하고, `NpmDownloader`는 packument 해석과 integrity/sha1 검증 기준을 제공한다.
 
 ### 클래스 구조
 

--- a/src/core/downloaders/conda.ts
+++ b/src/core/downloaders/conda.ts
@@ -1,6 +1,4 @@
-import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
-import * as fs from 'fs-extra';
 import {
   IDownloader,
   PackageInfo,
@@ -17,6 +15,7 @@ import {
   CondaSearchResult,
   CondaPackageFile,
 } from '../shared/conda-types';
+import { BaseLanguageDownloader } from './lang-shared/base-language-downloader';
 import { verifyFileChecksum } from '../shared/integrity/checksum';
 
 // CondaPackageInfo는 downloader 전용 (files, versions 등 추가 필드 포함)
@@ -36,7 +35,7 @@ interface CondaPackageInfo {
 // 지원 채널
 type CondaChannel = 'conda-forge' | 'main' | 'anaconda' | 'defaults' | string;
 
-export class CondaDownloader implements IDownloader {
+export class CondaDownloader extends BaseLanguageDownloader implements IDownloader {
   readonly type = 'conda' as const;
   private client: AxiosInstance;
   private readonly apiUrl = 'https://api.anaconda.org';
@@ -46,6 +45,7 @@ export class CondaDownloader implements IDownloader {
   private repodataCache: Map<string, RepoData> = new Map();
 
   constructor() {
+    super();
     this.client = axios.create({
       timeout: 600000, // 10분
       headers: {
@@ -61,8 +61,9 @@ export class CondaDownloader implements IDownloader {
     const cacheKey = `${channel}/${subdir}`;
 
     // 메모리 캐시 확인 (세션 내 재사용)
-    if (this.repodataCache.has(cacheKey)) {
-      return this.repodataCache.get(cacheKey)!;
+    const cached = this.repodataCache.get(cacheKey);
+    if (cached) {
+      return cached;
     }
 
     // 파일 시스템 캐시 + HTTP 조건부 요청 사용
@@ -93,7 +94,7 @@ export class CondaDownloader implements IDownloader {
     repodata: RepoData,
     name: string,
     version: string,
-    subdir: string
+    _subdir: string
   ): { filename: string; pkg: RepoDataPackage } | null {
     const normalizedName = name.toLowerCase();
 
@@ -369,78 +370,26 @@ export class CondaDownloader implements IDownloader {
         throw new Error(`다운로드 URL을 찾을 수 없습니다: ${info.name}@${info.version}`);
       }
 
-      // 파일명 추출
-      const fileName = path.basename(new URL(downloadUrl).pathname);
-      const filePath = path.join(destPath, fileName);
-
-      // 디렉토리 생성
-      await fs.ensureDir(destPath);
-
       logger.info('Conda 패키지 다운로드 시작', {
         name: info.name,
         version: info.version,
         url: downloadUrl,
-        filePath,
       });
 
-      // 파일 다운로드
-      const response = await axios({
-        method: 'GET',
-        url: downloadUrl,
-        responseType: 'stream',
-        timeout: 300000,
-      });
-
-      const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      let lastBytes = 0;
-      let lastTime = Date.now();
-      let currentSpeed = 0;
-
-      const writer = fs.createWriteStream(filePath);
-
-      response.data.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-
-        // 속도 계산 (0.3초마다)
-        const now = Date.now();
-        const elapsed = (now - lastTime) / 1000;
-        if (elapsed >= 0.3) {
-          currentSpeed = (downloadedBytes - lastBytes) / elapsed;
-          lastBytes = downloadedBytes;
-          lastTime = now;
-        }
-
-        if (onProgress) {
-          onProgress({
-            itemId: `${info.name}@${info.version}`,
-            progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
-            downloadedBytes,
-            totalBytes,
-            speed: currentSpeed,
-          });
-        }
-      });
-
-      response.data.pipe(writer);
-
-      await new Promise<void>((resolve, reject) => {
-        writer.on('finish', resolve);
-        writer.on('error', reject);
-      });
-
-      // 체크섬 검증
-      if (packageInfo.metadata?.checksum?.md5) {
-        const isValid = await this.verifyChecksum(
-          filePath,
-          packageInfo.metadata.checksum.md5,
-          'md5'
-        );
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('체크섬 검증 실패');
-        }
-      }
+      const expectedMd5 = packageInfo.metadata?.checksum?.md5;
+      const filePath = await this.downloadArtifact(
+        destPath,
+        {
+          downloadUrl,
+          itemId: `${info.name}@${info.version}`,
+          timeoutMs: 300000,
+          verifyFile: expectedMd5
+            ? (pathToVerify) => this.verifyChecksum(pathToVerify, expectedMd5, 'md5')
+            : undefined,
+          verificationFailureMessage: expectedMd5 ? '체크섬 검증 실패' : undefined,
+        },
+        onProgress
+      );
 
       logger.info('Conda 패키지 다운로드 완료', {
         name: info.name,

--- a/src/core/downloaders/lang-shared/base-language-downloader.test.ts
+++ b/src/core/downloaders/lang-shared/base-language-downloader.test.ts
@@ -1,0 +1,97 @@
+import * as os from 'os';
+import * as path from 'path';
+import { PassThrough } from 'stream';
+import axios from 'axios';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BaseLanguageDownloader,
+  type LanguageArtifactDownloadPlan,
+} from './base-language-downloader';
+import type { DownloadProgressEvent } from '../../../types';
+
+vi.mock('axios', () => ({
+  default: vi.fn(),
+}));
+
+class TestLanguageDownloader extends BaseLanguageDownloader {
+  async downloadFromPlan(
+    destPath: string,
+    plan: LanguageArtifactDownloadPlan,
+    onProgress?: (progress: DownloadProgressEvent) => void
+  ): Promise<string> {
+    return this.downloadArtifact(destPath, plan, onProgress);
+  }
+}
+
+describe('BaseLanguageDownloader', () => {
+  const downloader = new TestLanguageDownloader();
+  const tempPaths: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await Promise.all(tempPaths.splice(0).map((target) => fs.remove(target)));
+  });
+
+  it('다운로드 파일을 저장하고 progress 이벤트를 전달해야 함', async () => {
+    const stream = new PassThrough();
+    vi.mocked(axios).mockResolvedValue({
+      headers: { 'content-length': '4' },
+      data: stream,
+    } as never);
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-lang-base-'));
+    tempPaths.push(tempDir);
+    const onProgress = vi.fn();
+
+    const downloadPromise = downloader.downloadFromPlan(
+      tempDir,
+      {
+        downloadUrl: 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz',
+        itemId: 'pkg@1.0.0',
+        timeoutMs: 1000,
+      },
+      onProgress
+    );
+
+    stream.write(Buffer.from('test'));
+    stream.end();
+
+    const filePath = await downloadPromise;
+    expect(await fs.readFile(filePath, 'utf8')).toBe('test');
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: 'pkg@1.0.0',
+        downloadedBytes: 4,
+        totalBytes: 4,
+        progress: 100,
+      })
+    );
+  });
+
+  it('검증 실패 시 파일을 삭제하고 예외를 던져야 함', async () => {
+    const stream = new PassThrough();
+    vi.mocked(axios).mockResolvedValue({
+      headers: { 'content-length': '3' },
+      data: stream,
+    } as never);
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-lang-base-'));
+    tempPaths.push(tempDir);
+
+    const downloadPromise = downloader.downloadFromPlan(tempDir, {
+      downloadUrl: 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz',
+      itemId: 'pkg@1.0.0',
+      timeoutMs: 1000,
+      verifyFile: vi.fn().mockResolvedValue(false),
+      verificationFailureMessage: '검증 실패',
+    });
+
+    stream.write(Buffer.from('bad'));
+    stream.end();
+
+    await expect(downloadPromise).rejects.toThrow('검증 실패');
+    const files = await fs.readdir(tempDir);
+    expect(files).toHaveLength(0);
+  });
+});

--- a/src/core/downloaders/lang-shared/base-language-downloader.ts
+++ b/src/core/downloaders/lang-shared/base-language-downloader.ts
@@ -1,0 +1,84 @@
+import * as path from 'path';
+import axios from 'axios';
+import * as fs from 'fs-extra';
+import { sanitizePath } from '../../shared/path-utils';
+import type { DownloadProgressEvent } from '../../../types';
+
+export interface LanguageArtifactDownloadPlan {
+  downloadUrl: string;
+  itemId: string;
+  timeoutMs: number;
+  fileName?: string;
+  verifyFile?: (filePath: string) => Promise<boolean>;
+  verificationFailureMessage?: string;
+}
+
+export abstract class BaseLanguageDownloader {
+  protected async downloadArtifact(
+    destPath: string,
+    plan: LanguageArtifactDownloadPlan,
+    onProgress?: (progress: DownloadProgressEvent) => void
+  ): Promise<string> {
+    const filePath = this.resolveFilePath(plan, destPath);
+
+    await fs.ensureDir(destPath);
+
+    const response = await axios({
+      method: 'GET',
+      url: plan.downloadUrl,
+      responseType: 'stream',
+      timeout: plan.timeoutMs,
+    });
+
+    const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
+    let downloadedBytes = 0;
+    let lastBytes = 0;
+    let lastTime = Date.now();
+    let currentSpeed = 0;
+
+    const writer = fs.createWriteStream(filePath);
+
+    response.data.on('data', (chunk: Buffer) => {
+      downloadedBytes += chunk.length;
+
+      const now = Date.now();
+      const elapsed = (now - lastTime) / 1000;
+      if (elapsed >= 0.3) {
+        currentSpeed = (downloadedBytes - lastBytes) / elapsed;
+        lastBytes = downloadedBytes;
+        lastTime = now;
+      }
+
+      onProgress?.({
+        itemId: plan.itemId,
+        progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
+        downloadedBytes,
+        totalBytes,
+        speed: currentSpeed,
+      });
+    });
+
+    response.data.pipe(writer);
+
+    await new Promise<void>((resolve, reject) => {
+      writer.on('finish', resolve);
+      writer.on('error', reject);
+    });
+
+    if (plan.verifyFile) {
+      const isValid = await plan.verifyFile(filePath);
+      if (!isValid) {
+        await fs.remove(filePath);
+        throw new Error(plan.verificationFailureMessage ?? '다운로드 검증 실패');
+      }
+    }
+
+    return filePath;
+  }
+
+  private resolveFilePath(plan: LanguageArtifactDownloadPlan, destPath: string): string {
+    const rawFileName = plan.fileName ?? path.basename(new URL(plan.downloadUrl).pathname);
+    const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
+    return path.join(destPath, fileName);
+  }
+}

--- a/src/core/downloaders/npm.ts
+++ b/src/core/downloaders/npm.ts
@@ -6,7 +6,6 @@
  */
 
 import * as crypto from 'crypto';
-import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import * as fs from 'fs-extra';
 import * as ssri from 'ssri';
@@ -15,6 +14,7 @@ import {
   IDownloader,
   DownloadProgressEvent,
 } from '../../types';
+import { BaseLanguageDownloader } from './lang-shared/base-language-downloader';
 import logger from '../../utils/logger';
 import { NPM_CONSTANTS } from '../constants/npm';
 import { clearNpmCache } from '../shared/npm-cache';
@@ -24,12 +24,11 @@ import {
   NpmSearchResult,
 } from '../shared/npm-types';
 import { NpmVersionResolver } from '../shared/npm-version-resolver';
-import { sanitizePath } from '../shared/path-utils';
 
 /**
  * npm 다운로더 클래스
  */
-export class NpmDownloader implements IDownloader {
+export class NpmDownloader extends BaseLanguageDownloader implements IDownloader {
   readonly type = 'npm' as const;
   private client: AxiosInstance;
   private readonly registryUrl: string;
@@ -40,6 +39,7 @@ export class NpmDownloader implements IDownloader {
     registryUrl = NPM_CONSTANTS.DEFAULT_REGISTRY_URL,
     searchUrl = NPM_CONSTANTS.DEFAULT_SEARCH_URL
   ) {
+    super();
     this.registryUrl = registryUrl;
     this.searchUrl = searchUrl;
     this.client = axios.create({
@@ -133,7 +133,6 @@ export class NpmDownloader implements IDownloader {
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string> {
     try {
-      // 메타데이터에서 다운로드 URL 획득
       const packageInfo = await this.getPackageMetadata(info.name, info.version);
       const downloadUrl = packageInfo.metadata?.downloadUrl;
 
@@ -141,77 +140,27 @@ export class NpmDownloader implements IDownloader {
         throw new Error(`다운로드 URL을 찾을 수 없습니다: ${info.name}@${info.version}`);
       }
 
-      // 파일명 추출 (경로 조작 방지를 위해 정규화)
-      const rawFileName = path.basename(new URL(downloadUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
-      const filePath = path.join(destPath, fileName);
-
-      // 디렉토리 생성
-      await fs.ensureDir(destPath);
-
-      // 파일 다운로드
-      const response = await axios({
-        method: 'GET',
-        url: downloadUrl,
-        responseType: 'stream',
-        timeout: NPM_CONSTANTS.DOWNLOAD_TIMEOUT_MS,
-      });
-
-      const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      let lastBytes = 0;
-      let lastTime = Date.now();
-      let currentSpeed = 0;
-
-      const writer = fs.createWriteStream(filePath);
-
-      response.data.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-
-        // 속도 계산 (0.3초마다)
-        const now = Date.now();
-        const elapsed = (now - lastTime) / 1000;
-        if (elapsed >= 0.3) {
-          currentSpeed = (downloadedBytes - lastBytes) / elapsed;
-          lastBytes = downloadedBytes;
-          lastTime = now;
-        }
-
-        if (onProgress) {
-          onProgress({
-            itemId: `${info.name}@${info.version}`,
-            progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
-            downloadedBytes,
-            totalBytes,
-            speed: currentSpeed,
-          });
-        }
-      });
-
-      response.data.pipe(writer);
-
-      await new Promise<void>((resolve, reject) => {
-        writer.on('finish', resolve);
-        writer.on('error', reject);
-      });
-
-      // 체크섬 검증
       const expectedIntegrity = packageInfo.metadata?.checksum?.sha512;
       const expectedSha1 = packageInfo.metadata?.checksum?.sha1;
-
-      if (expectedIntegrity) {
-        const isValid = await this.verifyIntegrity(filePath, expectedIntegrity);
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('무결성 검증 실패 (integrity)');
-        }
-      } else if (expectedSha1) {
-        const isValid = await this.verifyShasum(filePath, expectedSha1);
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('체크섬 검증 실패 (sha1)');
-        }
-      }
+      const filePath = await this.downloadArtifact(
+        destPath,
+        {
+          downloadUrl,
+          itemId: `${info.name}@${info.version}`,
+          timeoutMs: NPM_CONSTANTS.DOWNLOAD_TIMEOUT_MS,
+          verifyFile: expectedIntegrity
+            ? (pathToVerify) => this.verifyIntegrity(pathToVerify, expectedIntegrity)
+            : expectedSha1
+              ? (pathToVerify) => this.verifyShasum(pathToVerify, expectedSha1)
+              : undefined,
+          verificationFailureMessage: expectedIntegrity
+            ? '무결성 검증 실패 (integrity)'
+            : expectedSha1
+              ? '체크섬 검증 실패 (sha1)'
+              : undefined,
+        },
+        onProgress
+      );
 
       logger.info('npm 패키지 다운로드 완료', {
         name: info.name,
@@ -240,68 +189,19 @@ export class NpmDownloader implements IDownloader {
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string> {
     try {
-      // 파일명 추출 (경로 조작 방지를 위해 정규화)
-      const rawFileName = path.basename(new URL(tarballUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
-      const filePath = path.join(destPath, fileName);
-
-      await fs.ensureDir(destPath);
-
-      const response = await axios({
-        method: 'GET',
-        url: tarballUrl,
-        responseType: 'stream',
-        timeout: NPM_CONSTANTS.DOWNLOAD_TIMEOUT_MS,
-      });
-
-      const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      let lastBytes = 0;
-      let lastTime = Date.now();
-      let currentSpeed = 0;
-
-      const writer = fs.createWriteStream(filePath);
-
-      response.data.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-
-        // 속도 계산 (0.3초마다)
-        const now = Date.now();
-        const elapsed = (now - lastTime) / 1000;
-        if (elapsed >= 0.3) {
-          currentSpeed = (downloadedBytes - lastBytes) / elapsed;
-          lastBytes = downloadedBytes;
-          lastTime = now;
-        }
-
-        if (onProgress) {
-          onProgress({
-            itemId: tarballUrl,
-            progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
-            downloadedBytes,
-            totalBytes,
-            speed: currentSpeed,
-          });
-        }
-      });
-
-      response.data.pipe(writer);
-
-      await new Promise<void>((resolve, reject) => {
-        writer.on('finish', resolve);
-        writer.on('error', reject);
-      });
-
-      // integrity 검증
-      if (integrity) {
-        const isValid = await this.verifyIntegrity(filePath, integrity);
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('무결성 검증 실패');
-        }
-      }
-
-      return filePath;
+      return await this.downloadArtifact(
+        destPath,
+        {
+          downloadUrl: tarballUrl,
+          itemId: tarballUrl,
+          timeoutMs: NPM_CONSTANTS.DOWNLOAD_TIMEOUT_MS,
+          verifyFile: integrity
+            ? (pathToVerify) => this.verifyIntegrity(pathToVerify, integrity)
+            : undefined,
+          verificationFailureMessage: integrity ? '무결성 검증 실패' : undefined,
+        },
+        onProgress
+      );
     } catch (error) {
       logger.error('tarball 다운로드 실패', { tarballUrl, error });
       throw error;

--- a/src/core/downloaders/pip.ts
+++ b/src/core/downloaders/pip.ts
@@ -1,6 +1,5 @@
-import * as path from 'path';
+/* eslint-disable import/order */
 import axios, { AxiosInstance } from 'axios';
-import * as fs from 'fs-extra';
 import {
   IDownloader,
   PackageInfo,
@@ -8,10 +7,10 @@ import {
   DownloadProgressEvent,
   Architecture,
 } from '../../types';
-import logger from '../../utils/logger';
 import { compareVersions } from '../shared';
+import { BaseLanguageDownloader } from './lang-shared/base-language-downloader';
+import logger from '../../utils/logger';
 import { verifyFileChecksum } from '../shared/integrity/checksum';
-import { sanitizePath } from '../shared/path-utils';
 import {
   fetchPackageFiles,
   extractVersionFromFilename,
@@ -23,14 +22,16 @@ import {
   PyPIResponse,
 } from '../shared/pip-types';
 import type { PipTargetPlatform } from '../../types/platform/pip-target-platform';
+/* eslint-enable import/order */
 
-export class PipDownloader implements IDownloader {
+export class PipDownloader extends BaseLanguageDownloader implements IDownloader {
   readonly type = 'pip' as const;
   private client: AxiosInstance;
   private readonly baseUrl = 'https://pypi.org/pypi';
   private pipTargetPlatform: PipTargetPlatform | null = null;
 
   constructor() {
+    super();
     this.client = axios.create({
       baseURL: this.baseUrl,
       timeout: 30000,
@@ -250,71 +251,20 @@ export class PipDownloader implements IDownloader {
         throw new Error(`다운로드 URL을 찾을 수 없습니다: ${info.name}@${info.version}`);
       }
 
-      // 파일명 추출 (경로 조작 방지를 위해 정규화)
-      const rawFileName = path.basename(new URL(downloadUrl).pathname);
-      const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
-      const filePath = path.join(destPath, fileName);
-
-      // 디렉토리 생성
-      await fs.ensureDir(destPath);
-
-      // 파일 다운로드
-      const response = await axios({
-        method: 'GET',
-        url: downloadUrl,
-        responseType: 'stream',
-        timeout: 300000, // 5분
-      });
-
-      const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      let lastBytes = 0;
-      let lastTime = Date.now();
-      let currentSpeed = 0;
-
-      const writer = fs.createWriteStream(filePath);
-
-      response.data.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-
-        // 속도 계산 (0.3초마다)
-        const now = Date.now();
-        const elapsed = (now - lastTime) / 1000;
-        if (elapsed >= 0.3) {
-          currentSpeed = (downloadedBytes - lastBytes) / elapsed;
-          lastBytes = downloadedBytes;
-          lastTime = now;
-        }
-
-        if (onProgress) {
-          onProgress({
-            itemId: `${info.name}@${info.version}`,
-            progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
-            downloadedBytes,
-            totalBytes,
-            speed: currentSpeed,
-          });
-        }
-      });
-
-      response.data.pipe(writer);
-
-      await new Promise<void>((resolve, reject) => {
-        writer.on('finish', resolve);
-        writer.on('error', reject);
-      });
-
-      // 체크섬 검증
-      if (packageInfo.metadata?.checksum?.sha256) {
-        const isValid = await this.verifyChecksum(
-          filePath,
-          packageInfo.metadata.checksum.sha256
-        );
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('체크섬 검증 실패');
-        }
-      }
+      const expectedSha256 = packageInfo.metadata?.checksum?.sha256;
+      const filePath = await this.downloadArtifact(
+        destPath,
+        {
+          downloadUrl,
+          itemId: `${info.name}@${info.version}`,
+          timeoutMs: 300000,
+          verifyFile: expectedSha256
+            ? (pathToVerify) => this.verifyChecksum(pathToVerify, expectedSha256)
+            : undefined,
+          verificationFailureMessage: expectedSha256 ? '체크섬 검증 실패' : undefined,
+        },
+        onProgress
+      );
 
       logger.info('패키지 다운로드 완료', {
         name: info.name,


### PR DESCRIPTION
## 요약
- 언어 패키지 downloader 공통 artifact 저장 레이어를 추가했습니다.
- `pip`, `conda`, `npm`이 공통 스트림 다운로드/진행률/검증 실패 정리 로직을 재사용하도록 정리했습니다.
- 관련 아키텍처/다운로더 문서를 현재 적용 범위에 맞게 갱신했습니다.

## 배경
- `pip`, `conda`, `npm` downloader가 파일 저장, 진행률 계산, 파일명 정규화, 검증 실패 시 정리 로직을 중복 구현하고 있었습니다.
- Phase 6의 목표는 언어 패키지 downloader의 공통 흐름을 작은 기반 계층으로 추출해 후속 정리를 쉽게 만드는 것입니다.

## 변경 사항
- `src/core/downloaders/lang-shared/base-language-downloader.ts` 추가
- `src/core/downloaders/lang-shared/base-language-downloader.test.ts` 추가
- `src/core/downloaders/pip.ts`를 공통 다운로드 레이어 사용 방식으로 정리
- `src/core/downloaders/conda.ts`를 공통 다운로드 레이어 사용 방식으로 정리
- `src/core/downloaders/npm.ts`와 `downloadTarball`을 공통 다운로드 레이어 사용 방식으로 정리
- `docs/downloaders.md`, `docs/architecture-overview.md` 갱신

## 검증
- `./node_modules/.bin/eslint src/core/downloaders/lang-shared/base-language-downloader.ts src/core/downloaders/lang-shared/base-language-downloader.test.ts src/core/downloaders/npm.ts src/core/downloaders/pip.ts src/core/downloaders/conda.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bash scripts/verify-worktree.sh src/core/downloaders/lang-shared/base-language-downloader.test.ts src/core/downloaders/npm.test.ts src/core/downloaders/pip.test.ts src/core/downloaders/conda.test.ts`
  - `216 passed | 6 skipped`

## 문서
- `docs/downloaders.md`
- `docs/architecture-overview.md`
