### PR TITLE
Phase 6: Conda repodata 요청을 공통 cache 계층으로 dedupe

### DIFF
--- a/docs/shared-cache.md
+++ b/docs/shared-cache.md
@@ -218,6 +218,8 @@ interface CacheStoreOptions {
 | Maven | O | O | 메모리 5분, 디스크 24시간 | [shared-maven.md](./shared-maven.md) |
 | Conda | X | O | HTTP Cache-Control 기반 | [shared-conda.md](./shared-conda.md) |
 
+Conda는 repodata payload를 메모리에 보존하지 않지만, 같은 채널/subdir 요청이 겹칠 때는 `CacheStore` 기반 request dedupe를 사용합니다.
+
 Maven 메모리 캐시와 중복 요청 관리는 `CacheStore<PomCacheEntry>` 어댑터로 통합되고, 디스크 캐시만 Maven 전용 파일 구조를 유지합니다.
 
 ---

--- a/docs/shared-conda.md
+++ b/docs/shared-conda.md
@@ -95,6 +95,7 @@ console.log(result);
 repodata.json 캐싱 및 조회 시스템 (**디스크 캐시 전용** - 메모리 캐시 미사용)
 
 > **참고**: Conda repodata.json 파일은 350MB+ 크기이므로 메모리 캐시를 사용하지 않고 디스크 캐시만 사용합니다.
+> Phase 6 기준으로 동시 동일 요청 dedupe만 `CacheStore` 기반 메모리 어댑터를 사용하고, payload 자체는 디스크 포맷만 유지합니다.
 
 ### 다운로드 진행 상황 로깅
 

--- a/src/core/shared/conda-cache.test.ts
+++ b/src/core/shared/conda-cache.test.ts
@@ -1,0 +1,161 @@
+import * as os from 'os';
+import * as path from 'path';
+import axios from 'axios';
+import * as fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchRepodata } from './conda-cache';
+import type { RepoData } from './conda-types';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    isAxiosError: vi.fn(),
+  },
+}));
+
+const mockedAxiosGet = vi.mocked(axios.get);
+const mockedIsAxiosError = vi.mocked(axios.isAxiosError);
+
+function getCachePaths(cacheDir: string, channel: string, subdir: string): {
+  dataPath: string;
+  metaPath: string;
+} {
+  const channelDir = path.join(cacheDir, channel, subdir);
+  return {
+    dataPath: path.join(channelDir, 'repodata.json'),
+    metaPath: path.join(channelDir, 'repodata.meta.json'),
+  };
+}
+
+async function writeCachedRepodata(
+  cacheDir: string,
+  channel: string,
+  subdir: string,
+  data: RepoData,
+  metaOverrides: Partial<{
+    url: string;
+    maxAge: number;
+    cachedAt: number;
+    packageCount: number;
+    compressed: boolean;
+  }> = {}
+): Promise<void> {
+  const { dataPath, metaPath } = getCachePaths(cacheDir, channel, subdir);
+  await fs.ensureDir(path.dirname(dataPath));
+  await fs.writeJson(dataPath, data);
+  await fs.writeJson(metaPath, {
+    url: metaOverrides.url ?? `https://conda.anaconda.org/${channel}/${subdir}/current_repodata.json`,
+    maxAge: metaOverrides.maxAge ?? 86400,
+    cachedAt: metaOverrides.cachedAt ?? Date.now(),
+    fileSize: JSON.stringify(data).length,
+    packageCount:
+      metaOverrides.packageCount ??
+      Object.keys(data.packages || {}).length + Object.keys(data['packages.conda'] || {}).length,
+    compressed: metaOverrides.compressed ?? false,
+  });
+}
+
+describe('conda-cache', () => {
+  let cacheDir: string;
+
+  beforeEach(async () => {
+    cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-conda-cache-'));
+    vi.clearAllMocks();
+    mockedIsAxiosError.mockReturnValue(false);
+  });
+
+  afterEach(async () => {
+    await fs.remove(cacheDir);
+  });
+
+  it('TTL이 유효한 디스크 캐시가 있으면 네트워크 요청 없이 반환해야 함', async () => {
+    const data: RepoData = {
+      info: { subdir: 'linux-64' },
+      packages: { 'python-3.12.0-0.tar.bz2': {} as never },
+      'packages.conda': {},
+    };
+    await writeCachedRepodata(cacheDir, 'conda-forge', 'linux-64', data);
+
+    const result = await fetchRepodata('conda-forge', 'linux-64', { cacheDir });
+
+    expect(result?.fromCache).toBe(true);
+    expect(result?.data.info.subdir).toBe('linux-64');
+    expect(mockedAxiosGet).not.toHaveBeenCalled();
+  });
+
+  it('304 Not Modified 응답이면 기존 디스크 캐시를 재사용하고 cachedAt을 갱신해야 함', async () => {
+    const channel = 'conda-forge';
+    const subdir = 'linux-64';
+    const cachedAt = Date.now() - 10_000;
+    const data: RepoData = {
+      info: { subdir },
+      packages: { 'python-3.12.0-0.tar.bz2': {} as never },
+      'packages.conda': {},
+    };
+    await writeCachedRepodata(cacheDir, channel, subdir, data, {
+      cachedAt,
+      maxAge: 1,
+      url: `https://conda.anaconda.org/${channel}/${subdir}/current_repodata.json`,
+    });
+
+    mockedAxiosGet.mockImplementation(async (url: string) => {
+      if (url.endsWith('repodata.json.zst')) {
+        throw new Error('missing compressed metadata');
+      }
+      return {
+        status: 304,
+        headers: {
+          'cache-control': 'max-age=60',
+        },
+      } as never;
+    });
+
+    const result = await fetchRepodata(channel, subdir, { cacheDir });
+    const { metaPath } = getCachePaths(cacheDir, channel, subdir);
+    const updatedMeta = await fs.readJson(metaPath);
+
+    expect(result?.fromCache).toBe(true);
+    expect(result?.data.info.subdir).toBe(subdir);
+    expect(updatedMeta.cachedAt).toBeGreaterThan(cachedAt);
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('동시에 같은 repodata를 요청하면 네트워크 요청을 한 번만 수행해야 함', async () => {
+    const channel = 'conda-forge';
+    const subdir = 'linux-64';
+    const data: RepoData = {
+      info: { subdir },
+      packages: { 'python-3.12.0-0.tar.bz2': {} as never },
+      'packages.conda': {},
+    };
+
+    mockedAxiosGet.mockImplementation(
+      async (url: string) => {
+        if (url.endsWith('repodata.json.zst')) {
+          throw new Error('missing compressed metadata');
+        }
+
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              status: 200,
+              data,
+              headers: {},
+            } as never);
+          }, 50);
+        });
+      }
+    );
+
+    const [first, second] = await Promise.all([
+      fetchRepodata(channel, subdir, { cacheDir }),
+      fetchRepodata(channel, subdir, { cacheDir }),
+    ]);
+
+    expect(first?.fromCache).toBe(false);
+    expect(second?.fromCache).toBe(false);
+    expect(first?.data.info.subdir).toBe(subdir);
+    expect(second?.data.info.subdir).toBe(subdir);
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/shared/conda-cache.ts
+++ b/src/core/shared/conda-cache.ts
@@ -5,15 +5,18 @@
  */
 
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import axios, { AxiosResponse } from 'axios';
 import * as fzstd from 'fzstd';
-import logger from '../../utils/logger';
+import { createMemoryCache } from './cache/cache-store';
 import { RepoData } from './conda-types';
+import logger from '../../utils/logger';
 
 /** DepsSmuggler용 기본 TTL: 24시간 (폐쇄망 전달 목적이므로 길게 설정) */
 const DEFAULT_MAX_AGE = 86400; // 24시간
+const REQUEST_DEDUPE_TTL_MS = 1000;
+const repodataRequestCache = createMemoryCache<CacheResult>('Conda repodata request', REQUEST_DEDUPE_TTL_MS);
 
 /**
  * 캐시 메타데이터
@@ -68,6 +71,17 @@ function getCachePaths(cacheDir: string, channel: string, subdir: string): {
     dataPath: path.join(channelDir, 'repodata.json'),
     metaPath: path.join(channelDir, 'repodata.meta.json'),
   };
+}
+
+function getRequestKey(
+  baseUrl: string,
+  cacheDir: string,
+  channel: string,
+  subdir: string,
+  useCache: boolean,
+  forceRefresh: boolean
+): string {
+  return `${baseUrl}:${cacheDir}:${channel}:${subdir}:${useCache ? 'cache' : 'nocache'}:${forceRefresh ? 'refresh' : 'normal'}`;
 }
 
 /**
@@ -223,156 +237,161 @@ export async function fetchRepodata(
     }
   }
 
-  // 2. HTTP 요청 준비
-  const urls = [
-    { url: `${baseUrl}/${channel}/${subdir}/repodata.json.zst`, compressed: true },
-    { url: `${baseUrl}/${channel}/${subdir}/current_repodata.json`, compressed: false },
-    { url: `${baseUrl}/${channel}/${subdir}/repodata.json`, compressed: false },
-  ];
+  const requestKey = getRequestKey(baseUrl, cacheDir, channel, subdir, useCache, forceRefresh);
+  const result = await repodataRequestCache.dedupeFetch(requestKey, async () => {
+    // 2. HTTP 요청 준비
+    const urls = [
+      { url: `${baseUrl}/${channel}/${subdir}/repodata.json.zst`, compressed: true },
+      { url: `${baseUrl}/${channel}/${subdir}/current_repodata.json`, compressed: false },
+      { url: `${baseUrl}/${channel}/${subdir}/repodata.json`, compressed: false },
+    ];
 
-  // 기존 캐시 메타데이터 (조건부 요청용)
-  const existingMeta = useCache ? readCacheMeta(metaPath) : null;
+    // 기존 캐시 메타데이터 (조건부 요청용)
+    const existingMeta = useCache ? readCacheMeta(metaPath) : null;
 
-  for (const { url, compressed } of urls) {
-    try {
-      // 조건부 요청 헤더 설정
-      const headers: Record<string, string> = {
-        'User-Agent': 'DepsSmuggler/1.0',
-      };
+    for (const { url, compressed } of urls) {
+      try {
+        // 조건부 요청 헤더 설정
+        const headers: Record<string, string> = {
+          'User-Agent': 'DepsSmuggler/1.0',
+        };
 
-      if (existingMeta && existingMeta.url === url && !forceRefresh) {
-        if (existingMeta.etag) {
-          headers['If-None-Match'] = existingMeta.etag;
-        }
-        if (existingMeta.lastModified) {
-          headers['If-Modified-Since'] = existingMeta.lastModified;
-        }
-      }
-
-      const startTime = Date.now();
-      logger.info(`repodata 다운로드 시작: ${channel}/${subdir}`, {
-        url,
-        compressed,
-        conditional: !!(headers['If-None-Match'] || headers['If-Modified-Since']),
-      });
-
-      let lastLoggedPercent = 0;
-      const response = await axios.get(url, {
-        responseType: compressed ? 'arraybuffer' : 'json',
-        headers,
-        timeout,
-        validateStatus: (status) => status === 200 || status === 304,
-        onDownloadProgress: (progressEvent) => {
-          const { loaded, total } = progressEvent;
-          if (total) {
-            const percent = Math.floor((loaded / total) * 100);
-            // 20% 단위로 로그 출력 (너무 많은 로그 방지)
-            if (percent >= lastLoggedPercent + 20) {
-              lastLoggedPercent = percent;
-              const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-              const loadedMB = (loaded / 1024 / 1024).toFixed(1);
-              const totalMB = (total / 1024 / 1024).toFixed(1);
-              logger.info(`repodata 다운로드 중: ${channel}/${subdir} (${loadedMB}MB / ${totalMB}MB, ${percent}%, ${elapsed}초)`);
-            }
+        if (existingMeta && existingMeta.url === url && !forceRefresh) {
+          if (existingMeta.etag) {
+            headers['If-None-Match'] = existingMeta.etag;
           }
-        },
-      });
+          if (existingMeta.lastModified) {
+            headers['If-Modified-Since'] = existingMeta.lastModified;
+          }
+        }
 
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-      logger.info(`repodata 다운로드 완료: ${channel}/${subdir} (${elapsed}초)`);
+        const startTime = Date.now();
+        logger.info(`repodata 다운로드 시작: ${channel}/${subdir}`, {
+          url,
+          compressed,
+          conditional: !!(headers['If-None-Match'] || headers['If-Modified-Since']),
+        });
 
-      // 304 Not Modified - 캐시 유효 (디스크에서 읽기)
-      if (response.status === 304) {
-        const cachedData = readCacheData(dataPath);
-        if (cachedData && existingMeta) {
-          // 캐시 시간 갱신
-          const { maxAge } = extractCacheHeaders(response);
-          const updatedMeta: RepodataCacheMeta = {
-            ...existingMeta,
-            maxAge,
-            cachedAt: Date.now(),
-          };
-          writeCacheMeta(metaPath, updatedMeta);
+        let lastLoggedPercent = 0;
+        const response = await axios.get(url, {
+          responseType: compressed ? 'arraybuffer' : 'json',
+          headers,
+          timeout,
+          validateStatus: (status) => status === 200 || status === 304,
+          onDownloadProgress: (progressEvent) => {
+            const { loaded, total } = progressEvent;
+            if (total) {
+              const percent = Math.floor((loaded / total) * 100);
+              // 20% 단위로 로그 출력 (너무 많은 로그 방지)
+              if (percent >= lastLoggedPercent + 20) {
+                lastLoggedPercent = percent;
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+                const loadedMB = (loaded / 1024 / 1024).toFixed(1);
+                const totalMB = (total / 1024 / 1024).toFixed(1);
+                logger.info(`repodata 다운로드 중: ${channel}/${subdir} (${loadedMB}MB / ${totalMB}MB, ${percent}%, ${elapsed}초)`);
+              }
+            }
+          },
+        });
 
-          logger.info('캐시 유효 (304 Not Modified)', {
-            url,
-            packages: existingMeta.packageCount,
-          });
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        logger.info(`repodata 다운로드 완료: ${channel}/${subdir} (${elapsed}초)`);
 
-          return {
-            data: cachedData,
-            fromCache: true,
-            meta: updatedMeta,
-          };
+        // 304 Not Modified - 캐시 유효 (디스크에서 읽기)
+        if (response.status === 304) {
+          const cachedData = readCacheData(dataPath);
+          if (cachedData && existingMeta) {
+            // 캐시 시간 갱신
+            const { maxAge } = extractCacheHeaders(response);
+            const updatedMeta: RepodataCacheMeta = {
+              ...existingMeta,
+              maxAge,
+              cachedAt: Date.now(),
+            };
+            writeCacheMeta(metaPath, updatedMeta);
+
+            logger.info('캐시 유효 (304 Not Modified)', {
+              url,
+              packages: existingMeta.packageCount,
+            });
+
+            return {
+              data: cachedData,
+              fromCache: true,
+              meta: updatedMeta,
+            };
+          }
+        }
+
+        // 200 OK - 새 데이터
+        let repodata: RepoData;
+        let fileSize: number;
+
+        if (compressed) {
+          const compressedData = new Uint8Array(response.data);
+          const decompressedData = fzstd.decompress(compressedData);
+          const jsonString = new TextDecoder().decode(decompressedData);
+          repodata = JSON.parse(jsonString) as RepoData;
+          fileSize = compressedData.length;
+        } else {
+          repodata = response.data as RepoData;
+          fileSize = JSON.stringify(repodata).length;
+        }
+
+        // 패키지 수 계산
+        const packageCount =
+          Object.keys(repodata.packages || {}).length +
+          Object.keys(repodata['packages.conda'] || {}).length;
+
+        // 캐시 헤더 추출
+        const { etag, lastModified, maxAge } = extractCacheHeaders(response);
+
+        // 메타데이터 생성
+        const meta: RepodataCacheMeta = {
+          url,
+          etag,
+          lastModified,
+          maxAge,
+          cachedAt: Date.now(),
+          fileSize,
+          packageCount,
+          compressed,
+        };
+
+        // 캐시 저장 (디스크만)
+        if (useCache) {
+          writeCacheData(dataPath, repodata);
+          writeCacheMeta(metaPath, meta);
+        }
+
+        logger.info('repodata 가져오기 성공', {
+          url,
+          packages: packageCount,
+          compressed,
+          fileSize,
+          cached: useCache,
+        });
+
+        return {
+          data: repodata,
+          fromCache: false,
+          meta,
+        };
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          logger.debug('repodata URL 없음, 다음 URL 시도', { url });
+        } else {
+          logger.warn('repodata 가져오기 실패, 다음 URL 시도', { url, error });
         }
       }
-
-      // 200 OK - 새 데이터
-      let repodata: RepoData;
-      let fileSize: number;
-
-      if (compressed) {
-        const compressedData = new Uint8Array(response.data);
-        const decompressedData = fzstd.decompress(compressedData);
-        const jsonString = new TextDecoder().decode(decompressedData);
-        repodata = JSON.parse(jsonString) as RepoData;
-        fileSize = compressedData.length;
-      } else {
-        repodata = response.data as RepoData;
-        fileSize = JSON.stringify(repodata).length;
-      }
-
-      // 패키지 수 계산
-      const packageCount =
-        Object.keys(repodata.packages || {}).length +
-        Object.keys(repodata['packages.conda'] || {}).length;
-
-      // 캐시 헤더 추출
-      const { etag, lastModified, maxAge } = extractCacheHeaders(response);
-
-      // 메타데이터 생성
-      const meta: RepodataCacheMeta = {
-        url,
-        etag,
-        lastModified,
-        maxAge,
-        cachedAt: Date.now(),
-        fileSize,
-        packageCount,
-        compressed,
-      };
-
-      // 캐시 저장 (디스크만)
-      if (useCache) {
-        writeCacheData(dataPath, repodata);
-        writeCacheMeta(metaPath, meta);
-      }
-
-      logger.info('repodata 가져오기 성공', {
-        url,
-        packages: packageCount,
-        compressed,
-        fileSize,
-        cached: useCache,
-      });
-
-      return {
-        data: repodata,
-        fromCache: false,
-        meta,
-      };
-    } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.status === 404) {
-        logger.debug('repodata URL 없음, 다음 URL 시도', { url });
-      } else {
-        logger.warn('repodata 가져오기 실패, 다음 URL 시도', { url, error });
-      }
-      continue;
     }
-  }
 
-  logger.error('모든 repodata URL 실패', { channel, subdir });
-  return null;
+    logger.error('모든 repodata URL 실패', { channel, subdir });
+    return null;
+  });
+
+  repodataRequestCache.delete(requestKey);
+  return result;
 }
 
 /**


### PR DESCRIPTION
## 요약
- `conda-cache.ts`에 `CacheStore` 기반 request dedupe를 추가했습니다.
- repodata payload는 여전히 디스크 전용으로 유지하면서, 같은 채널/subdir 동시 요청 중복만 줄였습니다.
- 관련 Conda/cache 문서를 현재 구조에 맞게 갱신했습니다.

## 배경
- Phase 6 계획상 언어 cache 모듈이 공통 cache 계층을 활용하도록 정리되어야 합니다.
- `conda-cache.ts`는 메모리 캐시를 두지 않는 대신 동시 동일 요청 dedupe도 없어서, 같은 repodata 요청이 겹치면 네트워크 호출이 그대로 중복될 수 있었습니다.

## 변경 사항
- `src/core/shared/conda-cache.ts`
  - request key 기반 `CacheStore` dedupe 도입
  - 디스크 TTL hit, 304 재검증, 새 데이터 저장 흐름은 유지
  - repodata payload 자체는 메모리에 보존하지 않고 디스크 포맷 유지
- `src/core/shared/conda-cache.test.ts`
  - TTL 유효 디스크 캐시 hit
  - 304 Not Modified 재사용
  - 동시 동일 요청 dedupe
- `docs/shared-conda.md`, `docs/shared-cache.md`
  - Conda cache가 disk-only payload + CacheStore request dedupe 구조임을 반영

## 검증
- `./node_modules/.bin/eslint src/core/shared/conda-cache.ts src/core/shared/conda-cache.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bash scripts/verify-worktree.sh src/core/shared/conda-cache.test.ts`
  - `3 passed`

## 문서
- `docs/shared-conda.md`
- `docs/shared-cache.md`
