### PR TITLE
Phase 7: delivery pipeline을 download-orchestrator에서 분리

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -124,7 +124,7 @@ depssmuggler/
 1. Renderer가 `renderer-data-client` facade를 통해 `window.electronAPI.search.*` 또는 `dependency.resolve`를 호출
 2. `search-handlers.ts`가 `electron/services/search-orchestrator.ts`와 관련 service에 위임
 3. `DownloadPage.tsx`의 `use-download-page-controller.tsx`가 `download:start`를 호출
-4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 `electron/services/download/session-registry.ts`로 세션 상태를 분리한 뒤 package router/progress emitter/packager를 조합해 실행
+4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 `electron/services/download/session-registry.ts`와 `electron/services/download/delivery-pipeline.ts`로 세션 상태/전달 파이프라인을 분리한 뒤 package router/progress emitter/packager를 조합해 실행
 5. 진행률 이벤트를 `download:*` 채널로 렌더러에 다시 전송
 6. 완료 시 출력 디렉터리와 결과를 히스토리에 저장
 

--- a/docs/ipc-handlers.md
+++ b/docs/ipc-handlers.md
@@ -113,6 +113,7 @@ electron/
 주요 위임 대상:
 
 - `electron/services/download-orchestrator.ts`
+- `electron/services/download/delivery-pipeline.ts`
 - `electron/services/download/session-registry.ts`
 - `electron/services/download-package-router.ts`
 - `electron/services/download-progress.ts`

--- a/electron/services/download-orchestrator.ts
+++ b/electron/services/download-orchestrator.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import pLimit from 'p-limit';
+import { createDeliveryPipeline } from './download/delivery-pipeline';
 import {
   bindSessionProgressEmitter,
   createDownloadSessionRegistry,
@@ -90,6 +91,13 @@ export function createDownloadOrchestrator(
   const progressEmitter = createProgressEmitter(deps.getMainWindow);
   const packageRouter = createPackageRouter();
   const sessionRegistry = createDownloadSessionRegistry();
+  const deliveryPipeline = createDeliveryPipeline({
+    archivePackager,
+    generateInstallScripts: installScripts,
+    initializeEmailSender: emailSenderFactory,
+    getFileSplitter: fileSplitterFactory,
+    stat,
+  });
 
   return {
     async startDownload(data) {
@@ -189,7 +197,7 @@ export function createDownloadOrchestrator(
     options: DownloadOptions;
   }, sessionProgressEmitter: DownloadProgressEmitter, state: DownloadExecutionState): Promise<void> {
     const { packages, options } = data;
-    const { outputDir, outputFormat, includeScripts, concurrency = 3 } = options;
+    const { outputDir, concurrency = 3 } = options;
     const packagesDir = path.join(outputDir, 'packages');
     const limit = createLimiter(concurrency);
     const emitCancelledCompletion = (
@@ -202,17 +210,6 @@ export function createDownloadOrchestrator(
         outputPath: currentOutputPath,
         artifactPaths: currentArtifactPaths,
       });
-    };
-    const shouldStopForCancellation = (
-      currentOutputPath: string,
-      currentArtifactPaths?: string[]
-    ): boolean => {
-      if (!state.isCancelled()) {
-        return false;
-      }
-
-      emitCancelledCompletion(currentOutputPath, currentArtifactPaths);
-      return true;
     };
 
     try {
@@ -242,131 +239,18 @@ export function createDownloadOrchestrator(
       const deliveredPackages = packages.filter((pkg) => successfulPackageIds.has(pkg.id));
       const packageInfos = deliveredPackages.map(toPackageInfo);
       const failedDownloadCount = results.filter((result) => !result.success).length;
-      let finalOutputPath = outputDir;
-      let artifactPaths: string[] = [];
-      let deliveryResult:
-        | {
-            emailSent: boolean;
-            emailsSent?: number;
-            attachmentsSent?: number;
-            splitApplied?: boolean;
-            error?: string;
-          }
-        | undefined;
-      const deliveryMethod = options.deliveryMethod || 'local';
-
-      if (successfulPackageIds.size === 0) {
-        sessionProgressEmitter.emitAllComplete({
-          success: false,
-          outputPath: outputDir,
-          deliveryMethod,
-          error: '다운로드에 성공한 패키지가 없습니다.',
-          results,
-        });
-        return;
-      }
-
-      if (includeScripts) {
-        try {
-          installScripts(outputDir, deliveredPackages);
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          sessionProgressEmitter.emitAllComplete({
-            success: false,
-            outputPath: outputDir,
-            error: errorMessage,
-            results,
-          });
-          return;
-        }
-      }
-
-      if (outputFormat !== 'zip' && outputFormat !== 'tar.gz') {
-        sessionProgressEmitter.emitAllComplete({
-          success: false,
-          outputPath: outputDir,
-          error: `지원하지 않는 출력 형식입니다: ${String(outputFormat)}`,
-          results,
-        });
-        return;
-      }
-
-      if (shouldStopForCancellation(finalOutputPath, artifactPaths)) {
-        return;
-      }
-
-      try {
-        sessionProgressEmitter.emitDownloadStatus({
-          phase: 'packaging',
-          message: `${outputFormat.toUpperCase()} 패키징 중...`,
-        });
-        const archivePath = `${outputDir}.${outputFormat === 'zip' ? 'zip' : 'tar.gz'}`;
-        finalOutputPath = await archivePackager.createArchiveFromDirectory(
-          outputDir,
-          archivePath,
-          packageInfos,
-          {
-            format: outputFormat,
-            includeManifest: true,
-            includeReadme: true,
-          }
-        );
-        artifactPaths = [finalOutputPath];
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        sessionProgressEmitter.emitAllComplete({
-          success: false,
-          outputPath: outputDir,
-          error: errorMessage,
-          results,
-        });
-        return;
-      }
-
-      if (shouldStopForCancellation(finalOutputPath, artifactPaths)) {
-        return;
-      }
-
-      if (deliveryMethod === 'email') {
-        const emailOutcome = await deliverByEmail({
-          options,
-          packageInfos,
-          results,
-          finalOutputPath,
-          artifactPaths,
-          failedDownloadCount,
-          isCancelled: () => state.isCancelled(),
-          progressEmitter: sessionProgressEmitter,
-        });
-
-        if (!emailOutcome.success) {
-          sessionProgressEmitter.emitAllComplete(emailOutcome.completionPayload);
-          return;
-        }
-
-        finalOutputPath = emailOutcome.finalOutputPath;
-        artifactPaths = emailOutcome.artifactPaths;
-        deliveryResult = emailOutcome.deliveryResult;
-      }
-
-      if (
-        !deliveryResult?.emailSent &&
-        shouldStopForCancellation(
-          finalOutputPath,
-          artifactPaths.length > 0 ? artifactPaths : [finalOutputPath]
-        )
-      ) {
-        return;
-      }
-
-      sessionProgressEmitter.emitAllComplete({
-        success: true,
-        outputPath: finalOutputPath,
-        artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
-        deliveryMethod,
-        deliveryResult,
+      const completionPayload = await deliveryPipeline.finalizeDownload({
+        outputDir,
+        options,
+        deliveredPackages,
+        packageInfos,
         results,
+        failedDownloadCount,
+        progressEmitter: sessionProgressEmitter,
+        isCancelled: () => state.isCancelled(),
       });
+
+      sessionProgressEmitter.emitAllComplete(completionPayload);
     } catch (error) {
       sessionProgressEmitter.emitAllComplete({
         success: false,
@@ -376,281 +260,6 @@ export function createDownloadOrchestrator(
     }
   }
 
-  async function deliverByEmail(params: {
-    options: DownloadOptions;
-    packageInfos: PackageInfo[];
-    results: DownloadPackageResult[];
-    finalOutputPath: string;
-    artifactPaths: string[];
-    failedDownloadCount: number;
-    isCancelled: () => boolean;
-    progressEmitter: DownloadProgressEmitter;
-  }): Promise<
-    | {
-        success: true;
-        finalOutputPath: string;
-        artifactPaths: string[];
-        deliveryResult: {
-          emailSent: true;
-          emailsSent?: number;
-          attachmentsSent?: number;
-          splitApplied: boolean;
-        };
-      }
-    | {
-        success: false;
-        completionPayload: Record<string, unknown>;
-      }
-  > {
-    const { options, packageInfos, results, failedDownloadCount, isCancelled, progressEmitter } = params;
-    let { finalOutputPath, artifactPaths } = params;
-    const smtpOptions = options.smtp;
-    const emailOptions = options.email;
-    const deliveryMethod = options.deliveryMethod || 'local';
-    const effectiveFrom = emailOptions?.from || smtpOptions?.from || smtpOptions?.user;
-
-    if (!smtpOptions?.host || !smtpOptions.port || !emailOptions?.to) {
-      return {
-        success: false,
-        completionPayload: {
-          success: false,
-          outputPath: finalOutputPath,
-          artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
-          deliveryMethod,
-          deliveryResult: {
-            emailSent: false,
-            splitApplied: false,
-            error: '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다',
-          },
-          error: '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다',
-          results,
-        },
-      };
-    }
-
-    if (!effectiveFrom) {
-      return {
-        success: false,
-        completionPayload: {
-          success: false,
-          outputPath: finalOutputPath,
-          artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
-          deliveryMethod,
-          deliveryResult: {
-            emailSent: false,
-            splitApplied: false,
-            error:
-              '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.',
-          },
-          error:
-            '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.',
-          results,
-        },
-      };
-    }
-
-    const maxAttachmentSizeBytes = (options.fileSplit?.maxSizeMB ?? 25) * 1024 * 1024;
-    let attachments = artifactPaths.length > 0 ? [...artifactPaths] : [finalOutputPath];
-    let splitApplied = false;
-    const getCurrentArtifacts = () =>
-      attachments.length > 0 ? attachments : artifactPaths.length > 0 ? artifactPaths : [finalOutputPath];
-    const getCancelledOutcome = (deliveryResult?: {
-      emailSent: boolean;
-      emailsSent?: number;
-      attachmentsSent?: number;
-      splitApplied?: boolean;
-      error?: string;
-    }) => {
-      if (!isCancelled()) {
-        return null;
-      }
-
-      return {
-        success: false as const,
-        completionPayload: {
-          success: false,
-          cancelled: true,
-          outputPath: finalOutputPath,
-          artifactPaths: getCurrentArtifacts(),
-          deliveryMethod,
-          deliveryResult,
-          results,
-        },
-      };
-    };
-
-    progressEmitter.emitDownloadStatus({
-      phase: 'packaging',
-      message: '이메일 전달 준비 중...',
-    });
-
-    try {
-      const cancelledBeforeStat = getCancelledOutcome();
-      if (cancelledBeforeStat) {
-        return cancelledBeforeStat;
-      }
-
-      const archiveStat = await (deps.stat ?? fse.stat.bind(fse))(finalOutputPath);
-      const cancelledAfterStat = getCancelledOutcome();
-      if (cancelledAfterStat) {
-        return cancelledAfterStat;
-      }
-
-      if (archiveStat.size > maxAttachmentSizeBytes) {
-        if (!options.fileSplit?.enabled) {
-          return {
-            success: false,
-            completionPayload: {
-              success: false,
-              outputPath: finalOutputPath,
-              artifactPaths: [finalOutputPath],
-              deliveryMethod,
-              deliveryResult: {
-                emailSent: false,
-                splitApplied: false,
-                error: '첨부 파일 크기가 제한을 초과했습니다. 파일 분할을 활성화하세요.',
-              },
-              error: '첨부 파일 크기가 제한을 초과했습니다. 파일 분할을 활성화하세요.',
-              results,
-            },
-          };
-        }
-
-        const splitter = fileSplitterFactory();
-        const splitResult = await splitter.splitFile(finalOutputPath, {
-          maxSizeMB: options.fileSplit.maxSizeMB,
-          generateMergeScripts: true,
-        });
-        attachments = collectSplitArtifacts(splitResult);
-        artifactPaths = attachments;
-        finalOutputPath = attachments[0] || finalOutputPath;
-        splitApplied = true;
-      }
-
-      const cancelledBeforeEmailSetup = getCancelledOutcome();
-      if (cancelledBeforeEmailSetup) {
-        return cancelledBeforeEmailSetup;
-      }
-
-      const emailSender = emailSenderFactory(
-        {
-          host: smtpOptions.host,
-          port: smtpOptions.port,
-          secure: smtpOptions.secure ?? smtpOptions.port === 465,
-          auth: smtpOptions.user
-            ? {
-                user: smtpOptions.user,
-                pass: smtpOptions.password || '',
-              }
-            : undefined,
-          from: effectiveFrom,
-        },
-        maxAttachmentSizeBytes
-      );
-
-      const cancelledBeforeSend = getCancelledOutcome();
-      if (cancelledBeforeSend) {
-        return cancelledBeforeSend;
-      }
-
-      const emailSendResult = await emailSender.sendEmail({
-        to: emailOptions.to,
-        subject:
-          emailOptions.subject || `DepsSmuggler 패키지 전달 (${packageInfos.length}개 패키지)`,
-        body: [
-          splitApplied
-            ? '첨부 용량 제한에 맞춰 파일을 분할해 전달했습니다.'
-            : '다운로드된 패키지 아카이브를 전달합니다.',
-          failedDownloadCount > 0
-            ? `다운로드 실패한 ${failedDownloadCount}개 패키지는 이번 전달에서 제외되었습니다.`
-            : '',
-        ]
-          .filter(Boolean)
-          .join('\n'),
-        attachments: getCurrentArtifacts(),
-        packages: packageInfos,
-      });
-
-      const cancelledAfterSend = getCancelledOutcome({
-        emailSent: emailSendResult.success,
-        emailsSent: emailSendResult.emailsSent,
-        attachmentsSent: emailSendResult.attachmentsSent,
-        splitApplied: emailSendResult.splitApplied ?? splitApplied,
-        error: emailSendResult.success ? undefined : emailSendResult.error,
-      });
-      if (cancelledAfterSend) {
-        return cancelledAfterSend;
-      }
-
-      if (!emailSendResult.success) {
-        const errorMessage = emailSendResult.error || '이메일 전달에 실패했습니다';
-        return {
-          success: false,
-          completionPayload: {
-            success: false,
-            outputPath: finalOutputPath,
-            artifactPaths: attachments,
-            deliveryMethod,
-            deliveryResult: {
-              emailSent: false,
-              emailsSent: emailSendResult.emailsSent,
-              attachmentsSent: emailSendResult.attachmentsSent,
-              splitApplied,
-              error: errorMessage,
-            },
-            error: errorMessage,
-            results,
-          },
-        };
-      }
-
-      return {
-        success: true,
-        finalOutputPath,
-        artifactPaths: attachments,
-        deliveryResult: {
-          emailSent: true,
-          emailsSent: emailSendResult.emailsSent,
-          attachmentsSent: emailSendResult.attachmentsSent,
-          splitApplied,
-        },
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        completionPayload: {
-          success: false,
-          outputPath: finalOutputPath,
-          artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
-          deliveryMethod,
-          deliveryResult: {
-            emailSent: false,
-            splitApplied,
-            error: errorMessage,
-          },
-          error: errorMessage,
-          results,
-        },
-      };
-    }
-  }
-}
-
-function collectSplitArtifacts(splitResult: {
-  parts: string[];
-  metadataPath?: string;
-  mergeScripts?: {
-    bash?: string;
-    powershell?: string;
-  };
-}): string[] {
-  return [
-    ...splitResult.parts,
-    splitResult.metadataPath,
-    splitResult.mergeScripts?.bash,
-    splitResult.mergeScripts?.powershell,
-  ].filter((value): value is string => Boolean(value));
 }
 
 function toPackageInfo(pkg: DownloadPackage): PackageInfo {

--- a/electron/services/download/delivery-pipeline.test.ts
+++ b/electron/services/download/delivery-pipeline.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDeliveryPipeline } from './delivery-pipeline';
+import { createEmailSenderMock } from '../../../src/core/mailer/__mocks__/email-sender-mock';
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const createBaseParams = () => ({
+  outputDir: '/tmp/out',
+  options: {
+    outputDir: '/tmp/out',
+    outputFormat: 'tar.gz' as const,
+    includeScripts: false,
+    deliveryMethod: 'local' as const,
+  },
+  deliveredPackages: [
+    {
+      id: 'pip-requests-2.32.0',
+      type: 'pip' as const,
+      name: 'requests',
+      version: '2.32.0',
+    },
+  ],
+  packageInfos: [
+    {
+      type: 'pip' as const,
+      name: 'requests',
+      version: '2.32.0',
+    },
+  ],
+  results: [
+    {
+      id: 'pip-requests-2.32.0',
+      success: true,
+    },
+  ],
+  failedDownloadCount: 0,
+});
+
+describe('createDeliveryPipeline', () => {
+  it('지원하지 않는 출력 형식이면 실패 payload를 반환해야 함', async () => {
+    const archivePackager = {
+      createArchiveFromDirectory: vi.fn(),
+    };
+    const pipeline = createDeliveryPipeline({
+      archivePackager: archivePackager as never,
+      generateInstallScripts: vi.fn(),
+      initializeEmailSender: vi.fn() as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn() as never,
+    });
+
+    const completionPayload = await pipeline.finalizeDownload({
+      ...createBaseParams(),
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'raw' as never,
+        includeScripts: false,
+        deliveryMethod: 'local',
+      },
+      progressEmitter: {
+        emitDownloadStatus: vi.fn(),
+      } as never,
+      isCancelled: () => false,
+    });
+
+    expect(completionPayload).toEqual(
+      expect.objectContaining({
+        success: false,
+        outputPath: '/tmp/out',
+        error: '지원하지 않는 출력 형식입니다: raw',
+      })
+    );
+    expect(archivePackager.createArchiveFromDirectory).not.toHaveBeenCalled();
+  });
+
+  it('이메일 전달 준비 중 취소되면 sendEmail 없이 cancelled payload를 반환해야 함', async () => {
+    const statDeferred = createDeferred<{ size: number }>();
+    const sendEmail = vi.fn();
+    const progressEmitter = {
+      emitDownloadStatus: vi.fn(),
+    };
+    let cancelled = false;
+
+    const pipeline = createDeliveryPipeline({
+      archivePackager: {
+        createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.tar.gz'),
+      } as never,
+      generateInstallScripts: vi.fn(),
+      initializeEmailSender: vi.fn(() => createEmailSenderMock({ sendEmail })) as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn().mockImplementation(async () => statDeferred.promise as never),
+    });
+
+    const completionPromise = pipeline.finalizeDownload({
+      ...createBaseParams(),
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'tar.gz',
+        includeScripts: false,
+        deliveryMethod: 'email',
+        email: {
+          to: 'offline@example.com',
+        },
+        fileSplit: {
+          enabled: false,
+          maxSizeMB: 10,
+        },
+        smtp: {
+          host: 'smtp.example.com',
+          port: 587,
+          user: 'sender@example.com',
+        },
+      },
+      progressEmitter: progressEmitter as never,
+      isCancelled: () => cancelled,
+    });
+
+    await vi.waitFor(() => {
+      expect(progressEmitter.emitDownloadStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: 'packaging',
+          message: '이메일 전달 준비 중...',
+        })
+      );
+    });
+
+    cancelled = true;
+    statDeferred.resolve({ size: 1024 });
+
+    const completionPayload = await completionPromise;
+
+    expect(progressEmitter.emitDownloadStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'packaging',
+        message: '이메일 전달 준비 중...',
+      })
+    );
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(completionPayload).toEqual(
+      expect.objectContaining({
+        success: false,
+        cancelled: true,
+        outputPath: '/tmp/out.tar.gz',
+        artifactPaths: ['/tmp/out.tar.gz'],
+        deliveryMethod: 'email',
+      })
+    );
+  });
+
+  it('분할 후 이메일 전달에 성공하면 분할 산출물과 deliveryResult를 반환해야 함', async () => {
+    const sendEmail = vi.fn().mockResolvedValue({
+      success: true,
+      emailsSent: 1,
+      attachmentsSent: 4,
+      splitApplied: true,
+    });
+    const splitArtifacts = [
+      '/tmp/out.tar.gz.001',
+      '/tmp/out.tar.gz.002',
+      '/tmp/out.tar.gz.metadata.json',
+      '/tmp/out.merge.sh',
+    ];
+    const pipeline = createDeliveryPipeline({
+      archivePackager: {
+        createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.tar.gz'),
+      } as never,
+      generateInstallScripts: vi.fn(),
+      initializeEmailSender: vi.fn(() => createEmailSenderMock({ sendEmail })) as never,
+      getFileSplitter: vi.fn(() => ({
+        splitFile: vi.fn().mockResolvedValue({
+          parts: splitArtifacts.slice(0, 2),
+          metadataPath: splitArtifacts[2],
+          mergeScripts: {
+            bash: splitArtifacts[3],
+          },
+        }),
+      })) as never,
+      stat: vi.fn().mockResolvedValue({ size: 20 * 1024 * 1024 } as never),
+    });
+
+    const completionPayload = await pipeline.finalizeDownload({
+      ...createBaseParams(),
+      options: {
+        outputDir: '/tmp/out',
+        outputFormat: 'tar.gz',
+        includeScripts: false,
+        deliveryMethod: 'email',
+        email: {
+          to: 'offline@example.com',
+          subject: 'offline bundle',
+        },
+        fileSplit: {
+          enabled: true,
+          maxSizeMB: 10,
+        },
+        smtp: {
+          host: 'smtp.example.com',
+          port: 587,
+          user: 'sender@example.com',
+        },
+      },
+      progressEmitter: {
+        emitDownloadStatus: vi.fn(),
+      } as never,
+      isCancelled: () => false,
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: splitArtifacts,
+        subject: 'offline bundle',
+      })
+    );
+    expect(completionPayload).toEqual(
+      expect.objectContaining({
+        success: true,
+        outputPath: '/tmp/out.tar.gz.001',
+        artifactPaths: splitArtifacts,
+        deliveryMethod: 'email',
+        deliveryResult: expect.objectContaining({
+          emailSent: true,
+          emailsSent: 1,
+          attachmentsSent: 4,
+          splitApplied: true,
+        }),
+      })
+    );
+  });
+});

--- a/electron/services/download/delivery-pipeline.ts
+++ b/electron/services/download/delivery-pipeline.ts
@@ -1,0 +1,483 @@
+import * as fse from 'fs-extra';
+import { initializeEmailSender } from '../../../src/core/mailer/email-sender';
+import { getArchivePackager } from '../../../src/core/packager/archive-packager';
+import { getFileSplitter } from '../../../src/core/packager/file-splitter';
+import { generateInstallScripts } from '../../../src/core/shared';
+import type { DownloadOptions, DownloadPackage } from '../../../src/core/shared';
+import type { PackageInfo } from '../../../src/types';
+import type { DownloadPackageResult } from '../download-package-router';
+import type { DownloadProgressEmitter } from '../download-progress';
+
+export interface DeliveryPipelineDeps {
+  archivePackager: ReturnType<typeof getArchivePackager>;
+  generateInstallScripts: typeof generateInstallScripts;
+  initializeEmailSender: typeof initializeEmailSender;
+  getFileSplitter: typeof getFileSplitter;
+  stat: typeof fse.stat;
+}
+
+export interface DeliveryPipeline {
+  finalizeDownload(params: {
+    outputDir: string;
+    options: DownloadOptions;
+    deliveredPackages: DownloadPackage[];
+    packageInfos: PackageInfo[];
+    results: DownloadPackageResult[];
+    failedDownloadCount: number;
+    progressEmitter: DownloadProgressEmitter;
+    isCancelled: () => boolean;
+  }): Promise<Record<string, unknown>>;
+}
+
+export function createDeliveryPipeline(deps: DeliveryPipelineDeps): DeliveryPipeline {
+  return {
+    async finalizeDownload(params) {
+      const {
+        outputDir,
+        options,
+        deliveredPackages,
+        packageInfos,
+        results,
+        failedDownloadCount,
+        progressEmitter,
+        isCancelled,
+      } = params;
+      const { outputFormat, includeScripts } = options;
+      const deliveryMethod = options.deliveryMethod || 'local';
+
+      if (deliveredPackages.length === 0) {
+        return {
+          success: false,
+          outputPath: outputDir,
+          deliveryMethod,
+          error: '다운로드에 성공한 패키지가 없습니다.',
+          results,
+        };
+      }
+
+      if (includeScripts) {
+        try {
+          deps.generateInstallScripts(outputDir, deliveredPackages);
+        } catch (error) {
+          return {
+            success: false,
+            outputPath: outputDir,
+            error: error instanceof Error ? error.message : String(error),
+            results,
+          };
+        }
+      }
+
+      if (outputFormat !== 'zip' && outputFormat !== 'tar.gz') {
+        return {
+          success: false,
+          outputPath: outputDir,
+          error: `지원하지 않는 출력 형식입니다: ${String(outputFormat)}`,
+          results,
+        };
+      }
+
+      const cancelledBeforePackaging = createCancelledPayload({
+        isCancelled,
+        outputPath: outputDir,
+      });
+      if (cancelledBeforePackaging) {
+        return cancelledBeforePackaging;
+      }
+
+      let finalOutputPath = outputDir;
+      let artifactPaths: string[] = [];
+      let deliveryResult:
+        | {
+            emailSent: boolean;
+            emailsSent?: number;
+            attachmentsSent?: number;
+            splitApplied?: boolean;
+            error?: string;
+          }
+        | undefined;
+
+      try {
+        progressEmitter.emitDownloadStatus({
+          phase: 'packaging',
+          message: `${outputFormat.toUpperCase()} 패키징 중...`,
+        });
+
+        const archivePath = `${outputDir}.${outputFormat === 'zip' ? 'zip' : 'tar.gz'}`;
+        finalOutputPath = await deps.archivePackager.createArchiveFromDirectory(
+          outputDir,
+          archivePath,
+          packageInfos,
+          {
+            format: outputFormat,
+            includeManifest: true,
+            includeReadme: true,
+          }
+        );
+        artifactPaths = [finalOutputPath];
+      } catch (error) {
+        return {
+          success: false,
+          outputPath: outputDir,
+          error: error instanceof Error ? error.message : String(error),
+          results,
+        };
+      }
+
+      const cancelledAfterPackaging = createCancelledPayload({
+        isCancelled,
+        outputPath: finalOutputPath,
+        artifactPaths,
+      });
+      if (cancelledAfterPackaging) {
+        return cancelledAfterPackaging;
+      }
+
+      if (deliveryMethod === 'email') {
+        const emailOutcome = await deliverByEmail({
+          deps,
+          options,
+          packageInfos,
+          results,
+          finalOutputPath,
+          artifactPaths,
+          failedDownloadCount,
+          isCancelled,
+          progressEmitter,
+        });
+
+        if (!emailOutcome.success) {
+          return emailOutcome.completionPayload;
+        }
+
+        finalOutputPath = emailOutcome.finalOutputPath;
+        artifactPaths = emailOutcome.artifactPaths;
+        deliveryResult = emailOutcome.deliveryResult;
+      }
+
+      const cancelledAfterDelivery = !deliveryResult?.emailSent
+        ? createCancelledPayload({
+            isCancelled,
+            outputPath: finalOutputPath,
+            artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+            deliveryMethod,
+            deliveryResult,
+            results,
+          })
+        : null;
+      if (cancelledAfterDelivery) {
+        return cancelledAfterDelivery;
+      }
+
+      return {
+        success: true,
+        outputPath: finalOutputPath,
+        artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+        deliveryMethod,
+        deliveryResult,
+        results,
+      };
+    },
+  };
+}
+
+async function deliverByEmail(params: {
+  deps: DeliveryPipelineDeps;
+  options: DownloadOptions;
+  packageInfos: PackageInfo[];
+  results: DownloadPackageResult[];
+  finalOutputPath: string;
+  artifactPaths: string[];
+  failedDownloadCount: number;
+  isCancelled: () => boolean;
+  progressEmitter: DownloadProgressEmitter;
+}): Promise<
+  | {
+      success: true;
+      finalOutputPath: string;
+      artifactPaths: string[];
+      deliveryResult: {
+        emailSent: true;
+        emailsSent?: number;
+        attachmentsSent?: number;
+        splitApplied: boolean;
+      };
+    }
+  | {
+      success: false;
+      completionPayload: Record<string, unknown>;
+    }
+> {
+  const { deps, options, packageInfos, results, failedDownloadCount, isCancelled, progressEmitter } = params;
+  let { finalOutputPath, artifactPaths } = params;
+  const smtpOptions = options.smtp;
+  const emailOptions = options.email;
+  const deliveryMethod = options.deliveryMethod || 'local';
+  const effectiveFrom = emailOptions?.from || smtpOptions?.from || smtpOptions?.user;
+
+  if (!smtpOptions?.host || !smtpOptions.port || !emailOptions?.to) {
+    return {
+      success: false,
+      completionPayload: {
+        success: false,
+        outputPath: finalOutputPath,
+        artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+        deliveryMethod,
+        deliveryResult: {
+          emailSent: false,
+          splitApplied: false,
+          error: '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다',
+        },
+        error: '이메일 전달에 필요한 SMTP 또는 수신자 설정이 없습니다',
+        results,
+      },
+    };
+  }
+
+  if (!effectiveFrom) {
+    return {
+      success: false,
+      completionPayload: {
+        success: false,
+        outputPath: finalOutputPath,
+        artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+        deliveryMethod,
+        deliveryResult: {
+          emailSent: false,
+          splitApplied: false,
+          error:
+            '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.',
+        },
+        error:
+          '이메일 전달에 필요한 발신자 설정이 없습니다. SMTP 발신자 또는 로그인 사용자를 설정하세요.',
+        results,
+      },
+    };
+  }
+
+  const maxAttachmentSizeBytes = (options.fileSplit?.maxSizeMB ?? 25) * 1024 * 1024;
+  let attachments = artifactPaths.length > 0 ? [...artifactPaths] : [finalOutputPath];
+  let splitApplied = false;
+  const getCurrentArtifacts = () =>
+    attachments.length > 0 ? attachments : artifactPaths.length > 0 ? artifactPaths : [finalOutputPath];
+  const getCancelledOutcome = (deliveryResult?: {
+    emailSent: boolean;
+    emailsSent?: number;
+    attachmentsSent?: number;
+    splitApplied?: boolean;
+    error?: string;
+  }) => {
+    const completionPayload = createCancelledPayload({
+      isCancelled,
+      outputPath: finalOutputPath,
+      artifactPaths: getCurrentArtifacts(),
+      deliveryMethod,
+      deliveryResult,
+      results,
+    });
+
+    if (!completionPayload) {
+      return null;
+    }
+
+    return {
+      success: false as const,
+      completionPayload,
+    };
+  };
+
+  progressEmitter.emitDownloadStatus({
+    phase: 'packaging',
+    message: '이메일 전달 준비 중...',
+  });
+
+  try {
+    const cancelledBeforeStat = getCancelledOutcome();
+    if (cancelledBeforeStat) {
+      return cancelledBeforeStat;
+    }
+
+    const archiveStat = await deps.stat(finalOutputPath);
+    const cancelledAfterStat = getCancelledOutcome();
+    if (cancelledAfterStat) {
+      return cancelledAfterStat;
+    }
+
+    if (archiveStat.size > maxAttachmentSizeBytes) {
+      if (!options.fileSplit?.enabled) {
+        return {
+          success: false,
+          completionPayload: {
+            success: false,
+            outputPath: finalOutputPath,
+            artifactPaths: [finalOutputPath],
+            deliveryMethod,
+            deliveryResult: {
+              emailSent: false,
+              splitApplied: false,
+              error: '첨부 파일 크기가 제한을 초과했습니다. 파일 분할을 활성화하세요.',
+            },
+            error: '첨부 파일 크기가 제한을 초과했습니다. 파일 분할을 활성화하세요.',
+            results,
+          },
+        };
+      }
+
+      const splitter = deps.getFileSplitter();
+      const splitResult = await splitter.splitFile(finalOutputPath, {
+        maxSizeMB: options.fileSplit.maxSizeMB,
+        generateMergeScripts: true,
+      });
+      attachments = collectSplitArtifacts(splitResult);
+      artifactPaths = attachments;
+      finalOutputPath = attachments[0] || finalOutputPath;
+      splitApplied = true;
+    }
+
+    const cancelledBeforeEmailSetup = getCancelledOutcome();
+    if (cancelledBeforeEmailSetup) {
+      return cancelledBeforeEmailSetup;
+    }
+
+    const emailSender = deps.initializeEmailSender(
+      {
+        host: smtpOptions.host,
+        port: smtpOptions.port,
+        secure: smtpOptions.secure ?? smtpOptions.port === 465,
+        auth: smtpOptions.user
+          ? {
+              user: smtpOptions.user,
+              pass: smtpOptions.password || '',
+            }
+          : undefined,
+        from: effectiveFrom,
+      },
+      maxAttachmentSizeBytes
+    );
+
+    const cancelledBeforeSend = getCancelledOutcome();
+    if (cancelledBeforeSend) {
+      return cancelledBeforeSend;
+    }
+
+    const emailSendResult = await emailSender.sendEmail({
+      to: emailOptions.to,
+      subject:
+        emailOptions.subject || `DepsSmuggler 패키지 전달 (${packageInfos.length}개 패키지)`,
+      body: [
+        splitApplied
+          ? '첨부 용량 제한에 맞춰 파일을 분할해 전달했습니다.'
+          : '다운로드된 패키지 아카이브를 전달합니다.',
+        failedDownloadCount > 0
+          ? `다운로드 실패한 ${failedDownloadCount}개 패키지는 이번 전달에서 제외되었습니다.`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      attachments: getCurrentArtifacts(),
+      packages: packageInfos,
+    });
+
+    const cancelledAfterSend = getCancelledOutcome({
+      emailSent: emailSendResult.success,
+      emailsSent: emailSendResult.emailsSent,
+      attachmentsSent: emailSendResult.attachmentsSent,
+      splitApplied: emailSendResult.splitApplied ?? splitApplied,
+      error: emailSendResult.success ? undefined : emailSendResult.error,
+    });
+    if (cancelledAfterSend) {
+      return cancelledAfterSend;
+    }
+
+    if (!emailSendResult.success) {
+      const errorMessage = emailSendResult.error || '이메일 전달에 실패했습니다';
+      return {
+        success: false,
+        completionPayload: {
+          success: false,
+          outputPath: finalOutputPath,
+          artifactPaths: attachments,
+          deliveryMethod,
+          deliveryResult: {
+            emailSent: false,
+            emailsSent: emailSendResult.emailsSent,
+            attachmentsSent: emailSendResult.attachmentsSent,
+            splitApplied,
+            error: errorMessage,
+          },
+          error: errorMessage,
+          results,
+        },
+      };
+    }
+
+    return {
+      success: true,
+      finalOutputPath,
+      artifactPaths: attachments,
+      deliveryResult: {
+        emailSent: true,
+        emailsSent: emailSendResult.emailsSent,
+        attachmentsSent: emailSendResult.attachmentsSent,
+        splitApplied,
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      completionPayload: {
+        success: false,
+        outputPath: finalOutputPath,
+        artifactPaths: artifactPaths.length > 0 ? artifactPaths : [finalOutputPath],
+        deliveryMethod,
+        deliveryResult: {
+          emailSent: false,
+          splitApplied,
+          error: errorMessage,
+        },
+        error: errorMessage,
+        results,
+      },
+    };
+  }
+}
+
+function createCancelledPayload(params: {
+  isCancelled: () => boolean;
+  outputPath: string;
+  artifactPaths?: string[];
+  deliveryMethod?: string;
+  deliveryResult?: Record<string, unknown>;
+  results?: DownloadPackageResult[];
+}): Record<string, unknown> | null {
+  if (!params.isCancelled()) {
+    return null;
+  }
+
+  return {
+    success: false,
+    cancelled: true,
+    outputPath: params.outputPath,
+    artifactPaths: params.artifactPaths,
+    deliveryMethod: params.deliveryMethod,
+    deliveryResult: params.deliveryResult,
+    results: params.results,
+  };
+}
+
+function collectSplitArtifacts(splitResult: {
+  parts: string[];
+  metadataPath?: string;
+  mergeScripts?: {
+    bash?: string;
+    powershell?: string;
+  };
+}): string[] {
+  return [
+    ...splitResult.parts,
+    splitResult.metadataPath,
+    splitResult.mergeScripts?.bash,
+    splitResult.mergeScripts?.powershell,
+  ].filter((value): value is string => Boolean(value));
+}


### PR DESCRIPTION
## 요약
- download-orchestrator의 패키징/이메일 전달 책임을 DeliveryPipeline support object로 추출했습니다
- 이메일 준비 중 취소, 분할 전달, 출력 형식 검증을 DeliveryPipeline 단위 테스트로 고정했습니다
- 관련 아키텍처 및 IPC 문서를 갱신했습니다

## 검증
- ./node_modules/.bin/eslint electron/services/download/delivery-pipeline.ts electron/services/download/delivery-pipeline.test.ts electron/services/download-orchestrator.ts
- ./node_modules/.bin/tsc --noEmit
- bash scripts/verify-worktree.sh electron/services/download-orchestrator.test.ts electron/services/download/delivery-pipeline.test.ts