### PR TITLE
Phase 7: download session runner와 concurrency limiter를 분리

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -124,7 +124,7 @@ depssmuggler/
 1. Renderer가 `renderer-data-client` facade를 통해 `window.electronAPI.search.*` 또는 `dependency.resolve`를 호출
 2. `search-handlers.ts`가 `electron/services/search-orchestrator.ts`와 관련 service에 위임
 3. `DownloadPage.tsx`의 `use-download-page-controller.tsx`가 `download:start`를 호출
-4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 `electron/services/download/session-registry.ts`와 `electron/services/download/delivery-pipeline.ts`로 세션 상태/전달 파이프라인을 분리한 뒤 package router/progress emitter/packager를 조합해 실행
+4. `download-handlers.ts`가 `electron/services/download-orchestrator.ts`를 호출하고, 서비스가 `electron/services/download/session-registry.ts`, `download-session.ts`, `delivery-pipeline.ts`, `concurrency-limiter.ts`로 세션 상태/실행 루프/전달 파이프라인/동시성 제어를 분리한 뒤 package router/progress emitter/packager를 조합해 실행
 5. 진행률 이벤트를 `download:*` 채널로 렌더러에 다시 전송
 6. 완료 시 출력 디렉터리와 결과를 히스토리에 저장
 

--- a/docs/ipc-handlers.md
+++ b/docs/ipc-handlers.md
@@ -113,6 +113,8 @@ electron/
 주요 위임 대상:
 
 - `electron/services/download-orchestrator.ts`
+- `electron/services/download/download-session.ts`
+- `electron/services/download/concurrency-limiter.ts`
 - `electron/services/download/delivery-pipeline.ts`
 - `electron/services/download/session-registry.ts`
 - `electron/services/download-package-router.ts`

--- a/electron/services/download-orchestrator.ts
+++ b/electron/services/download-orchestrator.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
-import pLimit from 'p-limit';
+import { createConcurrencyLimiter } from './download/concurrency-limiter';
 import { createDeliveryPipeline } from './download/delivery-pipeline';
+import { createDownloadSessionRunner } from './download/download-session';
 import {
   bindSessionProgressEmitter,
   createDownloadSessionRegistry,
@@ -9,8 +10,6 @@ import {
 } from './download/session-registry';
 import {
   createDownloadPackageRouter,
-  type DownloadExecutionState,
-  type DownloadPackageResult,
   type DownloadPackageRouter,
 } from './download-package-router';
 import {
@@ -22,12 +21,10 @@ import { getArchivePackager } from '../../src/core/packager/archive-packager';
 import { getFileSplitter } from '../../src/core/packager/file-splitter';
 import { generateInstallScripts } from '../../src/core/shared';
 import { createScopedLogger } from '../utils/logger';
+import type { ConcurrencyLimiterFactory } from './download/concurrency-limiter';
 import type { DownloadOptions, DownloadPackage } from '../../src/core/shared';
-import type { PackageInfo } from '../../src/types';
 
 const log = createScopedLogger('DownloadOrchestrator');
-
-type Limiter = <T>(task: () => Promise<T>) => Promise<T>;
 
 export interface DownloadOrchestratorDeps {
   getMainWindow: () => Electron.BrowserWindow | null;
@@ -36,7 +33,7 @@ export interface DownloadOrchestratorDeps {
   emptyDir?: (targetPath: string) => Promise<void>;
   readdir?: typeof fse.readdir;
   stat?: typeof fse.stat;
-  createLimiter?: (concurrency: number) => Limiter;
+  createLimiter?: ConcurrencyLimiterFactory;
   scheduleTask?: (task: () => Promise<void>) => Promise<void> | void;
   createPackageRouter?: () => DownloadPackageRouter;
   createProgressEmitter?: (
@@ -71,9 +68,7 @@ export function createDownloadOrchestrator(
   const emptyDir = deps.emptyDir ?? ((targetPath) => fse.emptyDir(targetPath));
   const readdir = deps.readdir ?? fse.readdir.bind(fse);
   const stat = deps.stat ?? fse.stat.bind(fse);
-  const createLimiter =
-    deps.createLimiter ??
-    ((concurrency: number): Limiter => pLimit(concurrency) as unknown as Limiter);
+  const createLimiter = deps.createLimiter ?? createConcurrencyLimiter;
   const scheduleTask =
     deps.scheduleTask ??
     ((task: () => Promise<void>) => {
@@ -98,6 +93,12 @@ export function createDownloadOrchestrator(
     getFileSplitter: fileSplitterFactory,
     stat,
   });
+  const downloadSession = createDownloadSessionRunner({
+    ensureDir,
+    createLimiter,
+    packageRouter,
+    deliveryPipeline,
+  });
 
   return {
     async startDownload(data) {
@@ -110,7 +111,7 @@ export function createDownloadOrchestrator(
         message: '다운로드 중...',
       });
 
-      await Promise.resolve(scheduleTask(() => runDownload(data, sessionProgressEmitter, state)));
+      await Promise.resolve(scheduleTask(() => downloadSession.run(data, sessionProgressEmitter, state)));
       return { success: true, started: true };
     },
 
@@ -189,85 +190,5 @@ export function createDownloadOrchestrator(
         return { success: false, deleted: false };
       }
     },
-  };
-
-  async function runDownload(data: {
-    sessionId?: number;
-    packages: DownloadPackage[];
-    options: DownloadOptions;
-  }, sessionProgressEmitter: DownloadProgressEmitter, state: DownloadExecutionState): Promise<void> {
-    const { packages, options } = data;
-    const { outputDir, concurrency = 3 } = options;
-    const packagesDir = path.join(outputDir, 'packages');
-    const limit = createLimiter(concurrency);
-    const emitCancelledCompletion = (
-      currentOutputPath: string,
-      currentArtifactPaths?: string[]
-    ) => {
-      sessionProgressEmitter.emitAllComplete({
-        success: false,
-        cancelled: true,
-        outputPath: currentOutputPath,
-        artifactPaths: currentArtifactPaths,
-      });
-    };
-
-    try {
-      await ensureDir(packagesDir);
-      const downloadPromises = packages.map((pkg) =>
-        limit(() =>
-          packageRouter.downloadPackage(pkg, {
-            packagesDir,
-            options,
-            progressEmitter: sessionProgressEmitter,
-            state,
-          })
-        )
-      );
-
-      const rawResults: DownloadPackageResult[] = await Promise.all(downloadPromises);
-      const results = rawResults.filter((result) => result.error !== 'cancelled');
-
-      if (state.isCancelled()) {
-        emitCancelledCompletion(outputDir);
-        return;
-      }
-
-      const successfulPackageIds = new Set(
-        results.filter((result) => result.success).map((result) => result.id)
-      );
-      const deliveredPackages = packages.filter((pkg) => successfulPackageIds.has(pkg.id));
-      const packageInfos = deliveredPackages.map(toPackageInfo);
-      const failedDownloadCount = results.filter((result) => !result.success).length;
-      const completionPayload = await deliveryPipeline.finalizeDownload({
-        outputDir,
-        options,
-        deliveredPackages,
-        packageInfos,
-        results,
-        failedDownloadCount,
-        progressEmitter: sessionProgressEmitter,
-        isCancelled: () => state.isCancelled(),
-      });
-
-      sessionProgressEmitter.emitAllComplete(completionPayload);
-    } catch (error) {
-      sessionProgressEmitter.emitAllComplete({
-        success: false,
-        outputPath: outputDir,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-
-}
-
-function toPackageInfo(pkg: DownloadPackage): PackageInfo {
-  return {
-    type: pkg.type as PackageInfo['type'],
-    name: pkg.name,
-    version: pkg.version,
-    arch: pkg.architecture as PackageInfo['arch'],
-    metadata: pkg.metadata,
   };
 }

--- a/electron/services/download/concurrency-limiter.test.ts
+++ b/electron/services/download/concurrency-limiter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createConcurrencyLimiter } from './concurrency-limiter';
+
+describe('createConcurrencyLimiter', () => {
+  it('concurrency 1에서는 다음 작업을 앞선 작업 완료 후 실행해야 함', async () => {
+    const limit = createConcurrencyLimiter(1);
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const firstTask = limit(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+    });
+
+    const secondTask = limit(async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(events).toEqual(['first:start']);
+
+    releaseFirst();
+    await Promise.all([firstTask, secondTask]);
+
+    expect(events).toEqual([
+      'first:start',
+      'first:end',
+      'second:start',
+      'second:end',
+    ]);
+  });
+});

--- a/electron/services/download/concurrency-limiter.ts
+++ b/electron/services/download/concurrency-limiter.ts
@@ -1,0 +1,8 @@
+import pLimit from 'p-limit';
+
+export type Limiter = <T>(task: () => Promise<T>) => Promise<T>;
+
+export type ConcurrencyLimiterFactory = (concurrency: number) => Limiter;
+
+export const createConcurrencyLimiter: ConcurrencyLimiterFactory = (concurrency) =>
+  pLimit(concurrency) as unknown as Limiter;

--- a/electron/services/download/download-session.test.ts
+++ b/electron/services/download/download-session.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDownloadSessionRunner } from './download-session';
+
+describe('createDownloadSessionRunner', () => {
+  it('성공한 패키지만 DeliveryPipeline으로 넘기고 completion payload를 emit해야 함', async () => {
+    const ensureDir = vi.fn().mockResolvedValue(undefined);
+    const limit = vi.fn(async (task: () => Promise<unknown>) => task());
+    const createLimiter = vi.fn(() => limit);
+    const packageRouter = {
+      downloadPackage: vi
+        .fn()
+        .mockResolvedValueOnce({ id: 'pip-requests-2.32.0', success: true })
+        .mockResolvedValueOnce({ id: 'pip-urllib3-2.1.0', success: false, error: 'network failed' }),
+    };
+    const deliveryPipeline = {
+      finalizeDownload: vi.fn().mockResolvedValue({
+        success: true,
+        outputPath: '/tmp/out.tar.gz',
+        artifactPaths: ['/tmp/out.tar.gz'],
+      }),
+    };
+    const progressEmitter = {
+      emitAllComplete: vi.fn(),
+    };
+
+    const runner = createDownloadSessionRunner({
+      ensureDir,
+      createLimiter,
+      packageRouter: packageRouter as never,
+      deliveryPipeline: deliveryPipeline as never,
+    });
+
+    await runner.run(
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.32.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.32.0',
+          },
+          {
+            id: 'pip-urllib3-2.1.0',
+            type: 'pip',
+            name: 'urllib3',
+            version: '2.1.0',
+          },
+        ],
+        options: {
+          outputDir: '/tmp/out',
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 4,
+        },
+      },
+      progressEmitter as never,
+      {
+        isCancelled: () => false,
+        isPaused: () => false,
+        waitWhilePaused: async () => undefined,
+      }
+    );
+
+    expect(ensureDir).toHaveBeenCalledWith('/tmp/out/packages');
+    expect(createLimiter).toHaveBeenCalledWith(4);
+    expect(limit).toHaveBeenCalledTimes(2);
+    expect(deliveryPipeline.finalizeDownload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: '/tmp/out',
+        deliveredPackages: [
+          expect.objectContaining({
+            id: 'pip-requests-2.32.0',
+          }),
+        ],
+        failedDownloadCount: 1,
+      })
+    );
+    expect(progressEmitter.emitAllComplete).toHaveBeenCalledWith({
+      success: true,
+      outputPath: '/tmp/out.tar.gz',
+      artifactPaths: ['/tmp/out.tar.gz'],
+    });
+  });
+
+  it('다운로드 이후 세션이 취소되면 DeliveryPipeline 없이 cancelled 완료 이벤트를 emit해야 함', async () => {
+    let cancelled = false;
+    const deliveryPipeline = {
+      finalizeDownload: vi.fn(),
+    };
+    const progressEmitter = {
+      emitAllComplete: vi.fn(),
+    };
+
+    const runner = createDownloadSessionRunner({
+      ensureDir: vi.fn().mockResolvedValue(undefined),
+      createLimiter: () => (async (task: () => Promise<unknown>) => task()) as never,
+      packageRouter: {
+        downloadPackage: vi.fn().mockImplementation(async () => {
+          cancelled = true;
+          return { id: 'pip-requests-2.32.0', success: true };
+        }),
+      } as never,
+      deliveryPipeline: deliveryPipeline as never,
+    });
+
+    await runner.run(
+      {
+        packages: [
+          {
+            id: 'pip-requests-2.32.0',
+            type: 'pip',
+            name: 'requests',
+            version: '2.32.0',
+          },
+        ],
+        options: {
+          outputDir: '/tmp/out',
+          outputFormat: 'tar.gz',
+          includeScripts: false,
+          concurrency: 1,
+        },
+      },
+      progressEmitter as never,
+      {
+        isCancelled: () => cancelled,
+        isPaused: () => false,
+        waitWhilePaused: async () => undefined,
+      }
+    );
+
+    expect(deliveryPipeline.finalizeDownload).not.toHaveBeenCalled();
+    expect(progressEmitter.emitAllComplete).toHaveBeenCalledWith({
+      success: false,
+      cancelled: true,
+      outputPath: '/tmp/out',
+      artifactPaths: undefined,
+    });
+  });
+});

--- a/electron/services/download/download-session.test.ts
+++ b/electron/services/download/download-session.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 import { createDownloadSessionRunner } from './download-session';
 
@@ -61,7 +62,7 @@ describe('createDownloadSessionRunner', () => {
       }
     );
 
-    expect(ensureDir).toHaveBeenCalledWith('/tmp/out/packages');
+    expect(ensureDir).toHaveBeenCalledWith(path.join('/tmp/out', 'packages'));
     expect(createLimiter).toHaveBeenCalledWith(4);
     expect(limit).toHaveBeenCalledTimes(2);
     expect(deliveryPipeline.finalizeDownload).toHaveBeenCalledWith(

--- a/electron/services/download/download-session.ts
+++ b/electron/services/download/download-session.ts
@@ -1,0 +1,111 @@
+import * as path from 'path';
+import type { DownloadOptions, DownloadPackage } from '../../../src/core/shared';
+import type { PackageInfo } from '../../../src/types';
+import type {
+  DownloadExecutionState,
+  DownloadPackageResult,
+  DownloadPackageRouter,
+} from '../download-package-router';
+import type { DownloadProgressEmitter } from '../download-progress';
+import type { ConcurrencyLimiterFactory } from './concurrency-limiter';
+import type { DeliveryPipeline } from './delivery-pipeline';
+
+export interface DownloadSessionRunnerDeps {
+  ensureDir: (targetPath: string) => Promise<void>;
+  createLimiter: ConcurrencyLimiterFactory;
+  packageRouter: DownloadPackageRouter;
+  deliveryPipeline: DeliveryPipeline;
+}
+
+export interface DownloadSessionRunner {
+  run(
+    data: {
+      sessionId?: number;
+      packages: DownloadPackage[];
+      options: DownloadOptions;
+    },
+    progressEmitter: DownloadProgressEmitter,
+    state: DownloadExecutionState
+  ): Promise<void>;
+}
+
+export function createDownloadSessionRunner(
+  deps: DownloadSessionRunnerDeps
+): DownloadSessionRunner {
+  return {
+    async run(data, progressEmitter, state) {
+      const { packages, options } = data;
+      const { outputDir, concurrency = 3 } = options;
+      const packagesDir = path.join(outputDir, 'packages');
+      const limit = deps.createLimiter(concurrency);
+      const emitCancelledCompletion = (
+        currentOutputPath: string,
+        currentArtifactPaths?: string[]
+      ) => {
+        progressEmitter.emitAllComplete({
+          success: false,
+          cancelled: true,
+          outputPath: currentOutputPath,
+          artifactPaths: currentArtifactPaths,
+        });
+      };
+
+      try {
+        await deps.ensureDir(packagesDir);
+        const downloadPromises = packages.map((pkg) =>
+          limit(() =>
+            deps.packageRouter.downloadPackage(pkg, {
+              packagesDir,
+              options,
+              progressEmitter,
+              state,
+            })
+          )
+        );
+
+        const rawResults: DownloadPackageResult[] = await Promise.all(downloadPromises);
+        const results = rawResults.filter((result) => result.error !== 'cancelled');
+
+        if (state.isCancelled()) {
+          emitCancelledCompletion(outputDir);
+          return;
+        }
+
+        const successfulPackageIds = new Set(
+          results.filter((result) => result.success).map((result) => result.id)
+        );
+        const deliveredPackages = packages.filter((pkg) => successfulPackageIds.has(pkg.id));
+        const packageInfos = deliveredPackages.map(toPackageInfo);
+        const failedDownloadCount = results.filter((result) => !result.success).length;
+        const completionPayload = await deps.deliveryPipeline.finalizeDownload({
+          outputDir,
+          options,
+          deliveredPackages,
+          packageInfos,
+          results,
+          failedDownloadCount,
+          progressEmitter,
+          isCancelled: () => state.isCancelled(),
+        });
+
+        progressEmitter.emitAllComplete(completionPayload);
+      } catch (error) {
+        progressEmitter.emitAllComplete({
+          success: false,
+          outputPath: outputDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+function toPackageInfo(pkg: DownloadPackage): PackageInfo {
+  return {
+    type: pkg.type as PackageInfo['type'],
+    name: pkg.name,
+    version: pkg.version,
+    arch: pkg.architecture as PackageInfo['arch'],
+    metadata: pkg.metadata,
+  };
+}


### PR DESCRIPTION
## 요약
- download-orchestrator의 실행 루프를 DownloadSessionRunner로 추출했습니다
- 기본 p-limit 생성 경로를 ConcurrencyLimiter support object로 분리했습니다
- 새 support object 단위 테스트와 관련 문서를 추가했습니다

## 검증
- ./node_modules/.bin/eslint electron/services/download/concurrency-limiter.ts electron/services/download/concurrency-limiter.test.ts electron/services/download/download-session.ts electron/services/download/download-session.test.ts electron/services/download-orchestrator.ts
- ./node_modules/.bin/tsc --noEmit
- bash scripts/verify-worktree.sh electron/services/download-orchestrator.test.ts electron/services/download/concurrency-limiter.test.ts electron/services/download/download-session.test.ts