### PR TITLE
Phase 6: Maven cache를 CacheStore 어댑터로 정리

### DIFF
--- a/docs/shared-cache.md
+++ b/docs/shared-cache.md
@@ -218,6 +218,8 @@ interface CacheStoreOptions {
 | Maven | O | O | 메모리 5분, 디스크 24시간 | [shared-maven.md](./shared-maven.md) |
 | Conda | X | O | HTTP Cache-Control 기반 | [shared-conda.md](./shared-conda.md) |
 
+Maven 메모리 캐시와 중복 요청 관리는 `CacheStore<PomCacheEntry>` 어댑터로 통합되고, 디스크 캐시만 Maven 전용 파일 구조를 유지합니다.
+
 ---
 
 ## 캐시 디렉토리 구조
@@ -233,8 +235,8 @@ interface CacheStoreOptions {
 │   └── {groupId}/
 │       └── {artifactId}/
 │           └── {version}/
-│               ├── pom.xml
-│               └── meta.json
+│               ├── {artifactId}-{version}.pom
+│               └── cache-meta.json
 └── conda/
     └── {channel}/
         └── {subdir}/

--- a/docs/shared-maven.md
+++ b/docs/shared-maven.md
@@ -119,7 +119,7 @@ buildMavenClassifier('macos', 'arm64');    // 'osx-aarch_64'
 
 Maven POM 캐싱 (메모리 + 디스크)
 
-MavenResolver와 MavenDownloader가 공유하여 중복 API 호출을 방지합니다.
+MavenResolver와 MavenDownloader가 공유하여 중복 API 호출을 방지합니다. Phase 6 기준으로 메모리 캐시와 중복 요청 관리는 `CacheStore<PomCacheEntry>` 어댑터로 통합하고, 디스크 캐시 디렉토리 구조는 Maven 전용 포맷을 유지합니다.
 
 ### 주요 함수
 
@@ -170,7 +170,11 @@ interface MavenCacheResult {
 ```typescript
 interface MavenCacheStats {
   memoryEntries: number;   // 메모리 캐시 항목 수
+  diskEntries: number;     // 디스크 캐시 파일 수
   pendingRequests: number; // 진행 중인 요청 수
+  oldestEntry: number | null;
+  newestEntry: number | null;
+  diskSize: number;
 }
 ```
 
@@ -182,8 +186,8 @@ interface MavenCacheStats {
 │   └── springframework/
 │       └── spring-core/
 │           └── 5.3.0/
-│               ├── pom.xml
-│               └── meta.json
+│               ├── spring-core-5.3.0.pom
+│               └── cache-meta.json
 └── com/
     └── ...
 ```

--- a/src/core/shared/maven-cache.test.ts
+++ b/src/core/shared/maven-cache.test.ts
@@ -182,6 +182,29 @@ describe('maven-cache', () => {
       // API는 1회만 호출
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
+
+    it('memoryTtl이 다른 동시 요청도 동일한 네트워크 요청을 공유해야 함', async () => {
+      const coord: MavenCoordinate = {
+        groupId: 'org.apache.commons',
+        artifactId: 'commons-lang3',
+        version: '3.12.0',
+      };
+      const mockPomXml = createMockPom(coord.groupId, coord.artifactId, coord.version);
+
+      mockGet.mockImplementation(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve({ data: mockPomXml }), 50))
+      );
+
+      const [first, second] = await Promise.all([
+        fetchPom(coord, { useDiskCache: false, memoryTtl: 60_000 }),
+        fetchPom(coord, { useDiskCache: false, memoryTtl: 300_000 }),
+      ]);
+
+      expect(first.groupId).toBe('org.apache.commons');
+      expect(second.groupId).toBe('org.apache.commons');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('fetchPomsParallel', () => {
@@ -277,6 +300,21 @@ describe('maven-cache', () => {
       await fetchPom(coord, { useDiskCache: false });
 
       expect(isPomCached(coord)).toBe(true);
+    });
+
+    it('custom memoryTtl로 적재한 항목도 기본 helper에서 관찰해야 함', async () => {
+      const coord: MavenCoordinate = {
+        groupId: 'org.springframework',
+        artifactId: 'spring-context',
+        version: '5.3.0',
+      };
+      const mockPomXml = createMockPom(coord.groupId, coord.artifactId, coord.version);
+      mockGet.mockResolvedValueOnce({ data: mockPomXml });
+
+      await fetchPom(coord, { useDiskCache: false, memoryTtl: 60_000 });
+
+      expect(isPomCached(coord)).toBe(true);
+      expect(getPomFromCache(coord)?.artifactId).toBe('spring-context');
     });
   });
 

--- a/src/core/shared/maven-cache.ts
+++ b/src/core/shared/maven-cache.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import { XMLParser } from 'fast-xml-parser';
 import * as fs from 'fs-extra';
-import { createMemoryCache, type CacheStore } from './cache/cache-store';
+import { createMemoryCache } from './cache/cache-store';
 import { PomProject, PomCacheEntry, MavenCoordinate, coordinateToString } from './maven-types';
 import logger from '../../utils/logger';
 
@@ -27,8 +27,8 @@ const DEFAULT_CACHE_DIR = path.join(os.homedir(), '.depssmuggler', 'cache', 'mav
 
 /** 병렬 조회 배치 크기 */
 const DEFAULT_BATCH_SIZE = 5;
-
-const memoryStores: Map<number, CacheStore<PomCacheEntry>> = new Map();
+const MEMORY_STORE_TTL = Number.MAX_SAFE_INTEGER;
+const memoryStore = createMemoryCache<PomCacheEntry>('Maven POM', MEMORY_STORE_TTL);
 
 /**
  * XML 파서 (싱글톤)
@@ -61,17 +61,6 @@ function getClient(repoUrl: string = DEFAULT_REPO_URL): AxiosInstance {
 
 function getCacheKey(coordinate: MavenCoordinate, repoUrl: string): string {
   return `${repoUrl}:${coordinateToString(coordinate)}`;
-}
-
-function getMemoryStore(memoryTtl: number = DEFAULT_MEMORY_TTL): CacheStore<PomCacheEntry> {
-  const existing = memoryStores.get(memoryTtl);
-  if (existing) {
-    return existing;
-  }
-
-  const store = createMemoryCache<PomCacheEntry>('Maven POM', memoryTtl);
-  memoryStores.set(memoryTtl, store);
-  return store;
 }
 
 /**
@@ -217,12 +206,12 @@ export async function fetchPom(
   } = options;
 
   const cacheKey = getCacheKey(coordinate, repoUrl);
-  const memoryStore = getMemoryStore(memoryTtl);
+  const now = Date.now();
 
   // 1. 메모리 캐시 확인
   if (!forceRefresh) {
     const cached = memoryStore.get(cacheKey);
-    if (cached) {
+    if (cached && now - cached.fetchedAt < memoryTtl) {
       logger.debug('Maven 메모리 캐시 히트', { coordinate: coordinateToString(coordinate) });
       return cached.pom;
     }
@@ -307,12 +296,12 @@ export async function fetchPomWithCacheInfo(
   } = options;
 
   const cacheKey = getCacheKey(coordinate, repoUrl);
-  const memoryStore = getMemoryStore(memoryTtl);
+  const now = Date.now();
 
   // 메모리 캐시 확인
   if (!forceRefresh) {
     const cached = memoryStore.get(cacheKey);
-    if (cached) {
+    if (cached && now - cached.fetchedAt < memoryTtl) {
       return { pom: cached.pom, fromCache: 'memory' };
     }
   }
@@ -409,9 +398,7 @@ export function prefetchPomsParallel(
   const {
     batchSize = DEFAULT_BATCH_SIZE,
     repoUrl = DEFAULT_REPO_URL,
-    memoryTtl = DEFAULT_MEMORY_TTL,
   } = options;
-  const memoryStore = getMemoryStore(memoryTtl);
 
   // 이미 메모리 캐시된 것 제외. 진행 중인 요청은 CacheStore가 dedupe한다.
   const toFetch = coordinates.filter((coord) => {
@@ -435,12 +422,8 @@ export function prefetchPomsParallel(
  * 메모리 캐시 초기화
  */
 export function clearMemoryCache(): void {
-  let size = 0;
-  for (const store of memoryStores.values()) {
-    size += store.getStats().memoryEntries;
-    store.clear();
-  }
-  memoryStores.clear();
+  const size = memoryStore.getStats().memoryEntries;
+  memoryStore.clear();
   logger.info('Maven 메모리 캐시 초기화', { clearedEntries: size });
 }
 
@@ -467,9 +450,7 @@ export function invalidatePom(
   repoUrl: string = DEFAULT_REPO_URL
 ): void {
   const cacheKey = getCacheKey(coordinate, repoUrl);
-  for (const store of memoryStores.values()) {
-    store.delete(cacheKey);
-  }
+  memoryStore.delete(cacheKey);
 }
 
 /**
@@ -510,30 +491,16 @@ function getDirectoryStatsSync(dirPath: string): { size: number; fileCount: numb
 }
 
 export function getMavenCacheStats(): MavenCacheStats {
-  let oldest: number | null = null;
-  let newest: number | null = null;
-  let memoryEntries = 0;
-  let pendingRequests = 0;
-
-  for (const store of memoryStores.values()) {
-    const stats = store.getStats();
-    memoryEntries += stats.memoryEntries;
-    pendingRequests += stats.pendingRequests;
-
-    if (stats.oldestEntry !== null && (oldest === null || stats.oldestEntry < oldest)) {
-      oldest = stats.oldestEntry;
-    }
-    if (stats.newestEntry !== null && (newest === null || stats.newestEntry > newest)) {
-      newest = stats.newestEntry;
-    }
-  }
+  const memoryStats = memoryStore.getStats();
+  const oldest = memoryStats.oldestEntry;
+  const newest = memoryStats.newestEntry;
 
   const diskStats = getDirectoryStatsSync(DEFAULT_CACHE_DIR);
 
   return {
-    memoryEntries,
+    memoryEntries: memoryStats.memoryEntries,
     diskEntries: diskStats.fileCount,
-    pendingRequests,
+    pendingRequests: memoryStats.pendingRequests,
     oldestEntry: oldest,
     newestEntry: newest,
     diskSize: diskStats.size,
@@ -544,7 +511,15 @@ export function getMavenCacheStats(): MavenCacheStats {
  * 만료된 메모리 캐시 정리
  */
 export function pruneExpiredMemoryCache(ttl: number = DEFAULT_MEMORY_TTL): number {
-  const pruned = getMemoryStore(ttl).prune();
+  const now = Date.now();
+  let pruned = 0;
+
+  memoryStore.forEach((entry, key) => {
+    if (now - entry.fetchedAt >= ttl) {
+      memoryStore.delete(key);
+      pruned++;
+    }
+  });
 
   if (pruned > 0) {
     logger.info('Maven 만료된 캐시 정리', { pruned });
@@ -561,7 +536,7 @@ export function getPomFromCache(
   repoUrl: string = DEFAULT_REPO_URL
 ): PomProject | null {
   const cacheKey = getCacheKey(coordinate, repoUrl);
-  const cached = getMemoryStore(DEFAULT_MEMORY_TTL).get(cacheKey);
+  const cached = memoryStore.get(cacheKey);
   return cached?.pom ?? null;
 }
 
@@ -574,5 +549,7 @@ export function isPomCached(
   ttl: number = DEFAULT_MEMORY_TTL
 ): boolean {
   const cacheKey = getCacheKey(coordinate, repoUrl);
-  return getMemoryStore(ttl).has(cacheKey);
+  const cached = memoryStore.get(cacheKey);
+  if (!cached) return false;
+  return Date.now() - cached.fetchedAt < ttl;
 }

--- a/src/core/shared/maven-cache.ts
+++ b/src/core/shared/maven-cache.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import axios, { AxiosInstance } from 'axios';
 import { XMLParser } from 'fast-xml-parser';
 import * as fs from 'fs-extra';
+import { createMemoryCache, type CacheStore } from './cache/cache-store';
 import { PomProject, PomCacheEntry, MavenCoordinate, coordinateToString } from './maven-types';
 import logger from '../../utils/logger';
 
@@ -27,15 +28,7 @@ const DEFAULT_CACHE_DIR = path.join(os.homedir(), '.depssmuggler', 'cache', 'mav
 /** 병렬 조회 배치 크기 */
 const DEFAULT_BATCH_SIZE = 5;
 
-/**
- * 모듈 레벨 공유 메모리 캐시
- */
-const memoryCache: Map<string, PomCacheEntry> = new Map();
-
-/**
- * 진행 중인 요청 추적 (중복 요청 방지)
- */
-const pendingRequests: Map<string, Promise<PomProject>> = new Map();
+const memoryStores: Map<number, CacheStore<PomCacheEntry>> = new Map();
 
 /**
  * XML 파서 (싱글톤)
@@ -64,6 +57,21 @@ function getClient(repoUrl: string = DEFAULT_REPO_URL): AxiosInstance {
     });
   }
   return sharedClient;
+}
+
+function getCacheKey(coordinate: MavenCoordinate, repoUrl: string): string {
+  return `${repoUrl}:${coordinateToString(coordinate)}`;
+}
+
+function getMemoryStore(memoryTtl: number = DEFAULT_MEMORY_TTL): CacheStore<PomCacheEntry> {
+  const existing = memoryStores.get(memoryTtl);
+  if (existing) {
+    return existing;
+  }
+
+  const store = createMemoryCache<PomCacheEntry>('Maven POM', memoryTtl);
+  memoryStores.set(memoryTtl, store);
+  return store;
 }
 
 /**
@@ -208,39 +216,33 @@ export async function fetchPom(
     cacheDir = DEFAULT_CACHE_DIR,
   } = options;
 
-  const cacheKey = `${repoUrl}:${coordinateToString(coordinate)}`;
-  const now = Date.now();
+  const cacheKey = getCacheKey(coordinate, repoUrl);
+  const memoryStore = getMemoryStore(memoryTtl);
 
   // 1. 메모리 캐시 확인
   if (!forceRefresh) {
-    const cached = memoryCache.get(cacheKey);
-    if (cached && now - cached.fetchedAt < memoryTtl) {
+    const cached = memoryStore.get(cacheKey);
+    if (cached) {
       logger.debug('Maven 메모리 캐시 히트', { coordinate: coordinateToString(coordinate) });
       return cached.pom;
     }
   }
 
-  // 2. 진행 중인 동일 요청 대기
-  const pending = pendingRequests.get(cacheKey);
-  if (pending) {
-    logger.debug('Maven 중복 요청 대기', { coordinate: coordinateToString(coordinate) });
-    return pending;
-  }
-
-  // 3. 디스크 캐시 확인
+  // 2. 디스크 캐시 확인
   if (!forceRefresh && useDiskCache) {
     const diskCached = await readFromDiskCache(coordinate, { diskTtl, cacheDir });
     if (diskCached) {
       logger.debug('Maven 디스크 캐시 히트', { coordinate: coordinateToString(coordinate) });
       // 메모리 캐시에도 저장
-      memoryCache.set(cacheKey, diskCached);
+      memoryStore.set(cacheKey, diskCached);
       return diskCached.pom;
     }
   }
 
-  // 4. API 요청
-  const requestPromise = (async (): Promise<PomProject> => {
-    try {
+  // 3. API 요청 (CacheStore가 중복 요청 방지를 담당)
+  const result = await memoryStore.getOrFetch(
+    cacheKey,
+    async () => {
       const { groupId, artifactId, version } = coordinate;
       const groupPath = groupId.replace(/\./g, '/');
       const url = `/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`;
@@ -248,48 +250,44 @@ export async function fetchPom(
 
       logger.debug('Maven API 요청', { coordinate: coordinateToString(coordinate) });
 
-      const response = await client.get<string>(url, { responseType: 'text' });
-      const pomContent = response.data;
-      const parsed = parser.parse(pomContent);
-      const pom = parsed.project as PomProject;
+      try {
+        const response = await client.get<string>(url, { responseType: 'text' });
+        const pomContent = response.data;
+        const parsed = parser.parse(pomContent);
+        const pom = parsed.project as PomProject;
 
-      const entry: PomCacheEntry = {
-        pom,
-        fetchedAt: Date.now(),
-        effectiveGroupId: pom.groupId || coordinate.groupId,
-        effectiveVersion: pom.version || coordinate.version,
-      };
+        const entry: PomCacheEntry = {
+          pom,
+          fetchedAt: Date.now(),
+          effectiveGroupId: pom.groupId || coordinate.groupId,
+          effectiveVersion: pom.version || coordinate.version,
+        };
 
-      // 메모리 캐시 저장
-      memoryCache.set(cacheKey, entry);
+        if (useDiskCache) {
+          await writeToDiskCache(coordinate, pomContent, entry, cacheDir);
+        }
 
-      // 디스크 캐시 저장
-      if (useDiskCache) {
-        await writeToDiskCache(coordinate, pomContent, entry, cacheDir);
+        logger.debug('Maven POM 조회 완료', {
+          coordinate: coordinateToString(coordinate),
+          dependencies: Array.isArray(pom.dependencies?.dependency)
+            ? pom.dependencies.dependency.length
+            : pom.dependencies?.dependency
+              ? 1
+              : 0,
+        });
+
+        return entry;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          throw new Error(`POM not found: ${coordinateToString(coordinate)}`);
+        }
+        throw error;
       }
+    },
+    { forceRefresh: true }
+  );
 
-      logger.debug('Maven POM 조회 완료', {
-        coordinate: coordinateToString(coordinate),
-        dependencies: Array.isArray(pom.dependencies?.dependency)
-          ? pom.dependencies.dependency.length
-          : pom.dependencies?.dependency
-            ? 1
-            : 0,
-      });
-
-      return pom;
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.status === 404) {
-        throw new Error(`POM not found: ${coordinateToString(coordinate)}`);
-      }
-      throw error;
-    } finally {
-      pendingRequests.delete(cacheKey);
-    }
-  })();
-
-  pendingRequests.set(cacheKey, requestPromise);
-  return requestPromise;
+  return result.data.pom;
 }
 
 /**
@@ -308,13 +306,13 @@ export async function fetchPomWithCacheInfo(
     cacheDir = DEFAULT_CACHE_DIR,
   } = options;
 
-  const cacheKey = `${repoUrl}:${coordinateToString(coordinate)}`;
-  const now = Date.now();
+  const cacheKey = getCacheKey(coordinate, repoUrl);
+  const memoryStore = getMemoryStore(memoryTtl);
 
   // 메모리 캐시 확인
   if (!forceRefresh) {
-    const cached = memoryCache.get(cacheKey);
-    if (cached && now - cached.fetchedAt < memoryTtl) {
+    const cached = memoryStore.get(cacheKey);
+    if (cached) {
       return { pom: cached.pom, fromCache: 'memory' };
     }
   }
@@ -323,13 +321,48 @@ export async function fetchPomWithCacheInfo(
   if (!forceRefresh && useDiskCache) {
     const diskCached = await readFromDiskCache(coordinate, { diskTtl, cacheDir });
     if (diskCached) {
-      memoryCache.set(cacheKey, diskCached);
+      memoryStore.set(cacheKey, diskCached);
       return { pom: diskCached.pom, fromCache: 'disk' };
     }
   }
 
-  const pom = await fetchPom(coordinate, options);
-  return { pom, fromCache: 'network' };
+  const result = await memoryStore.getOrFetch(
+    cacheKey,
+    async () => {
+      const { groupId, artifactId, version } = coordinate;
+      const groupPath = groupId.replace(/\./g, '/');
+      const url = `/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`;
+      const client = getClient(repoUrl);
+
+      try {
+        const response = await client.get<string>(url, { responseType: 'text' });
+        const pomContent = response.data;
+        const parsed = parser.parse(pomContent);
+        const pom = parsed.project as PomProject;
+
+        const entry: PomCacheEntry = {
+          pom,
+          fetchedAt: Date.now(),
+          effectiveGroupId: pom.groupId || coordinate.groupId,
+          effectiveVersion: pom.version || coordinate.version,
+        };
+
+        if (useDiskCache) {
+          await writeToDiskCache(coordinate, pomContent, entry, cacheDir);
+        }
+
+        return entry;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          throw new Error(`POM not found: ${coordinateToString(coordinate)}`);
+        }
+        throw error;
+      }
+    },
+    { forceRefresh: true }
+  );
+
+  return { pom: result.data.pom, fromCache: 'network' };
 }
 
 /**
@@ -373,12 +406,17 @@ export function prefetchPomsParallel(
   coordinates: MavenCoordinate[],
   options: MavenCacheOptions & { batchSize?: number } = {}
 ): void {
-  const { batchSize = DEFAULT_BATCH_SIZE, repoUrl = DEFAULT_REPO_URL } = options;
+  const {
+    batchSize = DEFAULT_BATCH_SIZE,
+    repoUrl = DEFAULT_REPO_URL,
+    memoryTtl = DEFAULT_MEMORY_TTL,
+  } = options;
+  const memoryStore = getMemoryStore(memoryTtl);
 
-  // 이미 캐시되었거나 진행 중인 것 제외
+  // 이미 메모리 캐시된 것 제외. 진행 중인 요청은 CacheStore가 dedupe한다.
   const toFetch = coordinates.filter((coord) => {
-    const cacheKey = `${repoUrl}:${coordinateToString(coord)}`;
-    return !memoryCache.has(cacheKey) && !pendingRequests.has(cacheKey);
+    const cacheKey = getCacheKey(coord, repoUrl);
+    return !memoryStore.has(cacheKey);
   });
 
   if (toFetch.length === 0) {
@@ -397,9 +435,12 @@ export function prefetchPomsParallel(
  * 메모리 캐시 초기화
  */
 export function clearMemoryCache(): void {
-  const size = memoryCache.size;
-  memoryCache.clear();
-  pendingRequests.clear();
+  let size = 0;
+  for (const store of memoryStores.values()) {
+    size += store.getStats().memoryEntries;
+    store.clear();
+  }
+  memoryStores.clear();
   logger.info('Maven 메모리 캐시 초기화', { clearedEntries: size });
 }
 
@@ -425,8 +466,10 @@ export function invalidatePom(
   coordinate: MavenCoordinate,
   repoUrl: string = DEFAULT_REPO_URL
 ): void {
-  const cacheKey = `${repoUrl}:${coordinateToString(coordinate)}`;
-  memoryCache.delete(cacheKey);
+  const cacheKey = getCacheKey(coordinate, repoUrl);
+  for (const store of memoryStores.values()) {
+    store.delete(cacheKey);
+  }
 }
 
 /**
@@ -469,22 +512,28 @@ function getDirectoryStatsSync(dirPath: string): { size: number; fileCount: numb
 export function getMavenCacheStats(): MavenCacheStats {
   let oldest: number | null = null;
   let newest: number | null = null;
+  let memoryEntries = 0;
+  let pendingRequests = 0;
 
-  memoryCache.forEach((entry) => {
-    if (oldest === null || entry.fetchedAt < oldest) {
-      oldest = entry.fetchedAt;
+  for (const store of memoryStores.values()) {
+    const stats = store.getStats();
+    memoryEntries += stats.memoryEntries;
+    pendingRequests += stats.pendingRequests;
+
+    if (stats.oldestEntry !== null && (oldest === null || stats.oldestEntry < oldest)) {
+      oldest = stats.oldestEntry;
     }
-    if (newest === null || entry.fetchedAt > newest) {
-      newest = entry.fetchedAt;
+    if (stats.newestEntry !== null && (newest === null || stats.newestEntry > newest)) {
+      newest = stats.newestEntry;
     }
-  });
+  }
 
   const diskStats = getDirectoryStatsSync(DEFAULT_CACHE_DIR);
 
   return {
-    memoryEntries: memoryCache.size,
+    memoryEntries,
     diskEntries: diskStats.fileCount,
-    pendingRequests: pendingRequests.size,
+    pendingRequests,
     oldestEntry: oldest,
     newestEntry: newest,
     diskSize: diskStats.size,
@@ -495,15 +544,7 @@ export function getMavenCacheStats(): MavenCacheStats {
  * 만료된 메모리 캐시 정리
  */
 export function pruneExpiredMemoryCache(ttl: number = DEFAULT_MEMORY_TTL): number {
-  const now = Date.now();
-  let pruned = 0;
-
-  memoryCache.forEach((entry, key) => {
-    if (now - entry.fetchedAt >= ttl) {
-      memoryCache.delete(key);
-      pruned++;
-    }
-  });
+  const pruned = getMemoryStore(ttl).prune();
 
   if (pruned > 0) {
     logger.info('Maven 만료된 캐시 정리', { pruned });
@@ -519,8 +560,8 @@ export function getPomFromCache(
   coordinate: MavenCoordinate,
   repoUrl: string = DEFAULT_REPO_URL
 ): PomProject | null {
-  const cacheKey = `${repoUrl}:${coordinateToString(coordinate)}`;
-  const cached = memoryCache.get(cacheKey);
+  const cacheKey = getCacheKey(coordinate, repoUrl);
+  const cached = getMemoryStore(DEFAULT_MEMORY_TTL).get(cacheKey);
   return cached?.pom ?? null;
 }
 
@@ -532,8 +573,6 @@ export function isPomCached(
   repoUrl: string = DEFAULT_REPO_URL,
   ttl: number = DEFAULT_MEMORY_TTL
 ): boolean {
-  const cacheKey = `${repoUrl}:${coordinateToString(coordinate)}`;
-  const cached = memoryCache.get(cacheKey);
-  if (!cached) return false;
-  return Date.now() - cached.fetchedAt < ttl;
+  const cacheKey = getCacheKey(coordinate, repoUrl);
+  return getMemoryStore(ttl).has(cacheKey);
 }


### PR DESCRIPTION
## 요약
- `maven-cache.ts`의 메모리 캐시와 중복 요청 관리를 `CacheStore<PomCacheEntry>` 어댑터로 정리했습니다.
- 디스크 캐시 포맷은 유지하면서 메모리/pending 관리 중복을 줄였습니다.
- 관련 cache 문서를 현재 구조에 맞게 갱신했습니다.

## 배경
- Phase 6 계획상 언어별 cache 모듈을 `CacheStore<T>` 중심 어댑터로 축소해야 합니다.
- `maven-cache.ts`는 `memoryCache`/`pendingRequests`를 별도로 들고 있어 동일한 캐시 책임이 분산되어 있었습니다.

## 변경 사항
- `src/core/shared/maven-cache.ts`
  - TTL별 `CacheStore<PomCacheEntry>` 레지스트리 도입
  - 메모리 캐시 조회/정리와 중복 요청 방지를 `CacheStore`로 위임
  - 디스크 캐시 경로/메타 파일 포맷은 기존 Maven 전용 구조 유지
- `docs/shared-maven.md`
  - Maven cache가 `CacheStore<PomCacheEntry>` 어댑터를 사용한다는 설명 추가
  - 실제 디스크 캐시 파일명 예시 수정
- `docs/shared-cache.md`
  - Maven cache 요약과 디스크 캐시 구조 설명 갱신

## 검증
- `./node_modules/.bin/eslint src/core/shared/maven-cache.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bash scripts/verify-worktree.sh src/core/shared/maven-cache.test.ts`
  - `14 passed`

## 문서
- `docs/shared-maven.md`
- `docs/shared-cache.md`
