### PR TITLE
Phase 6: Maven downloader를 공통 다운로드 레이어로 정렬

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -107,7 +107,7 @@ depssmuggler/
 | 영역 | 현재 구현 위치 | 비고 |
 |------|----------------|------|
 | 일반 다운로드 | `src/core/downloaders/*.ts` | `pip`, `conda`, `maven`, `npm`, `docker`, `yum`, `apt`, `apk` |
-| 언어 downloader 공용 레이어 | `src/core/downloaders/lang-shared/*` | 현재 `pip`, `conda`, `npm`이 공통 artifact 저장 로직을 재사용 |
+| 언어 downloader 공용 레이어 | `src/core/downloaders/lang-shared/*` | 현재 `pip`, `conda`, `npm`, `maven`이 공통 artifact 저장 로직을 재사용 |
 | OS 공용 기능 | `src/core/downloaders/os-shared/*` | 저장소 프리셋, GPG, 로컬 repo 패키징 |
 | Core 경계 포트 | `src/core/ports/*` | package metadata 조회, package fetch 스트림 |
 | 의존성 해결 | `src/core/resolver/*.ts` | `pip`, `conda`, `maven`, `npm`, `yum`, `apt`, `apk` |

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -4,7 +4,7 @@
 - 목적: 각 패키지 관리자별 패키지 검색 및 다운로드 구현
 - 위치: `src/core/downloaders/`
 - 공통 체크섬 검증은 `src/core/shared/integrity/checksum.ts`를 통해 공유한다. `pip`, `conda`, `maven`, Docker blob 다운로드, 캐시 검증, OS GPG verifier가 이 유틸리티를 재사용한다.
-- Phase 6부터 `src/core/downloaders/lang-shared/base-language-downloader.ts`가 언어 패키지 공통 다운로드 레이어를 제공한다. 현재 `pip`, `conda`, `npm`이 스트림 저장, 진행률 계산, 파일명 정규화, 검증 실패 시 정리 로직을 공유하고, `maven`은 후속 slice에서 정렬한다.
+- Phase 6부터 `src/core/downloaders/lang-shared/base-language-downloader.ts`가 언어 패키지 공통 다운로드 레이어를 제공한다. 현재 `pip`, `conda`, `npm`, `maven`이 스트림 저장, 진행률 계산, 파일명 정규화, 검증 실패 시 정리 로직을 공유한다.
 - Phase 4부터 downloader가 resolver 구현에 직접 기대지 않도록 `src/core/ports/package-metadata-port.ts`, `src/core/ports/package-fetch-port.ts` 경계를 기준으로 점진적으로 정리한다.
 
 ---
@@ -205,7 +205,7 @@ const valid = await downloader.verifyChecksum(result.filePath, result.sha256);
 ### 개요
 - 목적: Maven Central 아티팩트 검색 및 다운로드
 - 위치: `src/core/downloaders/maven.ts`
-- 현재는 jar/pom/checksum을 함께 내려받는 Maven 전용 흐름을 유지한다. 공통 artifact 저장 로직 정리는 후속 Phase 6 slice에서 진행한다.
+- artifact/POM 파일 저장과 진행률 이벤트 생성은 `BaseLanguageDownloader`가 담당하고, `MavenDownloader`는 `.m2` 상대 경로 계산과 SHA1 companion checksum 다운로드를 유지한다.
 
 ### 클래스 구조
 

--- a/src/core/downloaders/conda.ts
+++ b/src/core/downloaders/conda.ts
@@ -377,7 +377,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
       });
 
       const expectedMd5 = packageInfo.metadata?.checksum?.md5;
-      const filePath = await this.downloadArtifact(
+      const filePath = await this.downloadArtifactFile(
         destPath,
         {
           downloadUrl,

--- a/src/core/downloaders/lang-shared/base-language-downloader.test.ts
+++ b/src/core/downloaders/lang-shared/base-language-downloader.test.ts
@@ -20,7 +20,7 @@ class TestLanguageDownloader extends BaseLanguageDownloader {
     plan: LanguageArtifactDownloadPlan,
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string> {
-    return this.downloadArtifact(destPath, plan, onProgress);
+    return this.downloadArtifactFile(destPath, plan, onProgress);
   }
 }
 
@@ -93,5 +93,32 @@ describe('BaseLanguageDownloader', () => {
     await expect(downloadPromise).rejects.toThrow('검증 실패');
     const files = await fs.readdir(tempDir);
     expect(files).toHaveLength(0);
+  });
+
+  it('relativeFilePath가 주어지면 중첩 디렉토리 구조로 저장해야 함', async () => {
+    const stream = new PassThrough();
+    vi.mocked(axios).mockResolvedValue({
+      headers: { 'content-length': '4' },
+      data: stream,
+    } as never);
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-lang-base-'));
+    tempPaths.push(tempDir);
+
+    const downloadPromise = downloader.downloadFromPlan(tempDir, {
+      downloadUrl: 'https://repo1.maven.org/maven2/com/example/demo/demo-1.0.0.jar',
+      itemId: 'com.example:demo@1.0.0',
+      timeoutMs: 1000,
+      relativeFilePath: 'com/example/demo/1.0.0/demo-1.0.0.jar',
+    });
+
+    stream.write(Buffer.from('test'));
+    stream.end();
+
+    const filePath = await downloadPromise;
+    expect(filePath).toBe(
+      path.join(tempDir, 'com', 'example', 'demo', '1.0.0', 'demo-1.0.0.jar')
+    );
+    expect(await fs.readFile(filePath, 'utf8')).toBe('test');
   });
 });

--- a/src/core/downloaders/lang-shared/base-language-downloader.ts
+++ b/src/core/downloaders/lang-shared/base-language-downloader.ts
@@ -9,19 +9,20 @@ export interface LanguageArtifactDownloadPlan {
   itemId: string;
   timeoutMs: number;
   fileName?: string;
+  relativeFilePath?: string;
   verifyFile?: (filePath: string) => Promise<boolean>;
   verificationFailureMessage?: string;
 }
 
 export abstract class BaseLanguageDownloader {
-  protected async downloadArtifact(
+  protected async downloadArtifactFile(
     destPath: string,
     plan: LanguageArtifactDownloadPlan,
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string> {
     const filePath = this.resolveFilePath(plan, destPath);
 
-    await fs.ensureDir(destPath);
+    await fs.ensureDir(path.dirname(filePath));
 
     const response = await axios({
       method: 'GET',
@@ -77,6 +78,14 @@ export abstract class BaseLanguageDownloader {
   }
 
   private resolveFilePath(plan: LanguageArtifactDownloadPlan, destPath: string): string {
+    if (plan.relativeFilePath) {
+      const relativePathSegments = plan.relativeFilePath
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .map((segment) => sanitizePath(segment, /[^a-zA-Z0-9._-]/g));
+      return path.join(destPath, ...relativePathSegments);
+    }
+
     const rawFileName = plan.fileName ?? path.basename(new URL(plan.downloadUrl).pathname);
     const fileName = sanitizePath(rawFileName, /[^a-zA-Z0-9._-]/g);
     return path.join(destPath, fileName);

--- a/src/core/downloaders/maven.ts
+++ b/src/core/downloaders/maven.ts
@@ -15,6 +15,7 @@ import {
   retryWithExponentialBackoff,
   isRetryableHttpError,
 } from '../shared/retry-utils';
+import { BaseLanguageDownloader } from './lang-shared/base-language-downloader';
 
 // Maven Central Search API 응답 타입
 interface MavenSearchResponse {
@@ -110,13 +111,14 @@ const VALID_ARTIFACT_TYPES: ArtifactType[] = [
   'bundle', 'rar', 'aar', 'hpi', 'test-jar', 'sources', 'javadoc'
 ];
 
-export class MavenDownloader implements IDownloader {
+export class MavenDownloader extends BaseLanguageDownloader implements IDownloader {
   readonly type = 'maven' as const;
   private client: AxiosInstance;
   private readonly searchUrl = 'https://search.maven.org/solrsearch/select';
   private readonly repoUrl = 'https://repo1.maven.org/maven2';
 
   constructor() {
+    super();
     this.client = axios.create({
       timeout: 30000,
       headers: {
@@ -133,9 +135,11 @@ export class MavenDownloader implements IDownloader {
 
     // coordinates 형식이면 Sonatype API 우선 사용
     if (parsed.type === 'coordinates' && parsed.groupId && parsed.artifactId) {
+      const groupId = parsed.groupId;
+      const artifactId = parsed.artifactId;
       try {
         return await retryWithExponentialBackoff(
-          () => this.searchViaSonatypeApi(parsed.groupId!, parsed.artifactId!),
+          () => this.searchViaSonatypeApi(groupId, artifactId),
           {
             maxRetries: 2,
             delayMs: 1000,
@@ -245,18 +249,23 @@ export class MavenDownloader implements IDownloader {
             }
           );
 
-          return response.data.components
-            .filter((comp) => comp.latestVersionInfo?.version) // 버전이 있는 것만
-            .map((comp) => ({
+          return response.data.components.flatMap((comp) => {
+            const latestVersion = comp.latestVersionInfo?.version;
+            if (!latestVersion) {
+              return [];
+            }
+
+            return [{
               type: 'maven' as const,
               name: `${comp.namespace}:${comp.name}`,
-              version: comp.latestVersionInfo!.version,
+              version: latestVersion,
               metadata: {
                 groupId: comp.namespace,
                 artifactId: comp.name,
                 popularityCount: comp.nsPopularityAppCount,
               },
-            }));
+            }];
+          });
         },
         {
           maxRetries: 2,
@@ -424,7 +433,7 @@ export class MavenDownloader implements IDownloader {
   ): Promise<string> {
     const groupId = (info.metadata?.groupId as string) || info.name.split(':')[0];
     const artifactId = (info.metadata?.artifactId as string) || info.name.split(':')[1];
-    let classifier = info.metadata?.classifier as string | undefined;
+    const classifier = info.metadata?.classifier as string | undefined;
 
     // 네이티브 패키지이고 classifier가 없으면 경고만 표시 (자동 생성하지 않음)
     // 각 라이브러리마다 classifier 형식이 다르므로 (LWJGL: natives-linux, Netty: linux-x86_64)
@@ -547,14 +556,11 @@ export class MavenDownloader implements IDownloader {
     try {
       const downloadUrl = this.buildDownloadUrl(groupId, artifactId, version, artifactType, classifier);
       const fileName = this.buildFileName(artifactId, version, artifactType, classifier);
-      
+
       // .m2 형식의 디렉토리 구조 생성
       const m2SubPath = this.buildM2Path(groupId, artifactId, version);
-      const artifactDir = path.join(destPath, m2SubPath);
-      const filePath = path.join(artifactDir, fileName);
 
-      // 디렉토리 생성
-      await fs.ensureDir(artifactDir);
+      const artifactIdForProgress = `${groupId}:${artifactId}@${version}`;
 
       // SHA-1 체크섬 조회
       let expectedSha1: string | undefined;
@@ -565,60 +571,22 @@ export class MavenDownloader implements IDownloader {
         // 체크섬 없을 수 있음
       }
 
-      // 파일 다운로드
-      const response = await axios({
-        method: 'GET',
-        url: downloadUrl,
-        responseType: 'stream',
-        timeout: 300000,
-      });
+      const verifyFile = expectedSha1 === undefined
+        ? undefined
+        : async (artifactPath: string) => this.verifyChecksum(artifactPath, expectedSha1);
 
-      const totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-      let downloadedBytes = 0;
-      let lastBytes = 0;
-      let lastTime = Date.now();
-      let currentSpeed = 0;
-
-      const writer = fs.createWriteStream(filePath);
-
-      response.data.on('data', (chunk: Buffer) => {
-        downloadedBytes += chunk.length;
-
-        // 속도 계산 (0.3초마다)
-        const now = Date.now();
-        const elapsed = (now - lastTime) / 1000;
-        if (elapsed >= 0.3) {
-          currentSpeed = (downloadedBytes - lastBytes) / elapsed;
-          lastBytes = downloadedBytes;
-          lastTime = now;
-        }
-
-        if (onProgress) {
-          onProgress({
-            itemId: `${groupId}:${artifactId}@${version}`,
-            progress: totalBytes > 0 ? (downloadedBytes / totalBytes) * 100 : 0,
-            downloadedBytes,
-            totalBytes,
-            speed: currentSpeed,
-          });
-        }
-      });
-
-      response.data.pipe(writer);
-
-      await new Promise<void>((resolve, reject) => {
-        writer.on('finish', resolve);
-        writer.on('error', reject);
-      });
-
-      // 체크섬 검증
-      if (expectedSha1) {
-        const isValid = await this.verifyChecksum(filePath, expectedSha1);
-        if (!isValid) {
-          await fs.remove(filePath);
-          throw new Error('체크섬 검증 실패');
-        }
-      }
+      const filePath = await this.downloadArtifactFile(
+        destPath,
+        {
+          downloadUrl,
+          itemId: artifactIdForProgress,
+          timeoutMs: 300000,
+          relativeFilePath: path.posix.join(m2SubPath, fileName),
+          verifyFile,
+          verificationFailureMessage: '체크섬 검증 실패',
+        },
+        onProgress
+      );
 
       logger.info('Maven 아티팩트 다운로드 완료', {
         groupId,

--- a/src/core/downloaders/npm.ts
+++ b/src/core/downloaders/npm.ts
@@ -142,7 +142,7 @@ export class NpmDownloader extends BaseLanguageDownloader implements IDownloader
 
       const expectedIntegrity = packageInfo.metadata?.checksum?.sha512;
       const expectedSha1 = packageInfo.metadata?.checksum?.sha1;
-      const filePath = await this.downloadArtifact(
+      const filePath = await this.downloadArtifactFile(
         destPath,
         {
           downloadUrl,
@@ -189,7 +189,7 @@ export class NpmDownloader extends BaseLanguageDownloader implements IDownloader
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string> {
     try {
-      return await this.downloadArtifact(
+      return await this.downloadArtifactFile(
         destPath,
         {
           downloadUrl: tarballUrl,

--- a/src/core/downloaders/pip.ts
+++ b/src/core/downloaders/pip.ts
@@ -252,7 +252,7 @@ export class PipDownloader extends BaseLanguageDownloader implements IDownloader
       }
 
       const expectedSha256 = packageInfo.metadata?.checksum?.sha256;
-      const filePath = await this.downloadArtifact(
+      const filePath = await this.downloadArtifactFile(
         destPath,
         {
           downloadUrl,


### PR DESCRIPTION
## 요약
- `BaseLanguageDownloader`에 상대 경로 출력 지원을 추가했습니다.
- `MavenDownloader`의 artifact/POM 다운로드를 공통 다운로드 레이어 사용 방식으로 정리했습니다.
- 관련 문서를 현재 Phase 6 적용 범위에 맞게 갱신했습니다.

## 배경
- `maven` downloader는 `.m2` 구조를 만들기 위해 별도 스트림 저장/진행률/검증 로직을 중복 보유하고 있었습니다.
- Phase 6의 목표는 언어 downloader들이 공통 artifact 저장 레이어를 공유하도록 맞추는 것입니다.

## 변경 사항
- `src/core/downloaders/lang-shared/base-language-downloader.ts`
  - `relativeFilePath` 지원 추가
  - 중첩 디렉토리 저장 시 `path.dirname(filePath)` 기준으로 디렉토리 생성
- `src/core/downloaders/maven.ts`
  - `.m2` 상대 경로 계산은 유지하되 실제 파일 저장/진행률/검증 실패 정리는 공통 helper 사용
- `src/core/downloaders/{pip,npm,conda}.ts`
  - 공통 helper 메서드 이름 변경에 맞춘 내부 호출만 정리
- `docs/downloaders.md`, `docs/architecture-overview.md`
  - Maven도 공통 언어 downloader 레이어 사용자로 문서 갱신

## 검증
- `./node_modules/.bin/eslint src/core/downloaders/lang-shared/base-language-downloader.ts src/core/downloaders/lang-shared/base-language-downloader.test.ts src/core/downloaders/maven.ts src/core/downloaders/npm.ts src/core/downloaders/pip.ts src/core/downloaders/conda.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bash scripts/verify-worktree.sh src/core/downloaders/lang-shared/base-language-downloader.test.ts src/core/downloaders/maven.test.ts src/core/downloaders/maven.integration.test.ts src/core/downloaders/npm.test.ts src/core/downloaders/pip.test.ts src/core/downloaders/conda.test.ts`
  - `321 passed | 56 skipped`

## 문서
- `docs/downloaders.md`
- `docs/architecture-overview.md`
