### PR TITLE
Phase 7: download orchestrator 세션 상태를 SessionRegistry로 분리

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -124,7 +124,7 @@ depssmuggler/
 1. Renderer가 `renderer-data-client` facade를 통해 `window.electronAPI.search.*` 또는 `dependency.resolve`를 호출
 2. `search-handlers.ts`가 `electron/services/search-orchestrator.ts`와 관련 service에 위임
 3. `DownloadPage.tsx`의 `use-download-page-controller.tsx`가 `download:start`를 호출
-4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 package router/progress emitter/packager를 조합해 실행
+4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 `electron/services/download/session-registry.ts`로 세션 상태를 분리한 뒤 package router/progress emitter/packager를 조합해 실행
 5. 진행률 이벤트를 `download:*` 채널로 렌더러에 다시 전송
 6. 완료 시 출력 디렉터리와 결과를 히스토리에 저장
 

--- a/docs/ipc-handlers.md
+++ b/docs/ipc-handlers.md
@@ -113,6 +113,7 @@ electron/
 주요 위임 대상:
 
 - `electron/services/download-orchestrator.ts`
+- `electron/services/download/session-registry.ts`
 - `electron/services/download-package-router.ts`
 - `electron/services/download-progress.ts`
 - `electron/services/os-download-orchestrator.ts`

--- a/electron/services/download-orchestrator.ts
+++ b/electron/services/download-orchestrator.ts
@@ -1,13 +1,11 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import pLimit from 'p-limit';
-import { createScopedLogger } from '../utils/logger';
-import { generateInstallScripts } from '../../src/core/shared';
-import type { DownloadOptions, DownloadPackage } from '../../src/core/shared';
-import { getArchivePackager } from '../../src/core/packager/archive-packager';
-import { getFileSplitter } from '../../src/core/packager/file-splitter';
-import { initializeEmailSender } from '../../src/core/mailer/email-sender';
-import type { PackageInfo } from '../../src/types';
+import {
+  bindSessionProgressEmitter,
+  createDownloadSessionRegistry,
+  createExecutionState,
+} from './download/session-registry';
 import {
   createDownloadPackageRouter,
   type DownloadExecutionState,
@@ -18,17 +16,17 @@ import {
   createDownloadProgressEmitter,
   type DownloadProgressEmitter,
 } from './download-progress';
+import { initializeEmailSender } from '../../src/core/mailer/email-sender';
+import { getArchivePackager } from '../../src/core/packager/archive-packager';
+import { getFileSplitter } from '../../src/core/packager/file-splitter';
+import { generateInstallScripts } from '../../src/core/shared';
+import { createScopedLogger } from '../utils/logger';
+import type { DownloadOptions, DownloadPackage } from '../../src/core/shared';
+import type { PackageInfo } from '../../src/types';
 
 const log = createScopedLogger('DownloadOrchestrator');
 
 type Limiter = <T>(task: () => Promise<T>) => Promise<T>;
-
-interface DownloadSessionState {
-  sessionId: number;
-  cancelled: boolean;
-  paused: boolean;
-  abortController: AbortController;
-}
 
 export interface DownloadOrchestratorDeps {
   getMainWindow: () => Electron.BrowserWindow | null;
@@ -91,23 +89,13 @@ export function createDownloadOrchestrator(
 
   const progressEmitter = createProgressEmitter(deps.getMainWindow);
   const packageRouter = createPackageRouter();
-
-  let activeSession: DownloadSessionState | null = null;
-  let lastSessionId = 0;
+  const sessionRegistry = createDownloadSessionRegistry();
 
   return {
     async startDownload(data) {
-      const sessionId = data.sessionId ?? lastSessionId + 1;
-      lastSessionId = Math.max(lastSessionId, sessionId);
-      const sessionState: DownloadSessionState = {
-        sessionId,
-        cancelled: false,
-        paused: false,
-        abortController: new AbortController(),
-      };
-      activeSession = sessionState;
-      const state = createExecutionState(sessionState);
-      const sessionProgressEmitter = createSessionProgressEmitter(sessionId);
+      const session = sessionRegistry.createSession(data.sessionId);
+      const state = createExecutionState(session);
+      const sessionProgressEmitter = bindSessionProgressEmitter(progressEmitter, session.sessionId);
 
       sessionProgressEmitter.emitDownloadStatus({
         phase: 'downloading',
@@ -119,24 +107,17 @@ export function createDownloadOrchestrator(
     },
 
     async pauseDownload() {
-      if (activeSession) {
-        activeSession.paused = true;
-      }
+      sessionRegistry.pauseActiveSession();
       return { success: true };
     },
 
     async resumeDownload() {
-      if (activeSession) {
-        activeSession.paused = false;
-      }
+      sessionRegistry.resumeActiveSession();
       return { success: true };
     },
 
     async cancelDownload() {
-      if (activeSession) {
-        activeSession.cancelled = true;
-        activeSession.abortController.abort();
-      }
+      sessionRegistry.cancelActiveSession();
       progressEmitter.clearAllPackageProgress();
       return { success: true };
     },
@@ -201,60 +182,6 @@ export function createDownloadOrchestrator(
       }
     },
   };
-
-  function createExecutionState(session: DownloadSessionState): DownloadExecutionState {
-    return {
-      isCancelled: () => session.cancelled,
-      isPaused: () => session.paused,
-      waitWhilePaused: async () => {
-        while (session.paused && !session.cancelled) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-      },
-      get signal() {
-        return session.abortController.signal;
-      },
-    };
-  }
-
-  function createSessionProgressEmitter(sessionId: number): DownloadProgressEmitter {
-    return {
-      emitDownloadStatus(payload) {
-        progressEmitter.emitDownloadStatus({
-          ...payload,
-          sessionId,
-        });
-      },
-      emitPackageProgress(packageId, payload, force = false) {
-        progressEmitter.emitPackageProgress(
-          packageId,
-          {
-            ...payload,
-            sessionId,
-          },
-          force
-        );
-      },
-      clearPackageProgress(packageId) {
-        progressEmitter.clearPackageProgress(packageId);
-      },
-      clearAllPackageProgress() {
-        progressEmitter.clearAllPackageProgress();
-      },
-      emitAllComplete(payload) {
-        progressEmitter.emitAllComplete({
-          ...payload,
-          sessionId,
-        });
-      },
-      emitOSProgress(progress) {
-        progressEmitter.emitOSProgress(progress);
-      },
-      emitOSResolveDependenciesProgress(payload) {
-        progressEmitter.emitOSResolveDependenciesProgress(payload);
-      },
-    };
-  }
 
   async function runDownload(data: {
     sessionId?: number;

--- a/electron/services/download/session-registry.test.ts
+++ b/electron/services/download/session-registry.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  bindSessionProgressEmitter,
+  createDownloadSessionRegistry,
+  createExecutionState,
+} from './session-registry';
+import type { DownloadProgressEmitter } from '../download-progress';
+
+describe('createDownloadSessionRegistry', () => {
+  it('sessionId를 자동 증가시키고 active session을 교체해야 함', () => {
+    const registry = createDownloadSessionRegistry();
+
+    const first = registry.createSession();
+    const second = registry.createSession();
+
+    expect(first.sessionId).toBe(1);
+    expect(second.sessionId).toBe(2);
+    expect(registry.getActiveSession()).toBe(second);
+  });
+
+  it('활성 세션만 pause/resume/cancel 처리하고 이전 세션 상태는 유지해야 함', () => {
+    const registry = createDownloadSessionRegistry();
+
+    const first = registry.createSession(10);
+    registry.cancelActiveSession();
+
+    const second = registry.createSession(11);
+    registry.pauseActiveSession();
+    registry.resumeActiveSession();
+
+    expect(first.cancelled).toBe(true);
+    expect(first.abortController.signal.aborted).toBe(true);
+    expect(second.cancelled).toBe(false);
+    expect(second.paused).toBe(false);
+    expect(registry.getActiveSession()).toBe(second);
+  });
+});
+
+describe('createExecutionState', () => {
+  it('세션 상태를 DownloadExecutionState로 노출해야 함', async () => {
+    const registry = createDownloadSessionRegistry();
+    const session = registry.createSession(21);
+    const executionState = createExecutionState(session);
+
+    expect(executionState.isCancelled()).toBe(false);
+    expect(executionState.isPaused()).toBe(false);
+    expect(executionState.signal).toBe(session.abortController.signal);
+
+    registry.pauseActiveSession();
+    expect(executionState.isPaused()).toBe(true);
+
+    registry.cancelActiveSession();
+    expect(executionState.isCancelled()).toBe(true);
+
+    await executionState.waitWhilePaused();
+  });
+});
+
+describe('bindSessionProgressEmitter', () => {
+  it('sessionId가 필요한 이벤트 payload에 세션 정보를 주입해야 함', () => {
+    const emitter: DownloadProgressEmitter = {
+      emitDownloadStatus: vi.fn(),
+      emitPackageProgress: vi.fn(),
+      clearPackageProgress: vi.fn(),
+      clearAllPackageProgress: vi.fn(),
+      emitAllComplete: vi.fn(),
+      emitOSProgress: vi.fn(),
+      emitOSResolveDependenciesProgress: vi.fn(),
+    };
+
+    const sessionEmitter = bindSessionProgressEmitter(emitter, 33);
+
+    sessionEmitter.emitDownloadStatus({
+      phase: 'downloading',
+      message: '다운로드 중...',
+    });
+    sessionEmitter.emitPackageProgress('pkg-1', {
+      status: 'downloading',
+      progress: 50,
+      downloadedBytes: 5,
+      totalBytes: 10,
+    });
+    sessionEmitter.emitAllComplete({
+      success: true,
+    });
+    sessionEmitter.clearPackageProgress('pkg-1');
+    sessionEmitter.clearAllPackageProgress();
+    sessionEmitter.emitOSResolveDependenciesProgress({
+      message: 'resolving',
+      current: 1,
+      total: 2,
+    });
+
+    expect(emitter.emitDownloadStatus).toHaveBeenCalledWith({
+      sessionId: 33,
+      phase: 'downloading',
+      message: '다운로드 중...',
+    });
+    expect(emitter.emitPackageProgress).toHaveBeenCalledWith(
+      'pkg-1',
+      {
+        sessionId: 33,
+        status: 'downloading',
+        progress: 50,
+        downloadedBytes: 5,
+        totalBytes: 10,
+      },
+      false
+    );
+    expect(emitter.emitAllComplete).toHaveBeenCalledWith({
+      sessionId: 33,
+      success: true,
+    });
+    expect(emitter.clearPackageProgress).toHaveBeenCalledWith('pkg-1');
+    expect(emitter.clearAllPackageProgress).toHaveBeenCalled();
+    expect(emitter.emitOSResolveDependenciesProgress).toHaveBeenCalledWith({
+      message: 'resolving',
+      current: 1,
+      total: 2,
+    });
+  });
+});

--- a/electron/services/download/session-registry.ts
+++ b/electron/services/download/session-registry.ts
@@ -1,0 +1,125 @@
+import type { DownloadExecutionState } from '../download-package-router';
+import type { DownloadProgressEmitter } from '../download-progress';
+
+export interface DownloadSessionState {
+  sessionId: number;
+  cancelled: boolean;
+  paused: boolean;
+  abortController: AbortController;
+}
+
+export interface DownloadSessionRegistry {
+  createSession(sessionId?: number): DownloadSessionState;
+  getActiveSession(): DownloadSessionState | null;
+  pauseActiveSession(): void;
+  resumeActiveSession(): void;
+  cancelActiveSession(): void;
+}
+
+export function createDownloadSessionRegistry(): DownloadSessionRegistry {
+  let activeSession: DownloadSessionState | null = null;
+  let lastSessionId = 0;
+
+  return {
+    createSession(sessionId) {
+      const resolvedSessionId = sessionId ?? lastSessionId + 1;
+      lastSessionId = Math.max(lastSessionId, resolvedSessionId);
+
+      const session: DownloadSessionState = {
+        sessionId: resolvedSessionId,
+        cancelled: false,
+        paused: false,
+        abortController: new AbortController(),
+      };
+
+      activeSession = session;
+      return session;
+    },
+
+    getActiveSession() {
+      return activeSession;
+    },
+
+    pauseActiveSession() {
+      if (activeSession) {
+        activeSession.paused = true;
+      }
+    },
+
+    resumeActiveSession() {
+      if (activeSession) {
+        activeSession.paused = false;
+      }
+    },
+
+    cancelActiveSession() {
+      if (activeSession) {
+        activeSession.cancelled = true;
+        activeSession.abortController.abort();
+      }
+    },
+  };
+}
+
+export function createExecutionState(session: DownloadSessionState): DownloadExecutionState {
+  return {
+    isCancelled: () => session.cancelled,
+    isPaused: () => session.paused,
+    waitWhilePaused: async () => {
+      while (session.paused && !session.cancelled) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    },
+    get signal() {
+      return session.abortController.signal;
+    },
+  };
+}
+
+export function bindSessionProgressEmitter(
+  progressEmitter: DownloadProgressEmitter,
+  sessionId: number
+): DownloadProgressEmitter {
+  return {
+    emitDownloadStatus(payload) {
+      progressEmitter.emitDownloadStatus({
+        ...payload,
+        sessionId,
+      });
+    },
+
+    emitPackageProgress(packageId, payload, force = false) {
+      progressEmitter.emitPackageProgress(
+        packageId,
+        {
+          ...payload,
+          sessionId,
+        },
+        force
+      );
+    },
+
+    clearPackageProgress(packageId) {
+      progressEmitter.clearPackageProgress(packageId);
+    },
+
+    clearAllPackageProgress() {
+      progressEmitter.clearAllPackageProgress();
+    },
+
+    emitAllComplete(payload) {
+      progressEmitter.emitAllComplete({
+        ...payload,
+        sessionId,
+      });
+    },
+
+    emitOSProgress(progress) {
+      progressEmitter.emitOSProgress(progress);
+    },
+
+    emitOSResolveDependenciesProgress(payload) {
+      progressEmitter.emitOSResolveDependenciesProgress(payload);
+    },
+  };
+}


### PR DESCRIPTION
## 요약
- download-orchestrator 내부 세션 상태 관리를 SessionRegistry support object로 추출했습니다
- sessionId 주입용 progress emitter 바인더와 실행 상태 어댑터를 함께 분리했습니다
- 관련 문서와 단위 테스트를 추가해 Phase 7 후속 분해의 안전한 기반을 마련했습니다

## 검증
- ./node_modules/.bin/eslint electron/services/download/session-registry.ts electron/services/download/session-registry.test.ts electron/services/download-orchestrator.ts
- ./node_modules/.bin/tsc --noEmit
- bash scripts/verify-worktree.sh electron/services/download-orchestrator.test.ts electron/services/download/session-registry.test.ts