### PR TITLE
Phase 7: core download-manager를 CLI runner로 이동

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -32,6 +32,8 @@ depssmuggler/
 │   ├── cli/
 │   │   ├── index.ts
 │   │   └── commands/
+│   │       ├── download.ts
+│   │       └── download-runner.ts
 │   ├── core/
 │   │   ├── downloaders/
 │   │   ├── downloaders/lang-shared/
@@ -42,7 +44,6 @@ depssmuggler/
 │   │   ├── mailer/
 │   │   ├── shared/
 │   │   ├── config.ts
-│   │   ├── download-manager.ts
 │   │   └── cache-manager.ts      # compatibility shim → shared/cache/artifact-cache.ts
 │   ├── types/
 │   └── utils/

--- a/src/cli/commands/download-runner.test.ts
+++ b/src/cli/commands/download-runner.test.ts
@@ -11,9 +11,9 @@ import {
   type DownloadManagerItem,
   type DownloadManagerOptions,
   type DownloadManagerResult,
-} from './download-manager';
-import { IDownloader, PackageType, DownloadProgressEvent } from '../types';
-import { SpeedCalculator } from './speed-calculator';
+} from './download-runner';
+import { SpeedCalculator } from '../../core/speed-calculator';
+import { IDownloader, PackageType, DownloadProgressEvent } from '../../types';
 
 /**
  * 테스트용 DownloadManager 인터페이스
@@ -754,7 +754,7 @@ describe('DownloadManager 단위 테스트', () => {
 
   describe('getDownloadManager 싱글톤', () => {
     it('싱글톤 인스턴스 반환', async () => {
-      const { getDownloadManager } = await import('./download-manager');
+      const { getDownloadManager } = await import('./download-runner');
 
       const instance1 = getDownloadManager();
       const instance2 = getDownloadManager();

--- a/src/cli/commands/download-runner.ts
+++ b/src/cli/commands/download-runner.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'eventemitter3';
 import * as fs from 'fs-extra';
 import PQueue from 'p-queue';
-import logger from '../utils/logger';
-import { DOWNLOAD_CONSTANTS } from './constants/download';
-import { createRegisteredDownloader, getRegisteredDownloaderTypes } from './downloaders/registry';
-import { SpeedCalculator } from './speed-calculator';
+import { DOWNLOAD_CONSTANTS } from '../../core/constants/download';
+import {
+  createRegisteredDownloader,
+  getRegisteredDownloaderTypes,
+} from '../../core/downloaders/registry';
+import { SpeedCalculator } from '../../core/speed-calculator';
+import logger from '../../utils/logger';
 import type {
   PackageInfo,
   PackageType,
@@ -12,7 +15,7 @@ import type {
   IDownloader,
   DownloadItem as CanonicalDownloadItem,
   DownloadStatus as CanonicalDownloadStatus,
-} from '../types';
+} from '../../types';
 
 // 다운로드 아이템 상태
 export type DownloadManagerItemStatus = CanonicalDownloadStatus;

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -47,13 +47,15 @@ vi.mock('cli-progress', () => ({
   },
 }));
 
-vi.mock('../../core/download-manager', () => ({
-  getDownloadManager: vi.fn(() => ({
-    reset,
-    addToQueue,
-    on,
-    startDownload,
-  })),
+vi.mock('./download-runner', () => ({
+  DownloadManager: vi.fn(function DownloadManagerMock() {
+    return {
+      reset,
+      addToQueue,
+      on,
+      startDownload,
+    };
+  }),
 }));
 
 vi.mock('../../core/packager/archive-packager', () => ({

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
 import * as fs from 'fs-extra';
-import { getDownloadManager, OverallProgress } from '../../core/download-manager';
+import { DownloadManager, OverallProgress } from './download-runner';
 import { getArchivePackager, ArchiveFormat } from '../../core/packager/archive-packager';
 import { getScriptGenerator } from '../../core/packager/script-generator';
 import { DownloadPackage, resolveAllDependencies } from '../../core/shared';
@@ -170,7 +170,7 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
     console.log(chalk.cyan(`동시 다운로드: ${options.concurrency}개\n`));
 
     // 다운로드 매니저 설정
-    const downloadManager = getDownloadManager();
+    const downloadManager = new DownloadManager();
     downloadManager.reset();
     downloadManager.addToQueue(packages);
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,18 +20,6 @@ export type { ScriptOptions, GeneratedScript } from './packager/script-generator
 
 export { FileSplitter, getFileSplitter } from './packager/file-splitter';
 
-// Download Manager
-export { DownloadManager, getDownloadManager } from './download-manager';
-export type {
-  DownloadManagerItem,
-  DownloadManagerItemStatus,
-  DownloadManagerOptions,
-  DownloadManagerResult,
-  OverallProgress,
-  DownloadManagerEvents,
-} from './download-manager';
-export type { DownloadItem, DownloadItemStatus, DownloadOptions, DownloadResult } from './download-manager';
-
 // Resolvers
 export { PipResolver, getPipResolver } from './resolver/pip-resolver';
 export { MavenResolver, getMavenResolver } from './resolver/maven-resolver';


### PR DESCRIPTION
## 요약
- src/core/download-manager.ts를 src/cli/commands/download-runner.ts로 이동해 core 의존을 제거했습니다
- download 명령은 core singleton 대신 CLI runner 인스턴스를 직접 사용하도록 정리했습니다
- 관련 테스트와 아키텍처 문서 경로를 새 위치에 맞게 갱신했습니다

## 검증
- ./node_modules/.bin/eslint src/cli/commands/download-runner.ts src/cli/commands/download-runner.test.ts src/cli/commands/download.ts src/cli/commands/download.test.ts src/core/index.ts
- ./node_modules/.bin/tsc --noEmit
- bash scripts/verify-worktree.sh src/cli/commands/download-runner.test.ts src/cli/commands/download.test.ts