### PR TITLE
feat: 요청 단위 의존성 조회 재사용

### DIFF
--- a/docs/conda-dependency-resolution.md
+++ b/docs/conda-dependency-resolution.md
@@ -710,7 +710,24 @@ download-handlers.ts
 - 다운로드 시 추가 API 호출 불필요
 - 플랫폼/Python 버전 일치 보장
 
-## 8. 참고 자료
+## 8. 요청 단위 조회 재사용
+
+`resolveAllDependencies()`의 한 요청 안에서는 공통 Conda 전이 의존성의
+repodata 호환 후보 선택과 선택된 artifact 정보를 재사용합니다. 조회 키는
+소문자로 정규화한 이름, 최신 선택용 버전 조건 또는 정확 artifact 버전, build,
+channel, target subdir·아키텍처, Python 버전, CUDA 버전을 포함합니다. 따라서
+channel이나 대상 환경, build 조건이 다르면 결과를 공유하지 않습니다.
+
+동일 키의 in-flight 조회는 한 번만 실행하고 consumer마다 복제한 결과를
+반환합니다. 후보가 없거나 오류가 나면 결과를 남기지 않으므로 다음 직접 루트가
+기존 방식으로 다시 후보를 찾습니다. repodata의 메모리·디스크 cache와
+noarch/fallback 처리도 그대로 사용합니다.
+
+이 재사용은 후보와 artifact metadata에 한정됩니다. 각 직접 루트의 BFS 상태,
+부모-자식 관계, Python 호환성 판단과 최종 다운로드 목록은 계속 별도로
+구성되며, 다른 `resolveAllDependencies()` 요청에는 세션이 유지되지 않습니다.
+
+## 9. 참고 자료
 
 - [conda Deep Dive: Solvers](https://docs.conda.io/projects/conda/en/4.13.x/dev-guide/deep-dive-solvers.html)
 - [conda Package Specification](https://conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html)

--- a/docs/maven-dependency-resolution.md
+++ b/docs/maven-dependency-resolution.md
@@ -908,3 +908,22 @@ if (!packaging) {
 ```
 
 **적용 시점**: `downloadPackage` 호출 시 `metadata.packaging`이 없는 경우
+
+## 13. 요청 단위 POM·버전 조회 재사용
+
+여러 Maven 직접 루트를 하나의 `resolveAllDependencies()` 요청으로 처리하면
+공통 전이 좌표의 원시 POM/BOM 조회·파싱과 최신 버전 metadata 조회를 재사용합니다.
+POM key는 실제 적용 저장소 URL(설정된 cache option의 저장소 URL이 있으면 그 값)과
+`groupId:artifactId:version`으로 구성됩니다. 버전 조회는 같은 실제 저장소 URL과
+`groupId:artifactId`를 사용합니다.
+
+병렬 POM prefetch와 이후의 일반 POM 조회도 같은 요청 세션의 producer를
+사용하므로 동시에 발생해도 중복 원격 요청을 만들지 않습니다. prefetch 오류는
+기존처럼 best-effort로 처리하고, 실패·빈 결과는 저장하지 않아 후속 실제 조회나
+다음 직접 루트가 재시도할 수 있습니다. 각 consumer에는 복제한 POM snapshot이
+전달됩니다.
+
+classifier/type 기반 artifact 선택, scope·exclusion, parent/BOM의
+dependencyManagement 적용과 각 루트의 dependency tree는 재사용하지 않습니다.
+따라서 metadata를 절약하면서도 기존 Maven 간선 및 최종 다운로드 선택 규칙을
+유지하며, 요청이 끝나면 세션도 폐기됩니다.

--- a/docs/npm-dependency-resolution.md
+++ b/docs/npm-dependency-resolution.md
@@ -609,3 +609,20 @@ workspaces/arborist/
 
 - https://github.com/npm/cli
 - https://github.com/npm/arborist (npm/cli에 통합됨)
+
+## 14. 요청 단위 packument·버전 조회 재사용
+
+하나의 `resolveAllDependencies()` 요청에서 여러 npm 직접 루트가 같은 전이
+패키지를 요구하면 registry packument 조회와 그 packument에서 실제 버전을
+선택하는 작업을 재사용합니다. 키는 소문자로 정규화한 패키지명, 버전 조건,
+현재 resolver에 전달된 registry URL로 구성하므로 다른 registry의 응답은
+공유하지 않습니다. 이 변경은 기존 host 기반 동작에 새로운 target OS/아키텍처
+매핑을 추가하지 않습니다.
+
+동일 키의 in-flight 조회는 하나로 합치고 각 resolver는 복제한 snapshot을
+받습니다. 조회가 실패하거나 유효한 후보를 선택하지 못하면 저장하지 않아 다음
+직접 루트에서 재시도합니다. 세션은 요청 종료 시 폐기됩니다.
+
+packument와 버전 선택만 공유하며, dependency/optional/peer dependency 해석,
+peer 배치와 hoisting, 각 루트의 트리 및 최종 tarball 목록은 기존처럼 호출별로
+처리합니다.

--- a/docs/pip-dependency-resolution.md
+++ b/docs/pip-dependency-resolution.md
@@ -292,7 +292,25 @@ if (urls && urls.length > 0) {
 2. `sdist` (소스 배포) - wheel이 없는 경우 폴백
 3. 첫 번째 URL - 둘 다 없는 경우
 
-### 7.4 참고 링크
+### 7.4 요청 단위 조회 재사용
+
+`resolveAllDependencies()`로 여러 pip 직접 루트를 해결할 때에는 한 요청 안에서
+PEP 503 정규화 이름이 같은 공통 전이 의존성의 조회를 재사용합니다. 재사용 대상은
+버전 조건에 맞는 최신 후보 선택과 정확 버전의 PyPI JSON/Simple API
+artifact·Core Metadata 조회입니다.
+
+조회 키에는 정규화 이름, 버전 조건, index URL과 base URL, 대상 OS·아키텍처·
+Python 및 세부 플랫폼 정보, source distribution을 검증 없이 허용하는 모드를
+포함합니다. 따라서 서로 다른 저장소나 대상 환경의 결과가 섞이지 않습니다.
+동일 키의 동시 요청은 한 번만 원격 조회하고 각 호출자는 독립 snapshot을 받습니다.
+후보 없음·빈 값·조회 실패는 저장하지 않으므로 뒤의 직접 루트에서 다시 조회합니다.
+
+extras와 PEP 508 marker 평가, BFS 큐와 부모-자식 관계 구성, 최대 깊이와 직접
+루트 실패 의미는 호출별로 계속 처리합니다. 공개 `PipResolver`를 직접 쓰는
+경로와 서로 다른 `resolveAllDependencies()` 호출 사이에는 이 재사용 세션이
+공유되지 않습니다.
+
+### 7.5 참고 링크
 
 - [resolvelib GitHub](https://github.com/sarugaku/resolvelib)
 - [pip GitHub](https://github.com/pypa/pip)

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -6,6 +6,30 @@
 
 ---
 
+## 요청 단위 원격 조회 재사용
+
+공통 `resolveAllDependencies()`는 의존성 포함 요청마다 pip·Conda·Maven·npm의
+새 resolver 묶음과 내부 조회 세션을 만듭니다. 같은 요청 안에서 공통 전이
+의존성이 같은 원격 조회 문맥을 다시 요구하면 후보 선택·metadata/manifest
+조회만 재사용합니다. 동일한 in-flight 조회도 하나의 작업으로 합쳐지고 각
+consumer에는 독립 복제본이 반환됩니다.
+
+세션은 요청 종료와 함께 사라집니다. 실패, `null`, 빈 후보는 저장하지 않아
+뒤의 직접 루트가 재시도할 수 있습니다. 이는 최종 패키지 목록이나 전역 그래프를
+공유하는 기능이 아니므로 각 루트의 BFS 상태, pip extras·marker, Maven
+scope·exclusion·dependencyManagement, npm peer dependency·hoisting 규칙은
+그대로 유지됩니다. OS 패키지(yum/apt/apk)와 Docker는 대상이 아닙니다.
+
+키에는 resolver별 결과에 영향을 주는 입력만 넣습니다. pip은 PEP 503 이름·
+버전 조건·저장소·대상 환경·source 검증 모드, Conda는 이름·버전/build·channel·
+subdir/아키텍처·Python/CUDA, Maven은 실제 저장소 URL과 좌표, npm은 소문자 이름·
+버전 조건·registry URL을 사용합니다. pip과 Maven의 cache option은 요청 시작 시
+전용 resolver에 snapshot으로 복사되며 legacy singleton과 요청 상태를 공유하지
+않습니다. 상세 경계는 [공통 의존성 해결 문서](./shared-dependency.md)와 각
+resolver 문서를 참고합니다.
+
+---
+
 ## PipResolver
 
 ### 개요

--- a/docs/shared-dependency.md
+++ b/docs/shared-dependency.md
@@ -124,6 +124,37 @@ interface OSDistributionSetting {
 
 `resolveAllDependencies`의 `maxDepth` 기본값은 `5`이며 CLI 기본 의존성 포함 다운로드가 사용하는 값입니다. 각 리졸버는 이 깊이까지 해결된 패키지를 결과에 포함합니다. pip는 경계 노드에 적용 가능한 의존성이 남아 있으면 하위 확장을 생략하고 깊이 정보를 담은 경고를 애플리케이션 로그에 기록하지만, 직접 루트를 실패로 처리하지 않습니다. `resolveRootArtifactsOnly`는 shared resolver에서 pip의 `skipDependencyExpansion`으로만 전달되는 루트 전용 처리 힌트입니다. CLI의 `--no-deps`는 이 힌트와 `maxDepth: 0`을 함께 전달하므로 pip와 Conda 모두 루트 아티팩트만 조회하며, 깊이 제한 경고 없이 조용히 종료합니다. pip `PipResolver.resolveDependencies`를 직접 호출할 때의 `maxDepth` 기본값은 `10`입니다.
 
+### 요청 단위 원격 조회 재사용
+
+`includeDependencies`가 활성화된 `resolveAllDependencies()` 호출은 한 번의
+요청에만 살아 있는 내부 조회 세션과 pip·Conda·Maven·npm 전용 resolver를 하나씩
+만듭니다. requirements.txt처럼 여러 직접 루트가 공통 전이 의존성을 가질 때,
+같은 조회 문맥의 **원격 후보 선택과 metadata/manifest 조회 성공 결과**만
+재사용합니다. 함수가 반환되면 세션은 폐기되므로 별도의
+`resolveAllDependencies()` 호출 사이에는 결과를 보존하지 않으며, 이를 제어하는
+새 CLI 옵션이나 설정도 없습니다.
+
+| 타입 | 재사용하는 원격 조회 | 같은 조회로 판단하는 주요 문맥 |
+| --- | --- | --- |
+| pip | 호환 최신 버전, 정확 버전 artifact·metadata | PEP 503 정규화 이름, 버전 조건, index/base URL, 대상 Python·플랫폼, source artifact 검증 모드 |
+| conda | repodata의 호환 후보, 선택된 artifact 정보 | 소문자 이름, 버전 조건/정확 버전, build, channel, subdir·아키텍처, Python·CUDA |
+| Maven | 버전 metadata, 원시 POM/BOM | 실제 적용 저장소 URL, groupId:artifactId:version 좌표 |
+| npm | registry packument, 선택된 버전 | 소문자 이름, 버전 조건, registry URL |
+
+동일 키의 동시 조회는 하나의 원격 작업을 공유하고, 각 소비자에게는 복제한
+snapshot을 돌려주므로 한 트리의 수정이 다른 트리에 영향을 주지 않습니다.
+reject, `null`, 빈 후보처럼 유효하지 않은 결과는 남기지 않아 다음 직접 루트가
+다시 조회할 수 있습니다. 완료된 재사용 hit가 있으면 애플리케이션 info 로그에
+세션 hit/miss/join 통계를 남깁니다.
+
+이 최적화는 전역 의존성 solver가 아닙니다. 직접 루트별 dependency tree,
+best-effort/`--strict` 실패 처리, pip extras·marker, Maven scope·exclusion·
+dependencyManagement, npm peer·hoisting, 최종 다운로드 아티팩트 중복 제거는 기존
+규칙대로 각 호출 경로에서 계속 처리합니다. yum/apt/apk와 Docker는 이 세션 대상이
+아닙니다. pip·Maven의 기존 cache option은 요청 시작 시 전용 resolver에 복사한
+snapshot을 사용하므로, 요청 중 변경이 legacy singleton 설정으로 역전파되지
+않습니다.
+
 ### DependencyProgressCallback
 
 의존성 해결 진행 상황을 실시간으로 전달하는 콜백

--- a/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
+++ b/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
@@ -84,7 +84,7 @@ export function getAttachedResolutionSession(owner: object): ResolutionSession |
 
 - [ ] **Step 2: 테스트가 기능 부재로 실패하는지 확인한다.**
 
-Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts`
+Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts src/core/shared/internal/resolution-session-registry.test.ts`
 
 Expected: FAIL — 내부 `resolution-session` 모듈을 찾지 못한다.
 
@@ -113,7 +113,7 @@ export class ResolutionSession {
 
 - [ ] **Step 4: 세션 단위 테스트가 통과하는지 확인한다.**
 
-Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts`
+Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts src/core/shared/internal/resolution-session-registry.test.ts`
 
 Expected: PASS — producer 1회, snapshot 격리, namespace 분리, reject/null/empty 재시도가 확인된다.
 
@@ -134,6 +134,9 @@ git commit -m "feat: 요청 단위 의존성 세션 추가"
 - Modify: `src/core/resolver/npm-resolver.ts`
 - Modify: `src/core/shared/dependency-resolver.ts`
 - Modify: `src/core/shared/dependency-resolver.test.ts`
+- Modify: `src/core/resolver/pip-resolver.test.ts`
+- Modify: `src/core/resolver/maven-resolver.test.ts`
+- Modify: `src/core/resolver/npm-resolver.test.ts`
 
 - [ ] **Step 1: factory 사용과 동시 요청 격리의 실패 테스트를 작성한다.**
 
@@ -141,7 +144,7 @@ git commit -m "feat: 요청 단위 의존성 세션 추가"
 
 - [ ] **Step 2: 테스트가 기존 singleton 흐름 때문에 실패하는지 확인한다.**
 
-Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts`
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts src/core/resolver/npm-resolver.test.ts`
 
 Expected: FAIL — 요청 factory export가 없거나 `getPipResolver()` singleton이 호출된다.
 
@@ -165,14 +168,14 @@ Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복�
 
 - [ ] **Step 4: factory·동시 요청 테스트를 통과시킨다.**
 
-Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts`
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts src/core/resolver/npm-resolver.test.ts`
 
 Expected: PASS — 타입당 요청 factory 1회, 요청 간 상태 분리, cache option snapshot을 확인한다.
 
 - [ ] **Step 5: 두 번째 단위를 커밋한다.**
 
 ```bash
-git add src/core/shared/dependency-resolver.ts src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/conda-resolver.ts src/core/resolver/maven-resolver.ts src/core/resolver/maven-resolver.test.ts src/core/resolver/npm-resolver.ts
+git add src/core/shared/dependency-resolver.ts src/core/shared/dependency-resolver.test.ts src/core/shared/internal/resolution-session-registry.ts src/core/shared/internal/resolution-session-registry.test.ts src/core/resolver/pip-resolver.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/conda-resolver.ts src/core/resolver/maven-resolver.ts src/core/resolver/maven-resolver.test.ts src/core/resolver/npm-resolver.ts src/core/resolver/npm-resolver.test.ts
 git commit -m "feat: 의존성 요청별 resolver 상태 격리"
 ```
 

--- a/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
+++ b/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
@@ -14,8 +14,8 @@
 
 | 파일 | 책임 |
 | --- | --- |
-| `src/core/shared/resolution-session.ts` | 요청 수명 memoizer, namespace key, clone-on-read, hit/miss 통계 |
-| `src/core/shared/resolution-session.test.ts` | 세션의 동시성·실패·키·불변성 계약 |
+| `src/core/shared/internal/resolution-session.ts` | 내부 요청 수명 memoizer, namespace key, clone-on-read, hit/miss 통계 |
+| `src/core/shared/internal/resolution-session.test.ts` | 내부 세션의 동시성·실패·키·불변성 계약 |
 | `src/core/resolver/{pip,conda,maven,npm}-resolver.ts` | 요청 전용 factory 및 resolver별 session 적용 |
 | `src/core/shared/npm-version-resolver.ts` | npm packument/후보 선택 session 적용 |
 | `src/core/shared/dependency-resolver.ts` | 세션·요청 전용 resolver 묶음 생성과 통계 로그 |
@@ -26,13 +26,12 @@
 
 **Files:**
 
-- Create: `src/core/shared/resolution-session.ts`
-- Create: `src/core/shared/resolution-session.test.ts`
-- Modify: `src/core/shared/index.ts`
+- Create: `src/core/shared/internal/resolution-session.ts`
+- Create: `src/core/shared/internal/resolution-session.test.ts`
 
 - [ ] **Step 1: 실패하는 세션 단위 테스트를 작성한다.**
 
-`resolution-session.test.ts`에 다음을 각각 독립 테스트로 추가한다.
+`internal/resolution-session.test.ts`에 다음을 각각 독립 테스트로 추가한다.
 
 ```ts
 it('동일 resolver·operation·문맥의 in-flight producer를 한 번만 실행한다', async () => {
@@ -74,13 +73,13 @@ it('reject·null·빈 후보는 저장하지 않고 다음 조회에서 재시�
 
 - [ ] **Step 2: 테스트가 기능 부재로 실패하는지 확인한다.**
 
-Run: `npx vitest run src/core/shared/resolution-session.test.ts`
+Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts`
 
-Expected: FAIL — `resolution-session` 모듈 또는 `ResolutionSession` export를 찾지 못한다.
+Expected: FAIL — 내부 `resolution-session` 모듈을 찾지 못한다.
 
 - [ ] **Step 3: 최소 세션 구현을 작성한다.**
 
-`resolution-session.ts`에 다음 공개 API를 만든다.
+`internal/resolution-session.ts`에 내부 API를 만든다. `src/core/shared/index.ts` 또는 `src/core/index.ts`에는 export하지 않는다.
 
 ```ts
 export type ResolutionOperation = 'latest-version' | 'package-info' | 'packument' | 'pom';
@@ -99,18 +98,18 @@ export class ResolutionSession {
 
 `stableSerialize()`는 object key를 재귀 정렬하고 `undefined`를 일관되게 표현한다. map에는 canonical producer Promise만 저장한다. 새 항목은 `Promise.resolve().then(producer)`로 등록한다. reject 또는 `isCacheable(value) === false`일 때는 **map에 같은 Promise가 남아 있을 때만** 제거한다. 반환은 항상 `canonical.then((value) => structuredClone(value))`여야 한다. 기본 cacheable 규칙은 `value !== null && value !== undefined`; 후보 선택 caller는 `Boolean(value)` predicate를 전달해 빈 문자열도 제거한다. 복제 불가능한 값을 공유하지 말고 오류를 전파한다.
 
-`shared/index.ts`에서 세션 type과 클래스를 export한다.
+세션은 `resolveAllDependencies()`와 resolver module 내부 factory만 import한다. `ResolverOptions`에 session 필드를 추가하거나 public resolver constructor에 session 인자를 추가하지 않는다. 외부 호출 경로는 요청 session을 전달·보존할 수 없다.
 
 - [ ] **Step 4: 세션 단위 테스트가 통과하는지 확인한다.**
 
-Run: `npx vitest run src/core/shared/resolution-session.test.ts`
+Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts`
 
 Expected: PASS — producer 1회, snapshot 격리, namespace 분리, reject/null/empty 재시도가 확인된다.
 
 - [ ] **Step 5: 첫 단위를 커밋한다.**
 
 ```bash
-git add src/core/shared/resolution-session.ts src/core/shared/resolution-session.test.ts src/core/shared/index.ts
+git add src/core/shared/internal/resolution-session.ts src/core/shared/internal/resolution-session.test.ts
 git commit -m "feat: 요청 단위 의존성 세션 추가"
 ```
 
@@ -137,17 +136,19 @@ Expected: FAIL — 요청 factory export가 없거나 `getPipResolver()` singlet
 
 - [ ] **Step 3: 요청 전용 factory를 최소 구현한다.**
 
-각 library resolver module에 `createRequest*Resolver(session: ResolutionSession)` export를 추가한다. Factory는 매번 새 instance를 만들고 constructor로 session을 주입한다.
+각 library resolver module에는 `/** @internal */`로 표시하고 public barrel에서는 re-export하지 않는 `createRequest*Resolver(session)` helper를 추가한다. Factory는 매번 새 instance를 만든다. session은 public constructor/`ResolverOptions`가 아니라 module-private `WeakMap<Resolver, ResolutionSession>`에 factory가 연결하고 resolver의 private accessor만 읽는다.
 
 ```ts
+/** @internal dependency-resolver 전용 factory */
 export function createRequestPipResolver(session: ResolutionSession): PipResolver {
-  const resolver = new PipResolver(session);
+  const resolver = new PipResolver();
+  requestSessions.set(resolver, session);
   resolver.setCacheOptions(getPipResolver().getCacheOptions());
   return resolver;
 }
 ```
 
-Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복사본을 반환한다. Conda/Npm도 매번 새 resolver를 반환한다. 기존 singleton accessor와 session 없는 constructor의 동작은 유지한다.
+Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복사본을 반환한다. Conda/Npm도 매번 새 resolver를 반환한다. Factory와 `ResolutionSession`은 `src/core/index.ts`와 public shared barrel에 export하지 않으며, `dependency-resolver.ts`만 이 internal module path를 사용한다. 기존 singleton accessor와 public constructor는 session 없는 동작을 유지한다.
 
 `dependency-resolver.ts`에서는 함수 시작 시 session과 library resolver 묶음을 한 번 생성한다. `getResolverByType`은 OS/Docker 특수 경로를 건드리지 않고 pip/conda/Maven/npm만 묶음에서 반환한다. 종료 시 hit이 1 이상일 때만 hit/miss/join 통계를 `logger.info`로 남긴다. `includeDependencies: false` 조기 반환은 세션/factory를 만들지 않는다.
 
@@ -173,7 +174,7 @@ git commit -m "feat: 의존성 요청별 resolver 상태 격리"
 
 - [ ] **Step 1: 공통 전이 pip 의존성 재사용의 실패 테스트를 작성한다.**
 
-두 직접 root `alpha`와 `beta`가 `shared>=1`을 요구하도록 PyPI JSON mock을 구성한다. 하나의 `ResolutionSession`을 주입한 별도 `PipResolver` 두 개를 순차 실행하고 `shared`의 release lookup과 exact artifact metadata lookup이 각각 1회인지 검증한다. Simple API와 JSON 경로를 모두 포함한다. 다른 `indexUrl`, Python 버전 또는 `skipDependencyExpansion`의 source-artifact 검증 모드에서는 shared 조회가 재사용되지 않는 테스트도 작성한다. 첫 호출의 null/empty 후보 또는 reject 뒤 두 번째 root가 producer를 다시 호출하는 테스트를 추가한다.
+두 직접 root `alpha`와 `beta`가 `shared>=1`을 요구하도록 PyPI JSON mock을 구성한다. 하나의 내부 `ResolutionSession`을 factory로 연결한 별도 resolver 두 개를 순차 실행하고 `shared`의 release lookup과 exact artifact metadata lookup이 각각 1회인지 검증한다. Simple API와 JSON 경로를 모두 포함한다. 다른 `indexUrl`, Python 버전 또는 `skipDependencyExpansion`의 source-artifact 검증 모드에서는 shared 조회가 재사용되지 않는 테스트도 작성한다. `Shared_Pkg`, `shared-pkg`, `shared.pkg`가 PEP 503 canonical name 하나로 재사용되는 테스트와 첫 호출의 null/empty 후보 또는 reject 뒤 두 번째 root가 producer를 다시 호출하는 테스트를 추가한다.
 
 - [ ] **Step 2: 테스트가 중복 조회를 보여 주며 실패하는지 확인한다.**
 
@@ -187,7 +188,7 @@ Expected: FAIL — shared의 latest-version/package-info producer가 두 번 실
 
 ```ts
 {
-  name: normalize(name), versionSpec: versionSpec ?? null, indexUrl: indexUrl ?? null,
+  name: pep503Normalize(name), versionSpec: versionSpec ?? null, indexUrl: indexUrl ?? null,
   target: this.pipTargetPlatform, pythonVersion: this.pythonVersion,
   baseUrl: this.cacheOptions.baseUrl ?? null,
   allowUnverifiedSourceArtifact,
@@ -219,7 +220,7 @@ git commit -m "feat: pip 의존성 조회를 요청 세션에서 재사용"
 
 - [ ] **Step 1: conda 공통 전이 의존성의 실패 테스트를 작성한다.**
 
-두 root가 같은 `shared` Conda dependency를 갖는 fixture를 만들고, 두 요청 전용 `CondaResolver(session)` 실행에서 `getLatestVersionFromRepoData`와 candidate selection이 한 번만 수행되는지 spy한다. channel, targetSubdir, Python, CUDA, build가 달라지면 재사용하지 않는 테스트와 null 후보 뒤 두 번째 resolver가 repodata candidate producer를 다시 실행하는 테스트를 추가한다.
+두 root가 같은 `shared` Conda dependency를 갖는 fixture를 만들고, 내부 factory로 연결한 두 요청 전용 resolver 실행에서 `getLatestVersionFromRepoData`와 candidate selection이 한 번만 수행되는지 spy한다. channel, targetSubdir, Python, CUDA, build가 달라지면 재사용하지 않는 테스트와 `Shared`/`shared`가 하나의 canonical key를 쓰는 테스트, null 후보 뒤 두 번째 resolver가 repodata candidate producer를 다시 실행하는 테스트를 추가한다.
 
 - [ ] **Step 2: 테스트가 중복 candidate selection으로 실패하는지 확인한다.**
 
@@ -229,7 +230,7 @@ Expected: FAIL — 같은 channel/subdir 후보 탐색이 root마다 반복된�
 
 - [ ] **Step 3: resolver helper를 통해 conda 세션 적용 지점을 단일화한다.**
 
-`CondaResolver`에 `getLatestVersionFromRepoDataWithSession()`와 `fetchPackageInfoBFSWithSession()` helper를 만든다. 전자는 processor의 `getLatestVersionFromRepoData()` 호출을 `'conda'/'latest-version'`으로, 후자는 현재 `fetchPackageInfoBFS()` body를 `'conda'/'package-info'`으로 감싼다. 두 key는 `{ name, versionSpec/version, buildSpec, channel, targetSubdir, targetArchitecture, pythonVersion, cudaVersion }`을 포함한다. null/latest 후보와 대상 artifact 오류는 cache하지 않는다. processor의 disk/memory repodata cache와 Conda BFS parent-child map은 변경하지 않는다.
+`CondaResolver`에 `getLatestVersionFromRepoDataWithSession()`와 `fetchPackageInfoBFSWithSession()` helper를 만든다. 전자는 processor의 `getLatestVersionFromRepoData()` 호출을 `'conda'/'latest-version'`으로, 후자는 현재 `fetchPackageInfoBFS()` body를 `'conda'/'package-info'`으로 감싼다. 두 key는 `{ name: name.toLowerCase(), versionSpec/version, buildSpec, channel, targetSubdir, targetArchitecture, pythonVersion, cudaVersion }`을 포함한다. null/latest 후보와 대상 artifact 오류는 cache하지 않는다. processor의 disk/memory repodata cache와 Conda BFS parent-child map은 변경하지 않는다.
 
 - [ ] **Step 4: conda 회귀 테스트를 통과시킨다.**
 
@@ -254,7 +255,7 @@ git commit -m "feat: conda 후보 탐색을 요청 세션에서 재사용"
 
 - [ ] **Step 1: Maven POM sharing·prefetch의 실패 테스트를 작성한다.**
 
-`MavenResolver(session)` 두 개가 같은 GAV POM을 읽을 때 raw POM producer가 한 번만 호출되는 테스트를 만든다. 한 resolver의 `fetchPomWithCache` 결과를 mutate한 뒤 다른 resolver 결과는 원본인 clone-on-read 테스트를 추가한다. prefetch 직후 동일 coordinate 단건 fetch가 같은 in-flight producer를 사용하는 테스트와, prefetch 실패가 실제 resolve의 오류 정책을 바꾸지 않는 테스트를 추가한다. 같은 GAV라도 classifier가 다른 root는 raw POM 한 번을 공유하면서 각 root artifact selection은 독립적인 assertion을 넣는다.
+내부 factory로 연결한 Maven resolver 두 개가 같은 GAV POM을 읽을 때 raw POM producer가 한 번만 호출되는 테스트를 만든다. `setCacheOptions({ repoUrl: 'https://repo-a.example/maven2' })`와 다른 `repoUrl`인 resolver는 raw POM을 공유하지 않는 테스트를 추가한다. 한 resolver의 `fetchPomWithCache` 결과를 mutate한 뒤 다른 resolver 결과는 원본인 clone-on-read 테스트를 추가한다. prefetch 직후 동일 coordinate 단건 fetch가 같은 in-flight producer를 사용하는 테스트와, prefetch 실패가 실제 resolve의 오류 정책을 바꾸지 않는 테스트를 추가한다. 같은 GAV라도 classifier가 다른 root는 raw POM 한 번을 공유하면서 각 root artifact selection은 독립적인 assertion을 넣는다.
 
 - [ ] **Step 2: 테스트가 POM producer 중복 호출로 실패하는지 확인한다.**
 
@@ -264,7 +265,7 @@ Expected: FAIL — session-aware POM producer가 없고 prefetch가 별도 cache
 
 - [ ] **Step 3: Maven 세션 producer를 단일화한다.**
 
-`fetchPomWithCache()`를 `'maven'/'pom'` session operation으로 감싼다. context는 `{ repoUrl, groupId, artifactId, version }`만 포함하고 classifier/type은 포함하지 않는다. `getLatestVersion()`은 `'maven'/'latest-version'`으로 분리해 빈 문자열을 cache하지 않는다.
+`fetchPomWithCache()`를 `'maven'/'pom'` session operation으로 감싼다. context에는 실제 `fetchPomFromCache()`가 쓰는 `effectiveRepoUrl = this.cacheOptions.repoUrl ?? this.repoUrl`와 `{ groupId, artifactId, version }`만 포함하고 classifier/type은 포함하지 않는다. `getLatestVersion()`은 `'maven'/'latest-version'`으로 분리해 빈 문자열을 cache하지 않는다. repository URL 격리와 동일 GAV/classifier 재사용을 각각 테스트로 고정한다.
 
 `prefetchPomsParallelInternal()`은 `prefetchPomsParallel()` 직접 호출 대신 같은 `fetchPomWithCache()`를 `parallelThreads` 제한으로 fire-and-forget 호출한다. 각 task 오류는 debug log로 소비해 best-effort prefetch 의미를 유지하고, 이후 실제 fetch의 오류는 기존 호출자가 처리한다. POM/BOM을 소비하는 scope/exclusion, dependency-management, classifier/type 선택 로직은 session 밖에 둔다.
 
@@ -292,7 +293,7 @@ git commit -m "feat: Maven POM 조회를 요청 세션에서 재사용"
 
 - [ ] **Step 1: npm 공통 dependency의 실패 테스트를 작성한다.**
 
-공유 session을 받는 별도 `NpmResolver` 두 개가 같은 transitive `shared@^1`을 처리할 때 `fetchPackument`와 비동기 version candidate producer가 각각 한 번 실행되는지 검증한다. registry URL 또는 name/spec이 다르면 재사용하지 않는 테스트, 없는 version(`null`) 뒤 두 번째 resolver가 재시도하는 테스트를 추가한다. OS/architecture는 session key에 새로 추가하지 않고 기존 `NpmResolver`의 package `os`/`cpu` 필터가 root별로 유지되는지도 검증한다.
+내부 factory로 연결한 별도 `NpmResolver` 두 개가 같은 transitive `shared@^1`을 처리할 때 `fetchPackument`와 비동기 version candidate producer가 각각 한 번 실행되는지 검증한다. registry URL 또는 name/spec이 다르면 재사용하지 않는 테스트, `Shared`/`shared`가 npm canonical lowercase name 하나로 재사용되는 테스트, 없는 version(`null`) 뒤 두 번째 resolver가 재시도하는 테스트를 추가한다. OS/architecture는 session key에 새로 추가하지 않고 기존 `NpmResolver`의 package `os`/`cpu` 필터가 root별로 유지되는지도 검증한다.
 
 - [ ] **Step 2: 테스트가 packument와 version resolution을 반복하며 실패하는지 확인한다.**
 
@@ -302,7 +303,7 @@ Expected: FAIL — `fetchPackument`과 선택 함수가 두 resolver에서 각�
 
 - [ ] **Step 3: NpmVersionResolver에 session-aware async accessor를 추가한다.**
 
-기존 synchronous `resolveVersion()` public API는 유지한다. `fetchPackument()`은 `'npm'/'packument'` session operation으로 감싸고 context에 `{ registryUrl, name }`을 넣는다. 새 `resolveVersionForRequest(spec, packument)`은 `'npm'/'latest-version'` operation으로 `{ registryUrl, name: packument.name, spec }`을 key로 사용하며 `Boolean(version)` predicate를 전달한다. `NpmResolver.resolveDependencies()`와 `processDepItem()`만 새 async accessor를 await한다. `NpmVersionResolver` constructor에는 optional session을 추가하고 Npm request factory는 이를 주입한다. `NpmTreeManager`, peer/optional 처리, hoisting 및 현재 target OS/architecture mapping은 변경하지 않는다.
+기존 synchronous `resolveVersion()` public API는 유지한다. `fetchPackument()`은 `'npm'/'packument'` session operation으로 감싸고 context에 `{ registryUrl, name: name.toLowerCase() }`을 넣는다. 새 `resolveVersionForRequest(spec, packument)`은 `'npm'/'latest-version'` operation으로 `{ registryUrl, name: packument.name.toLowerCase(), spec }`을 key로 사용하며 `Boolean(version)` predicate를 전달한다. `NpmResolver.resolveDependencies()`와 `processDepItem()`만 새 async accessor를 await한다. `NpmVersionResolver`는 resolver module의 private session accessor만 사용하고 public constructor/공개 API에는 session을 추가하지 않는다. `NpmTreeManager`, peer/optional 처리, hoisting 및 현재 target OS/architecture mapping은 변경하지 않는다.
 
 - [ ] **Step 4: npm 회귀 테스트를 통과시킨다.**
 

--- a/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
+++ b/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
@@ -1,0 +1,402 @@
+# 요청 단위 의존성 탐색 재사용 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 하나의 `resolveAllDependencies()` 요청에서 공통 라이브러리 의존성의 후보 선택과 원격 metadata 조회를 한 번만 수행하고, 기존 트리와 실패 의미를 보존한다.
+
+**Architecture:** `ResolutionSession`은 resolver 종류·작업 종류·안정 직렬화 문맥으로 canonical Promise를 관리하고 consumer마다 복제한 snapshot을 반환한다. 공통 resolver는 매 호출마다 세션과 요청 전용 pip/conda/Maven/npm resolver를 만들며, resolver는 원격 후보/manifest 조회만 세션화한다. extras·scope/exclusion·peer/hoisting의 부모 간선 평가는 기존처럼 직접 루트별로 수행한다.
+
+**Tech Stack:** TypeScript, Node.js `structuredClone`, Vitest, 기존 PyPI/Conda/Maven/npm cache 모듈
+
+---
+
+## 파일 구조
+
+| 파일 | 책임 |
+| --- | --- |
+| `src/core/shared/resolution-session.ts` | 요청 수명 memoizer, namespace key, clone-on-read, hit/miss 통계 |
+| `src/core/shared/resolution-session.test.ts` | 세션의 동시성·실패·키·불변성 계약 |
+| `src/core/resolver/{pip,conda,maven,npm}-resolver.ts` | 요청 전용 factory 및 resolver별 session 적용 |
+| `src/core/shared/npm-version-resolver.ts` | npm packument/후보 선택 session 적용 |
+| `src/core/shared/dependency-resolver.ts` | 세션·요청 전용 resolver 묶음 생성과 통계 로그 |
+| 기존 resolver 테스트 | 공통 전이 의존성 재사용, 키 격리, 재시도 회귀 |
+| `docs/shared-dependency.md`, `docs/resolvers.md`, 유형별 문서 | 재사용 범위·비범위·검증 방법 |
+
+### Task 1: `ResolutionSession`의 공통 계약을 TDD로 만든다
+
+**Files:**
+
+- Create: `src/core/shared/resolution-session.ts`
+- Create: `src/core/shared/resolution-session.test.ts`
+- Modify: `src/core/shared/index.ts`
+
+- [ ] **Step 1: 실패하는 세션 단위 테스트를 작성한다.**
+
+`resolution-session.test.ts`에 다음을 각각 독립 테스트로 추가한다.
+
+```ts
+it('동일 resolver·operation·문맥의 in-flight producer를 한 번만 실행한다', async () => {
+  let release!: (value: { value: string }) => void;
+  const pending = new Promise<{ value: string }>((resolve) => { release = resolve; });
+  const producer = vi.fn(() => pending);
+  const session = new ResolutionSession();
+
+  const first = session.getOrCreate('pip', 'package-info', { name: 'shared' }, producer);
+  const second = session.getOrCreate('pip', 'package-info', { name: 'shared' }, producer);
+  release({ value: 'ok' });
+
+  await expect(Promise.all([first, second])).resolves.toEqual([{ value: 'ok' }, { value: 'ok' }]);
+  expect(producer).toHaveBeenCalledTimes(1);
+});
+
+it('각 consumer에 clone-on-read snapshot을 반환한다', async () => {
+  // 첫 반환값의 중첩 속성을 수정해도 두 번째 반환값은 원래 값을 유지해야 한다.
+});
+
+it.each([
+  ['pip', 'latest-version'],
+  ['pip', 'package-info'],
+  ['npm', 'package-info'],
+])('resolver와 operation namespace가 다르면 값을 섞지 않는다', async (resolver, operation) => {
+  // 같은 name 문맥이어도 producer가 각각 실행되는지 검증한다.
+});
+
+it('객체 키 순서가 다른 동등 문맥을 같은 key로 정규화한다', async () => {
+  // target object의 key 순서만 다른 두 context를 사용한다.
+});
+
+it('reject·null·빈 후보는 저장하지 않고 다음 조회에서 재시도한다', async () => {
+  // null/빈 문자열은 isCacheable: Boolean과 함께 호출해 두 번째 producer 실행을 검증한다.
+});
+```
+
+`getStats()`가 miss/hit/in-flight join을 올바르게 집계하는 테스트도 추가한다.
+
+- [ ] **Step 2: 테스트가 기능 부재로 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/shared/resolution-session.test.ts`
+
+Expected: FAIL — `resolution-session` 모듈 또는 `ResolutionSession` export를 찾지 못한다.
+
+- [ ] **Step 3: 최소 세션 구현을 작성한다.**
+
+`resolution-session.ts`에 다음 공개 API를 만든다.
+
+```ts
+export type ResolutionOperation = 'latest-version' | 'package-info' | 'packument' | 'pom';
+
+export class ResolutionSession {
+  getOrCreate<T>(
+    resolver: 'pip' | 'conda' | 'maven' | 'npm',
+    operation: ResolutionOperation,
+    context: Record<string, unknown>,
+    producer: () => Promise<T>,
+    options?: { isCacheable?: (value: T) => boolean },
+  ): Promise<T>;
+  getStats(): { hits: number; misses: number; joins: number };
+}
+```
+
+`stableSerialize()`는 object key를 재귀 정렬하고 `undefined`를 일관되게 표현한다. map에는 canonical producer Promise만 저장한다. 새 항목은 `Promise.resolve().then(producer)`로 등록한다. reject 또는 `isCacheable(value) === false`일 때는 **map에 같은 Promise가 남아 있을 때만** 제거한다. 반환은 항상 `canonical.then((value) => structuredClone(value))`여야 한다. 기본 cacheable 규칙은 `value !== null && value !== undefined`; 후보 선택 caller는 `Boolean(value)` predicate를 전달해 빈 문자열도 제거한다. 복제 불가능한 값을 공유하지 말고 오류를 전파한다.
+
+`shared/index.ts`에서 세션 type과 클래스를 export한다.
+
+- [ ] **Step 4: 세션 단위 테스트가 통과하는지 확인한다.**
+
+Run: `npx vitest run src/core/shared/resolution-session.test.ts`
+
+Expected: PASS — producer 1회, snapshot 격리, namespace 분리, reject/null/empty 재시도가 확인된다.
+
+- [ ] **Step 5: 첫 단위를 커밋한다.**
+
+```bash
+git add src/core/shared/resolution-session.ts src/core/shared/resolution-session.test.ts src/core/shared/index.ts
+git commit -m "feat: 요청 단위 의존성 세션 추가"
+```
+
+### Task 2: 요청 전용 resolver factory와 요청 격리를 추가한다
+
+**Files:**
+
+- Modify: `src/core/resolver/pip-resolver.ts`
+- Modify: `src/core/resolver/conda-resolver.ts`
+- Modify: `src/core/resolver/maven-resolver.ts`
+- Modify: `src/core/resolver/npm-resolver.ts`
+- Modify: `src/core/shared/dependency-resolver.ts`
+- Modify: `src/core/shared/dependency-resolver.test.ts`
+
+- [ ] **Step 1: factory 사용과 동시 요청 격리의 실패 테스트를 작성한다.**
+
+기존 `dependency-resolver.test.ts` module mock에 `createRequestPipResolver`, `createRequestCondaResolver`, `createRequestMavenResolver`, `createRequestNpmResolver`를 추가한다. pip root 두 개의 같은 요청은 `createRequestPipResolver` 1회와 해당 resolver의 `resolveDependencies` 2회를 기대한다. linux/arm64와 windows/x86_64의 `resolveAllDependencies()`를 동시에 실행해 서로 다른 factory 반환값과 resolver options가 섞이지 않는지 검증한다. Pip/Maven resolver 단위 테스트에는 singleton의 `setCacheOptions()` 이후 factory 결과가 같은 값을 복사하고 factory resolver 변경이 singleton에 역전파되지 않는 검증을 추가한다.
+
+- [ ] **Step 2: 테스트가 기존 singleton 흐름 때문에 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts`
+
+Expected: FAIL — 요청 factory export가 없거나 `getPipResolver()` singleton이 호출된다.
+
+- [ ] **Step 3: 요청 전용 factory를 최소 구현한다.**
+
+각 library resolver module에 `createRequest*Resolver(session: ResolutionSession)` export를 추가한다. Factory는 매번 새 instance를 만들고 constructor로 session을 주입한다.
+
+```ts
+export function createRequestPipResolver(session: ResolutionSession): PipResolver {
+  const resolver = new PipResolver(session);
+  resolver.setCacheOptions(getPipResolver().getCacheOptions());
+  return resolver;
+}
+```
+
+Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복사본을 반환한다. Conda/Npm도 매번 새 resolver를 반환한다. 기존 singleton accessor와 session 없는 constructor의 동작은 유지한다.
+
+`dependency-resolver.ts`에서는 함수 시작 시 session과 library resolver 묶음을 한 번 생성한다. `getResolverByType`은 OS/Docker 특수 경로를 건드리지 않고 pip/conda/Maven/npm만 묶음에서 반환한다. 종료 시 hit이 1 이상일 때만 hit/miss/join 통계를 `logger.info`로 남긴다. `includeDependencies: false` 조기 반환은 세션/factory를 만들지 않는다.
+
+- [ ] **Step 4: factory·동시 요청 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/maven-resolver.test.ts`
+
+Expected: PASS — 타입당 요청 factory 1회, 요청 간 상태 분리, cache option snapshot을 확인한다.
+
+- [ ] **Step 5: 두 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/shared/dependency-resolver.ts src/core/shared/dependency-resolver.test.ts src/core/resolver/pip-resolver.ts src/core/resolver/pip-resolver.test.ts src/core/resolver/conda-resolver.ts src/core/resolver/maven-resolver.ts src/core/resolver/maven-resolver.test.ts src/core/resolver/npm-resolver.ts
+git commit -m "feat: 의존성 요청별 resolver 상태 격리"
+```
+
+### Task 3: pip 후보와 artifact metadata 조회를 세션화한다
+
+**Files:**
+
+- Modify: `src/core/resolver/pip-resolver.ts`
+- Modify: `src/core/resolver/pip-resolver-download.test.ts`
+
+- [ ] **Step 1: 공통 전이 pip 의존성 재사용의 실패 테스트를 작성한다.**
+
+두 직접 root `alpha`와 `beta`가 `shared>=1`을 요구하도록 PyPI JSON mock을 구성한다. 하나의 `ResolutionSession`을 주입한 별도 `PipResolver` 두 개를 순차 실행하고 `shared`의 release lookup과 exact artifact metadata lookup이 각각 1회인지 검증한다. Simple API와 JSON 경로를 모두 포함한다. 다른 `indexUrl`, Python 버전 또는 `skipDependencyExpansion`의 source-artifact 검증 모드에서는 shared 조회가 재사용되지 않는 테스트도 작성한다. 첫 호출의 null/empty 후보 또는 reject 뒤 두 번째 root가 producer를 다시 호출하는 테스트를 추가한다.
+
+- [ ] **Step 2: 테스트가 중복 조회를 보여 주며 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/resolver/pip-resolver-download.test.ts -t "요청 세션"`
+
+Expected: FAIL — shared의 latest-version/package-info producer가 두 번 실행된다.
+
+- [ ] **Step 3: pip의 원격 조회만 세션으로 감싼다.**
+
+`PipResolver`에 private `sessionGet()` helper를 추가한다. `getLatestVersion()` 전체를 `'pip'/'latest-version'` operation으로, `fetchPackageInfo()`의 원격 artifact/metadata producer 전체를 `'pip'/'package-info'` operation으로 감싼다. key context는 아래처럼 고정한다.
+
+```ts
+{
+  name: normalize(name), versionSpec: versionSpec ?? null, indexUrl: indexUrl ?? null,
+  target: this.pipTargetPlatform, pythonVersion: this.pythonVersion,
+  baseUrl: this.cacheOptions.baseUrl ?? null,
+  allowUnverifiedSourceArtifact,
+}
+```
+
+`getLatestVersion`은 `Boolean(version)` predicate를 전달해 null/빈 버전을 저장하지 않는다. `fetchPackageInfo`는 non-null `FetchedPackageInfo`만 저장한다. `fetchPackageInfo`가 latest를 해결하기 위해 `getLatestVersion`을 호출하는 구조는 유지하되 operation name이 다르므로 순환 key를 만들지 않는다. PEP 508 marker, extras, BFS queue, dependency node 생성은 session producer 밖에 남긴다.
+
+- [ ] **Step 4: pip 회귀 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/resolver/pip-resolver-download.test.ts src/core/resolver/pip-resolver.test.ts`
+
+Expected: PASS — 공통 조회는 1회, 키가 다르면 재사용하지 않고 기존 source artifact 정책도 유지된다.
+
+- [ ] **Step 5: 세 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/resolver/pip-resolver.ts src/core/resolver/pip-resolver-download.test.ts src/core/resolver/pip-resolver.test.ts
+git commit -m "feat: pip 의존성 조회를 요청 세션에서 재사용"
+```
+
+### Task 4: conda 후보 선택과 artifact 정보 조회를 세션화한다
+
+**Files:**
+
+- Modify: `src/core/resolver/conda-resolver.ts`
+- Modify: `src/core/resolver/conda-resolver.test.ts` 또는 현재 conda resolver 테스트 파일
+- Modify: `src/core/resolver/conda-repodata-processor.test.ts` (기존 파일이면)
+
+- [ ] **Step 1: conda 공통 전이 의존성의 실패 테스트를 작성한다.**
+
+두 root가 같은 `shared` Conda dependency를 갖는 fixture를 만들고, 두 요청 전용 `CondaResolver(session)` 실행에서 `getLatestVersionFromRepoData`와 candidate selection이 한 번만 수행되는지 spy한다. channel, targetSubdir, Python, CUDA, build가 달라지면 재사용하지 않는 테스트와 null 후보 뒤 두 번째 resolver가 repodata candidate producer를 다시 실행하는 테스트를 추가한다.
+
+- [ ] **Step 2: 테스트가 중복 candidate selection으로 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/resolver/conda-resolver.test.ts src/core/resolver/conda-repodata-processor.test.ts`
+
+Expected: FAIL — 같은 channel/subdir 후보 탐색이 root마다 반복된다.
+
+- [ ] **Step 3: resolver helper를 통해 conda 세션 적용 지점을 단일화한다.**
+
+`CondaResolver`에 `getLatestVersionFromRepoDataWithSession()`와 `fetchPackageInfoBFSWithSession()` helper를 만든다. 전자는 processor의 `getLatestVersionFromRepoData()` 호출을 `'conda'/'latest-version'`으로, 후자는 현재 `fetchPackageInfoBFS()` body를 `'conda'/'package-info'`으로 감싼다. 두 key는 `{ name, versionSpec/version, buildSpec, channel, targetSubdir, targetArchitecture, pythonVersion, cudaVersion }`을 포함한다. null/latest 후보와 대상 artifact 오류는 cache하지 않는다. processor의 disk/memory repodata cache와 Conda BFS parent-child map은 변경하지 않는다.
+
+- [ ] **Step 4: conda 회귀 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/resolver/conda-resolver.test.ts src/core/resolver/conda-repodata-processor.test.ts`
+
+Expected: PASS — 동일 문맥은 1회, 환경·channel·build가 다르면 독립 조회, 실패 후 재시도한다.
+
+- [ ] **Step 5: 네 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/resolver/conda-resolver.ts src/core/resolver/conda-resolver.test.ts src/core/resolver/conda-repodata-processor.test.ts
+git commit -m "feat: conda 후보 탐색을 요청 세션에서 재사용"
+```
+
+### Task 5: Maven POM과 metadata 조회를 세션화하고 prefetch를 통합한다
+
+**Files:**
+
+- Modify: `src/core/resolver/maven-resolver.ts`
+- Modify: `src/core/resolver/maven-resolver.test.ts`
+- Modify: `src/core/shared/maven-cache.test.ts`
+
+- [ ] **Step 1: Maven POM sharing·prefetch의 실패 테스트를 작성한다.**
+
+`MavenResolver(session)` 두 개가 같은 GAV POM을 읽을 때 raw POM producer가 한 번만 호출되는 테스트를 만든다. 한 resolver의 `fetchPomWithCache` 결과를 mutate한 뒤 다른 resolver 결과는 원본인 clone-on-read 테스트를 추가한다. prefetch 직후 동일 coordinate 단건 fetch가 같은 in-flight producer를 사용하는 테스트와, prefetch 실패가 실제 resolve의 오류 정책을 바꾸지 않는 테스트를 추가한다. 같은 GAV라도 classifier가 다른 root는 raw POM 한 번을 공유하면서 각 root artifact selection은 독립적인 assertion을 넣는다.
+
+- [ ] **Step 2: 테스트가 POM producer 중복 호출로 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/resolver/maven-resolver.test.ts src/core/shared/maven-cache.test.ts`
+
+Expected: FAIL — session-aware POM producer가 없고 prefetch가 별도 cache helper를 우회한다.
+
+- [ ] **Step 3: Maven 세션 producer를 단일화한다.**
+
+`fetchPomWithCache()`를 `'maven'/'pom'` session operation으로 감싼다. context는 `{ repoUrl, groupId, artifactId, version }`만 포함하고 classifier/type은 포함하지 않는다. `getLatestVersion()`은 `'maven'/'latest-version'`으로 분리해 빈 문자열을 cache하지 않는다.
+
+`prefetchPomsParallelInternal()`은 `prefetchPomsParallel()` 직접 호출 대신 같은 `fetchPomWithCache()`를 `parallelThreads` 제한으로 fire-and-forget 호출한다. 각 task 오류는 debug log로 소비해 best-effort prefetch 의미를 유지하고, 이후 실제 fetch의 오류는 기존 호출자가 처리한다. POM/BOM을 소비하는 scope/exclusion, dependency-management, classifier/type 선택 로직은 session 밖에 둔다.
+
+- [ ] **Step 4: Maven 회귀 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/resolver/maven-resolver.test.ts src/core/shared/maven-cache.test.ts`
+
+Expected: PASS — raw POM 단일 producer, prefetch 공유, classifier 독립, 기존 prefetch 실패 정책을 확인한다.
+
+- [ ] **Step 5: 다섯 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/resolver/maven-resolver.ts src/core/resolver/maven-resolver.test.ts src/core/shared/maven-cache.test.ts
+git commit -m "feat: Maven POM 조회를 요청 세션에서 재사용"
+```
+
+### Task 6: npm packument와 version candidate 선택을 세션화한다
+
+**Files:**
+
+- Modify: `src/core/shared/npm-version-resolver.ts`
+- Modify: `src/core/resolver/npm-resolver.ts`
+- Modify: `src/core/resolver/npm-resolver.test.ts`
+- Create: `src/core/shared/npm-version-resolver.test.ts` (기존 unit test가 없을 때)
+
+- [ ] **Step 1: npm 공통 dependency의 실패 테스트를 작성한다.**
+
+공유 session을 받는 별도 `NpmResolver` 두 개가 같은 transitive `shared@^1`을 처리할 때 `fetchPackument`와 비동기 version candidate producer가 각각 한 번 실행되는지 검증한다. registry URL 또는 name/spec이 다르면 재사용하지 않는 테스트, 없는 version(`null`) 뒤 두 번째 resolver가 재시도하는 테스트를 추가한다. OS/architecture는 session key에 새로 추가하지 않고 기존 `NpmResolver`의 package `os`/`cpu` 필터가 root별로 유지되는지도 검증한다.
+
+- [ ] **Step 2: 테스트가 packument와 version resolution을 반복하며 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/resolver/npm-resolver.test.ts src/core/shared/npm-version-resolver.test.ts`
+
+Expected: FAIL — `fetchPackument`과 선택 함수가 두 resolver에서 각각 호출된다.
+
+- [ ] **Step 3: NpmVersionResolver에 session-aware async accessor를 추가한다.**
+
+기존 synchronous `resolveVersion()` public API는 유지한다. `fetchPackument()`은 `'npm'/'packument'` session operation으로 감싸고 context에 `{ registryUrl, name }`을 넣는다. 새 `resolveVersionForRequest(spec, packument)`은 `'npm'/'latest-version'` operation으로 `{ registryUrl, name: packument.name, spec }`을 key로 사용하며 `Boolean(version)` predicate를 전달한다. `NpmResolver.resolveDependencies()`와 `processDepItem()`만 새 async accessor를 await한다. `NpmVersionResolver` constructor에는 optional session을 추가하고 Npm request factory는 이를 주입한다. `NpmTreeManager`, peer/optional 처리, hoisting 및 현재 target OS/architecture mapping은 변경하지 않는다.
+
+- [ ] **Step 4: npm 회귀 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/resolver/npm-resolver.test.ts src/core/shared/npm-version-resolver.test.ts`
+
+Expected: PASS — packument·valid version은 재사용되고 null은 다시 조회하며 트리 배치는 유지된다.
+
+- [ ] **Step 5: 여섯 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/shared/npm-version-resolver.ts src/core/shared/npm-version-resolver.test.ts src/core/resolver/npm-resolver.ts src/core/resolver/npm-resolver.test.ts
+git commit -m "feat: npm metadata 조회를 요청 세션에서 재사용"
+```
+
+### Task 7: 공통 resolver의 사용자 결과와 실패 정책 회귀를 완성한다
+
+**Files:**
+
+- Modify: `src/core/shared/dependency-resolver.test.ts`
+- Modify: `src/cli/commands/download.test.ts` (필요할 때만)
+
+- [ ] **Step 1: end-to-end shared dependency와 실패 정책의 실패 테스트를 작성한다.**
+
+factory mock이 실제 session을 관찰할 수 있도록 최소 fake resolver를 사용한다. requirements 입력 두 root가 같은 dependency를 가져도 `successfulPackages`에는 한 아티팩트만 남고 각 root `dependencyTrees`는 둘 다 남는지 확인한다. 첫 root의 shared dependency가 일시적으로 실패하고 두 번째 root에서 재시도 성공할 때 default best-effort는 성공 root 결과만 다운로드하고, `--strict`는 기존대로 하나라도 실패하면 중단하는 테스트를 만든다. logger spy로 hit이 있을 때만 세션 통계 info log가 나오고 hit이 없으면 나오지 않는지도 검증한다.
+
+- [ ] **Step 2: 테스트가 재시도·통계 계약 부재로 실패하는지 확인한다.**
+
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/cli/commands/download.test.ts`
+
+Expected: FAIL — 재시도 횟수 또는 세션 통계 로그 assertion이 충족되지 않는다.
+
+- [ ] **Step 3: 최소 통합 보완을 적용한다.**
+
+Task 2의 session/factory 사용 범위에서 누락된 resolver option 전파나 종료 로그만 보완한다. 기존 `successfulPackageSet`·`resolvedSet` 병합 순서, progress current/total, strict 처리, CLI `--file` parser는 변경하지 않는다. 새 CLI 옵션이나 출력 줄을 추가하지 않는다.
+
+- [ ] **Step 4: 공통 resolver와 CLI 회귀 테스트를 통과시킨다.**
+
+Run: `npx vitest run src/core/shared/dependency-resolver.test.ts src/cli/commands/download.test.ts`
+
+Expected: PASS — 다운로드 목록과 failure semantics은 유지되고 조회만 재사용된다.
+
+- [ ] **Step 5: 일곱 번째 단위를 커밋한다.**
+
+```bash
+git add src/core/shared/dependency-resolver.ts src/core/shared/dependency-resolver.test.ts src/cli/commands/download.test.ts
+git commit -m "test: 의존성 세션 재사용 정책을 검증"
+```
+
+### Task 8: 모든 영향 문서를 갱신하고 검증한다
+
+**Files:**
+
+- Modify: `docs/shared-dependency.md`
+- Modify: `docs/resolvers.md`
+- Modify: `docs/pip-dependency-resolution.md`
+- Modify: `docs/conda-dependency-resolution.md`
+- Modify: `docs/maven-dependency-resolution.md`
+- Modify: `docs/npm-dependency-resolution.md`
+
+- [ ] **Step 1: 문서 변경의 기대 문구를 작성한다.**
+
+각 문서에 한 다운로드 요청 안에서만 조회 snapshot을 재사용하고 요청 종료 후 폐기된다는 사실을 추가한다. `shared-dependency.md`에는 적용 타입(pip/conda/Maven/npm), session key 격리, 실패/null 비캐시 및 기존 최종 다운로드 중복 제거와의 차이를 적는다. `resolvers.md`와 유형별 문서에는 해당 resolver의 cached operation과 부모 문맥(extras, build, scope/exclusion, peer/hoisting)을 별도 평가하는 경계를 적는다. OS/Docker가 이번 session 비범위임도 명시한다.
+
+- [ ] **Step 2: 문서가 이전 동작만 설명하는지 확인한다.**
+
+Run: `rg -n "중복|세션|재사용|공통 의존성" docs/shared-dependency.md docs/resolvers.md docs/{pip,conda,maven,npm}-dependency-resolution.md`
+
+Expected: 새 request-session 동작 설명이 아직 없어 필요한 문서 변경 위치를 확인한다.
+
+- [ ] **Step 3: 문서를 갱신한다.**
+
+설계 문서의 키 표를 복제하지 말고, 사용자와 운영자에게 필요한 짧은 정책으로 요약한다. CLI 사용자 경험이나 설정값은 바뀌지 않으므로 `docs/cli.md`에는 중복 항목을 추가하지 않는다.
+
+- [ ] **Step 4: 전체 검증을 실행한다.**
+
+Run: `bash scripts/verify-worktree.sh`
+
+Expected: 전체 Vitest suite PASS.
+
+Run: `npm run lint`
+
+Expected: exit 0; 기존 경고가 있으면 새 error가 없는지 확인한다.
+
+Run: `npm run typecheck`
+
+Expected: exit 0.
+
+Run: `git diff --check origin/main...HEAD`
+
+Expected: whitespace error 없음.
+
+- [ ] **Step 5: 문서와 검증 변경을 커밋한다.**
+
+```bash
+git add docs/shared-dependency.md docs/resolvers.md docs/pip-dependency-resolution.md docs/conda-dependency-resolution.md docs/maven-dependency-resolution.md docs/npm-dependency-resolution.md
+git commit -m "docs: 요청 단위 의존성 재사용을 안내"
+```

--- a/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
+++ b/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
@@ -140,7 +140,7 @@ git commit -m "feat: 요청 단위 의존성 세션 추가"
 
 - [ ] **Step 1: factory 사용과 동시 요청 격리의 실패 테스트를 작성한다.**
 
-기존 `dependency-resolver.test.ts` module mock에 `createRequestPipResolver`, `createRequestCondaResolver`, `createRequestMavenResolver`, `createRequestNpmResolver`를 추가한다. pip root 두 개의 같은 요청은 `createRequestPipResolver` 1회와 해당 resolver의 `resolveDependencies` 2회를 기대한다. linux/arm64와 windows/x86_64의 `resolveAllDependencies()`를 동시에 실행해 서로 다른 factory 반환값과 resolver options가 섞이지 않는지 검증한다. Pip/Maven resolver 단위 테스트에는 singleton의 `setCacheOptions()` 이후 factory 결과가 같은 값을 복사하고 factory resolver 변경이 singleton에 역전파되지 않는 검증을 추가한다. Npm resolver test에는 factory가 private `NpmVersionResolver`까지 같은 session을 연결해 두 별도 root resolver의 packument producer가 공유되는 검증을 추가한다.
+기존 `dependency-resolver.test.ts` module mock에 `createRequestPipResolver`, `createRequestCondaResolver`, `createRequestMavenResolver`, `createRequestNpmResolver`를 추가한다. pip root 두 개의 같은 요청은 `createRequestPipResolver` 1회와 해당 resolver의 `resolveDependencies` 2회를 기대한다. linux/arm64와 windows/x86_64의 `resolveAllDependencies()`를 동시에 실행해 서로 다른 factory 반환값과 resolver options가 섞이지 않는지 검증한다. Pip/Maven resolver 단위 테스트에는 singleton의 `setCacheOptions()` 이후 factory 결과가 같은 값을 복사하고 factory resolver 변경이 singleton에 역전파되지 않는 검증을 추가한다. Npm resolver test에는 factory가 private `NpmVersionResolver`에 session을 연결하고, session 없는 legacy resolver에는 registry 연결이 없는지만 검증한다. packument producer 공유 검증은 Task 6에서 session-aware 조회와 함께 추가한다.
 
 - [ ] **Step 2: 테스트가 기존 singleton 흐름 때문에 실패하는지 확인한다.**
 
@@ -307,7 +307,7 @@ git commit -m "feat: Maven POM 조회를 요청 세션에서 재사용"
 
 - [ ] **Step 1: npm 공통 dependency의 실패 테스트를 작성한다.**
 
-내부 factory로 연결한 별도 `NpmResolver` 두 개가 같은 transitive `shared@^1`을 처리할 때 `fetchPackument`와 비동기 version candidate producer가 각각 한 번 실행되는지 검증한다. registry URL 또는 name/spec이 다르면 재사용하지 않는 테스트, `Shared`/`shared`가 npm canonical lowercase name 하나로 재사용되는 테스트, 없는 version(`null`) 뒤 두 번째 resolver가 재시도하는 테스트를 추가한다. OS/architecture는 session key에 새로 추가하지 않고 기존 `NpmResolver`의 package `os`/`cpu` 필터가 root별로 유지되는지도 검증한다.
+내부 factory로 연결한 별도 `NpmResolver` 두 개가 같은 transitive `shared@^1`을 처리할 때 `fetchPackument`와 비동기 version candidate producer가 각각 한 번 실행되는지 검증한다. 이 검증으로 factory가 private `NpmVersionResolver`에 연결한 session을 실제 조회가 읽는지도 함께 확인한다. registry URL 또는 name/spec이 다르면 재사용하지 않는 테스트, `Shared`/`shared`가 npm canonical lowercase name 하나로 재사용되는 테스트, 없는 version(`null`) 뒤 두 번째 resolver가 재시도하는 테스트를 추가한다. OS/architecture는 session key에 새로 추가하지 않고 기존 `NpmResolver`의 package `os`/`cpu` 필터가 root별로 유지되는지도 검증한다.
 
 - [ ] **Step 2: 테스트가 packument와 version resolution을 반복하며 실패하는지 확인한다.**
 

--- a/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
+++ b/docs/superpowers/plans/2026-08-13-request-scoped-resolution-session.md
@@ -16,6 +16,8 @@
 | --- | --- |
 | `src/core/shared/internal/resolution-session.ts` | 내부 요청 수명 memoizer, namespace key, clone-on-read, hit/miss 통계 |
 | `src/core/shared/internal/resolution-session.test.ts` | 내부 세션의 동시성·실패·키·불변성 계약 |
+| `src/core/shared/internal/resolution-session-registry.ts` | resolver와 내부 resolver service를 요청 세션에 연결하는 private `WeakMap` |
+| `src/core/shared/internal/resolution-session-registry.test.ts` | owner별 session 연결·분리 계약 |
 | `src/core/resolver/{pip,conda,maven,npm}-resolver.ts` | 요청 전용 factory 및 resolver별 session 적용 |
 | `src/core/shared/npm-version-resolver.ts` | npm packument/후보 선택 session 적용 |
 | `src/core/shared/dependency-resolver.ts` | 세션·요청 전용 resolver 묶음 생성과 통계 로그 |
@@ -28,6 +30,8 @@
 
 - Create: `src/core/shared/internal/resolution-session.ts`
 - Create: `src/core/shared/internal/resolution-session.test.ts`
+- Create: `src/core/shared/internal/resolution-session-registry.ts`
+- Create: `src/core/shared/internal/resolution-session-registry.test.ts`
 
 - [ ] **Step 1: 실패하는 세션 단위 테스트를 작성한다.**
 
@@ -71,6 +75,13 @@ it('reject·null·빈 후보는 저장하지 않고 다음 조회에서 재시�
 
 `getStats()`가 miss/hit/in-flight join을 올바르게 집계하는 테스트도 추가한다.
 
+registry test에는 plain object owner A/B에 각각 다른 session을 연결했을 때 `getAttachedResolutionSession(owner)`가 해당 session만 반환하고, 연결하지 않은 owner는 `undefined`를 반환하는 검증을 추가한다. registry의 내부 API는 아래와 같다.
+
+```ts
+export function attachResolutionSession(owner: object, session: ResolutionSession): void;
+export function getAttachedResolutionSession(owner: object): ResolutionSession | undefined;
+```
+
 - [ ] **Step 2: 테스트가 기능 부재로 실패하는지 확인한다.**
 
 Run: `npx vitest run src/core/shared/internal/resolution-session.test.ts`
@@ -79,7 +90,7 @@ Expected: FAIL — 내부 `resolution-session` 모듈을 찾지 못한다.
 
 - [ ] **Step 3: 최소 세션 구현을 작성한다.**
 
-`internal/resolution-session.ts`에 내부 API를 만든다. `src/core/shared/index.ts` 또는 `src/core/index.ts`에는 export하지 않는다.
+`internal/resolution-session.ts`와 `internal/resolution-session-registry.ts`에 내부 API를 만든다. `src/core/shared/index.ts` 또는 `src/core/index.ts`에는 export하지 않는다.
 
 ```ts
 export type ResolutionOperation = 'latest-version' | 'package-info' | 'packument' | 'pom';
@@ -109,7 +120,7 @@ Expected: PASS — producer 1회, snapshot 격리, namespace 분리, reject/null
 - [ ] **Step 5: 첫 단위를 커밋한다.**
 
 ```bash
-git add src/core/shared/internal/resolution-session.ts src/core/shared/internal/resolution-session.test.ts
+git add src/core/shared/internal/resolution-session.ts src/core/shared/internal/resolution-session.test.ts src/core/shared/internal/resolution-session-registry.ts src/core/shared/internal/resolution-session-registry.test.ts
 git commit -m "feat: 요청 단위 의존성 세션 추가"
 ```
 
@@ -126,7 +137,7 @@ git commit -m "feat: 요청 단위 의존성 세션 추가"
 
 - [ ] **Step 1: factory 사용과 동시 요청 격리의 실패 테스트를 작성한다.**
 
-기존 `dependency-resolver.test.ts` module mock에 `createRequestPipResolver`, `createRequestCondaResolver`, `createRequestMavenResolver`, `createRequestNpmResolver`를 추가한다. pip root 두 개의 같은 요청은 `createRequestPipResolver` 1회와 해당 resolver의 `resolveDependencies` 2회를 기대한다. linux/arm64와 windows/x86_64의 `resolveAllDependencies()`를 동시에 실행해 서로 다른 factory 반환값과 resolver options가 섞이지 않는지 검증한다. Pip/Maven resolver 단위 테스트에는 singleton의 `setCacheOptions()` 이후 factory 결과가 같은 값을 복사하고 factory resolver 변경이 singleton에 역전파되지 않는 검증을 추가한다.
+기존 `dependency-resolver.test.ts` module mock에 `createRequestPipResolver`, `createRequestCondaResolver`, `createRequestMavenResolver`, `createRequestNpmResolver`를 추가한다. pip root 두 개의 같은 요청은 `createRequestPipResolver` 1회와 해당 resolver의 `resolveDependencies` 2회를 기대한다. linux/arm64와 windows/x86_64의 `resolveAllDependencies()`를 동시에 실행해 서로 다른 factory 반환값과 resolver options가 섞이지 않는지 검증한다. Pip/Maven resolver 단위 테스트에는 singleton의 `setCacheOptions()` 이후 factory 결과가 같은 값을 복사하고 factory resolver 변경이 singleton에 역전파되지 않는 검증을 추가한다. Npm resolver test에는 factory가 private `NpmVersionResolver`까지 같은 session을 연결해 두 별도 root resolver의 packument producer가 공유되는 검증을 추가한다.
 
 - [ ] **Step 2: 테스트가 기존 singleton 흐름 때문에 실패하는지 확인한다.**
 
@@ -136,19 +147,19 @@ Expected: FAIL — 요청 factory export가 없거나 `getPipResolver()` singlet
 
 - [ ] **Step 3: 요청 전용 factory를 최소 구현한다.**
 
-각 library resolver module에는 `/** @internal */`로 표시하고 public barrel에서는 re-export하지 않는 `createRequest*Resolver(session)` helper를 추가한다. Factory는 매번 새 instance를 만든다. session은 public constructor/`ResolverOptions`가 아니라 module-private `WeakMap<Resolver, ResolutionSession>`에 factory가 연결하고 resolver의 private accessor만 읽는다.
+각 library resolver module에는 `/** @internal */`로 표시하고 public barrel에서는 re-export하지 않는 `createRequest*Resolver(session)` helper를 추가한다. Factory는 매번 새 instance를 만든다. session은 public constructor/`ResolverOptions`가 아니라 `resolution-session-registry.ts`의 private `WeakMap<object, ResolutionSession>`에 factory가 연결하고 resolver의 private accessor만 읽는다.
 
 ```ts
 /** @internal dependency-resolver 전용 factory */
 export function createRequestPipResolver(session: ResolutionSession): PipResolver {
   const resolver = new PipResolver();
-  requestSessions.set(resolver, session);
+  attachResolutionSession(resolver, session);
   resolver.setCacheOptions(getPipResolver().getCacheOptions());
   return resolver;
 }
 ```
 
-Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복사본을 반환한다. Conda/Npm도 매번 새 resolver를 반환한다. Factory와 `ResolutionSession`은 `src/core/index.ts`와 public shared barrel에 export하지 않으며, `dependency-resolver.ts`만 이 internal module path를 사용한다. 기존 singleton accessor와 public constructor는 session 없는 동작을 유지한다.
+Pip/Maven에는 `getCacheOptions()`를 추가해 `{ ...this.cacheOptions }` 복사본을 반환한다. Conda factory는 resolver instance를 registry에 연결한다. Npm factory는 새 `NpmResolver`의 `/** @internal */ attachRequestSession(session)`만 호출하고, 이 method가 registry에 `NpmResolver`와 private `NpmVersionResolver` service를 모두 연결한다. `NpmVersionResolver`는 constructor 인자나 공개 setter 없이 `getAttachedResolutionSession(this)`로만 session을 읽는다. Factory와 내부 session registry는 `src/core/index.ts`와 public shared barrel에 export하지 않으며, `dependency-resolver.ts`만 direct internal module path로 factory를 사용한다. 기존 singleton accessor와 public constructor는 session 없는 동작을 유지한다.
 
 `dependency-resolver.ts`에서는 함수 시작 시 session과 library resolver 묶음을 한 번 생성한다. `getResolverByType`은 OS/Docker 특수 경로를 건드리지 않고 pip/conda/Maven/npm만 묶음에서 반환한다. 종료 시 hit이 1 이상일 때만 hit/miss/join 통계를 `logger.info`로 남긴다. `includeDependencies: false` 조기 반환은 세션/factory를 만들지 않는다.
 

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -176,7 +176,8 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
    snapshot으로 전달되고 역전파되지 않는지 검증한다.
 7. 서로 다른 환경 옵션으로 동시에 두 `resolveAllDependencies()`를 실행해
    요청별 resolver 인스턴스와 세션 상태가 섞이지 않는지 검증한다.
-8. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
+8. 전체 test, lint, typecheck와 PR CI를 실행한다. 로컬 build는 별도 사용자 요청이
+   있을 때만 실행한다.
 
 ## 영향 문서
 

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -19,8 +19,8 @@
 - `resolveAllDependencies()`로 시작하는 한 요청에만 유효한 공유
   `ResolutionSession`을 만든다.
 - 라이브러리 resolver인 pip, conda, Maven, npm에 세션을 전달한다.
-- 동일한 조회 문맥의 후보 선택·아티팩트 메타데이터·의존성 manifest 조회를
-  성공과 실패 모두 재사용한다.
+- 동일한 조회 문맥의 후보 선택·아티팩트 메타데이터·의존성 manifest 조회의
+  **성공 결과**를 재사용한다.
 - 동일한 키의 동시 조회도 하나의 Promise를 공유한다.
 - 기존의 직접 루트별 `dependencyTrees`, `successfulPackages`, best-effort 및
   `--strict` 실패 정책, 최종 다운로드 아티팩트 중복 제거를 유지한다.
@@ -51,24 +51,32 @@
 ### 공통 세션
 
 `src/core/shared/resolution-session.ts`에 요청 수명과 같은 `ResolutionSession`을
-둔다. 세션은 문자열 키와 `Promise<T>`를 저장하는 memoizer를 제공한다.
+둔다. 세션은 문자열 키와 성공 값을 위한 `Promise<T>`를 저장하는 memoizer를
+제공한다.
 
 - 최초 호출은 producer Promise를 저장하고 실행한다.
 - 후속 호출은 같은 Promise를 반환한다. 완료 전 동시 호출도 중복 네트워크
   작업을 만들지 않는다.
-- reject된 Promise도 세션 종료까지 보존해 동일한 실패를 다시 조회하지 않는다.
-  각 resolver는 현재처럼 부모 패키지 정보를 포함한 오류로 감싸므로, 실패
-  원인과 직접 루트별 실패 기록은 사라지지 않는다.
-- 세션 값은 선택된 아티팩트와 원격 metadata의 불변 snapshot이다. resolver는
-  매 호출마다 새 `DependencyNode`와 부모-자식 관계를 구성하므로 한 트리의
-  변경이 다른 트리에 새지 않는다.
+- producer가 reject되면 캐시 항목을 즉시 제거한다. 같은 시점의 호출자는 같은
+  실패를 받지만, 이후 직접 루트는 다시 조회한다. 따라서 일시적 네트워크 실패가
+  뒤의 루트 성공 기회를 없애지 않는다. 각 resolver의 기존 오류 감싸기와
+  `failedPackages` 기록도 그대로 유지한다.
+- 세션에는 canonical snapshot만 저장하고, memoizer는 consumer마다 clone-on-read
+  값을 반환한다. resolver는 매 호출마다 새 `DependencyNode`와 부모-자식 관계를
+  구성하므로 한 트리의 변경이 다른 트리에 새지 않는다.
 - hit/miss 횟수를 기록하고, hit이 하나 이상이면 공통 resolver가 요청 종료 시
   재사용 건수를 info 로그로 남긴다. 다운로드 결과와 CLI 출력 계약은 바꾸지
   않는다.
 
-`resolveAllDependencies()`가 세션을 생성해 모든 라이브러리 resolver 옵션으로
-전달한다. 외부 호출자가 세션을 전달하거나 보존할 수 없게 하여 요청 경계를
-강제한다.
+`resolveAllDependencies()`는 세션과 함께 **요청 전용 resolver 인스턴스 묶음**을
+생성한다. 기존 `getPipResolver()` 등 singleton accessor는 다른 기존 호출 경로의
+호환성을 위해 유지하되, 이 함수에서는 새 factory로 pip·conda·Maven·npm 인스턴스를
+한 요청에 하나씩 만든다. 이로써 resolver 인스턴스 필드(visited, queue, conflicts,
+tree manager, 대상 환경)가 동시 다운로드 요청 사이에 섞이지 않는다. 원격 metadata
+cache는 기존 모듈 수준 캐시를 계속 사용한다.
+
+세션은 이 요청 전용 인스턴스의 resolver 옵션으로만 전달하며, 외부 호출자가
+세션을 전달하거나 보존할 수 없게 하여 요청 경계를 강제한다.
 
 ### 키 격리
 
@@ -79,8 +87,8 @@
 | --- | --- |
 | pip | 정규화 이름, 요청 버전 조건, index URL, 대상 OS/아키텍처, Python 버전, source artifact 검증 모드 |
 | conda | 정규화 이름, 버전 조건·build, channel, subdir/아키텍처, Python·CUDA 버전 |
-| Maven | group:artifact:version 좌표와 저장소 URL |
-| npm | 정규화 이름, 버전 조건, registry URL, 대상 OS/CPU |
+| Maven | 원시 POM/BOM에는 group:artifact:version 좌표와 저장소 URL |
+| npm | 정규화 이름, 버전 조건, 현재 resolver가 실제로 받는 registry/host 환경 입력 |
 
 extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에서
 나오는 간선**을 바꾸는 값은 manifest 캐시 키가 아니라 각 resolver의 기존
@@ -89,15 +97,19 @@ extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에
 
 ### resolver별 적용 지점
 
-- **pip**: `fetchPackageInfo()`의 후보 선택과 Core Metadata/JSON·Simple API
-  조회 결과를 세션으로 감싼다. 이후 extras 및 PEP 508 marker 평가는 현재
-  BFS 호출별로 수행한다.
-- **conda**: `fetchPackageInfoBFS()`의 repodata 후보 선택 결과를 세션으로
-  감싼다. build와 target subdir을 키에 포함한다.
-- **Maven**: 좌표의 POM/선택 결과를 세션으로 감싼다. scope, exclusion,
-  dependency management 적용은 각 부모의 queue processor가 수행한다.
+- **pip**: `getLatestVersion()`과 `fetchPackageInfo()`의 후보 선택, Core
+  Metadata/JSON·Simple API 조회 결과를 세션으로 감싼다. 이후 extras 및 PEP 508
+  marker 평가는 현재 BFS 호출별로 수행한다.
+- **conda**: `getLatestVersionFromRepoData()`와 `fetchPackageInfoBFS()`의
+  repodata 후보 선택 결과를 세션으로 감싼다. build와 target subdir을 키에
+  포함한다.
+- **Maven**: 좌표의 원시 POM/BOM 조회·파싱과 version range 선택을 세션으로
+  감싼다. classifier/type 기반 아티팩트 선택, scope, exclusion, dependency
+  management 적용은 호출별 queue processor가 수행한다.
 - **npm**: registry manifest와 선택된 버전 조회를 세션으로 감싼다. hoisting과
-  peer dependency 배치는 기존 root별 tree manager가 구성한다.
+  peer dependency 배치는 기존 root별 tree manager가 구성한다. 공통 resolver가
+  npm에 `targetOS`/`architecture`를 새로 매핑하지는 않으며, 현재 host 기반 선택
+  동작을 변경하지 않는다.
 
 각 적용 지점은 세션이 없을 때 기존 producer를 그대로 실행하도록 해 단일
 resolver의 공개 사용 경로와 기존 테스트를 유지한다.
@@ -117,8 +129,9 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
 ## 오류 처리와 호환성
 
 - 서로 다른 키의 조회는 절대 재사용하지 않는다.
-- 동일 키의 실패는 한 번의 원격 조회로 재사용하지만 각 경로의 부모 정보가
-  들어간 기존 오류 메시지와 `failedPackages` 항목은 유지한다.
+- 동일 키의 동시 실패는 동일 Promise로 전달하되, 실패 뒤 캐시를 제거한다. 뒤의
+  루트는 기존처럼 재시도하고, 각 경로의 기존 오류 메시지와 `failedPackages`
+  항목을 유지한다.
 - `--no-deps`의 pip source artifact 검증 모드는 키에 포함해, 허용 범위가
   넓은 조회 결과가 일반 의존성 모드로 새지 않게 한다.
 - 기존 resolver 내부의 순환 의존성, 최대 깊이, 충돌 기록, 최종 패키지 병합
@@ -126,16 +139,19 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
 
 ## 검증 계획
 
-1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, 실패 재사용,
-   서로 다른 키 분리를 검증한다.
+1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, reject 후 재시도,
+   clone-on-read, 서로 다른 키 분리를 검증한다.
 2. pip·conda·Maven·npm resolver 테스트에서 두 직접 루트가 공통 전이
-   의존성을 가질 때 공통 metadata/candidate producer가 한 번만 호출되는지
-   검증한다.
-3. pip index/대상 환경, conda channel/subdir, Maven 좌표, npm 대상 플랫폼이
-   다른 경우 재사용하지 않는 회귀 테스트를 추가한다.
-4. 공통 의존성 실패가 각 직접 루트의 best-effort/`--strict` 정책 및 오류
-   문맥을 유지하는지 `resolveAllDependencies()` 테스트로 검증한다.
-5. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
+   의존성을 가질 때 `getLatestVersion`을 포함한 공통 metadata/candidate producer가
+   한 번만 호출되는지 검증한다.
+3. pip index/대상 환경, conda channel/subdir, Maven 좌표·classifier 경계가 다른
+   경우 재사용하지 않거나 원시 POM만 재사용하는 회귀 테스트를 추가한다. npm은
+   현재 전달되는 입력만 키에 반영하는 테스트를 추가한다.
+4. 공통 의존성의 일시적 실패가 다음 직접 루트에서 재시도되고, 각 직접 루트의
+   best-effort/`--strict` 정책 및 오류 문맥을 유지하는지 검증한다.
+5. 서로 다른 환경 옵션으로 동시에 두 `resolveAllDependencies()`를 실행해
+   요청별 resolver 인스턴스와 세션 상태가 섞이지 않는지 검증한다.
+6. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
 
 ## 영향 문서
 

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -1,0 +1,145 @@
+# 요청 단위 의존성 탐색 재사용 설계
+
+## 배경
+
+`resolveAllDependencies()`는 여러 직접 패키지를 순차적으로 처리한다. 최종
+다운로드 목록은 아티팩트 키로 중복 제거하지만, 각 직접 루트마다 해당 패키지
+관리자의 resolver가 새 BFS 상태로 시작한다. 따라서 `A → C`, `B → C`처럼
+공통 전이 의존성이 있으면 `C`의 레지스트리 조회, 버전 후보 선택, 메타데이터
+해석이 반복된다. requirements.txt처럼 많은 직접 패키지를 한 번에 다운로드할 때
+이 반복이 누적된다.
+
+목표는 한 번의 다운로드 요청 안에서 이미 확인한 의존성 조회 결과를 재사용해
+중복 탐색을 줄이되, 현재의 패키지 선택과 실패 처리 의미를 바꾸지 않는 것이다.
+
+## 범위와 비범위
+
+### 범위
+
+- `resolveAllDependencies()`로 시작하는 한 요청에만 유효한 공유
+  `ResolutionSession`을 만든다.
+- 라이브러리 resolver인 pip, conda, Maven, npm에 세션을 전달한다.
+- 동일한 조회 문맥의 후보 선택·아티팩트 메타데이터·의존성 manifest 조회를
+  성공과 실패 모두 재사용한다.
+- 동일한 키의 동시 조회도 하나의 Promise를 공유한다.
+- 기존의 직접 루트별 `dependencyTrees`, `successfulPackages`, best-effort 및
+  `--strict` 실패 정책, 최종 다운로드 아티팩트 중복 제거를 유지한다.
+- 요청 종료 시 세션을 폐기한다. 영속 캐시의 TTL, 설정 또는 캐시 삭제 동작은
+  변경하지 않는다.
+
+### 비범위
+
+- pip resolvelib 같은 전역 버전 충돌 solver로 교체하지 않는다.
+- 서로 다른 `resolveAllDependencies()` 호출 사이에 결과를 보존하지 않는다.
+- yum, apt, apk와 Docker의 해결 알고리즘을 이번 변경 대상으로 포함하지 않는다.
+  이들은 라이브러리 resolver와 다른 배포판·저장소 문맥을 사용한다.
+- 사용자에게 새로운 CLI 옵션이나 출력 형식을 추가하지 않는다.
+
+## 대안과 결정
+
+1. 직접 입력이 동일할 때만 resolver 결과를 재사용하는 안은 구현 위험은 작지만
+   공통 전이 의존성을 해결하지 못해 제외한다.
+2. 모든 직접 입력을 한 전역 그래프로 푸는 배치 solver는 중복을 가장 많이
+   줄이지만 pip extras, Maven scope/exclusion, npm peer dependency의 기존 의미와
+   충돌할 위험이 커서 제외한다.
+3. 요청 단위의 조회 세션을 공유하는 안을 채택한다. 아티팩트 선택과 manifest
+   조회는 재사용하고, 부모별 의존성 간선 정책은 기존 각 resolver가 계속
+   적용한다.
+
+## 설계
+
+### 공통 세션
+
+`src/core/shared/resolution-session.ts`에 요청 수명과 같은 `ResolutionSession`을
+둔다. 세션은 문자열 키와 `Promise<T>`를 저장하는 memoizer를 제공한다.
+
+- 최초 호출은 producer Promise를 저장하고 실행한다.
+- 후속 호출은 같은 Promise를 반환한다. 완료 전 동시 호출도 중복 네트워크
+  작업을 만들지 않는다.
+- reject된 Promise도 세션 종료까지 보존해 동일한 실패를 다시 조회하지 않는다.
+  각 resolver는 현재처럼 부모 패키지 정보를 포함한 오류로 감싸므로, 실패
+  원인과 직접 루트별 실패 기록은 사라지지 않는다.
+- 세션 값은 선택된 아티팩트와 원격 metadata의 불변 snapshot이다. resolver는
+  매 호출마다 새 `DependencyNode`와 부모-자식 관계를 구성하므로 한 트리의
+  변경이 다른 트리에 새지 않는다.
+- hit/miss 횟수를 기록하고, hit이 하나 이상이면 공통 resolver가 요청 종료 시
+  재사용 건수를 info 로그로 남긴다. 다운로드 결과와 CLI 출력 계약은 바꾸지
+  않는다.
+
+`resolveAllDependencies()`가 세션을 생성해 모든 라이브러리 resolver 옵션으로
+전달한다. 외부 호출자가 세션을 전달하거나 보존할 수 없게 하여 요청 경계를
+강제한다.
+
+### 키 격리
+
+캐시 키에는 결과에 영향을 주는 문맥을 모두 넣는다. 다른 저장소나 대상 환경의
+응답을 재사용하지 않는 것이 중복 제거보다 우선한다.
+
+| 유형 | 세션 키 문맥 |
+| --- | --- |
+| pip | 정규화 이름, 요청 버전 조건, index URL, 대상 OS/아키텍처, Python 버전, source artifact 검증 모드 |
+| conda | 정규화 이름, 버전 조건·build, channel, subdir/아키텍처, Python·CUDA 버전 |
+| Maven | group:artifact:version 좌표와 저장소 URL |
+| npm | 정규화 이름, 버전 조건, registry URL, 대상 OS/CPU |
+
+extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에서
+나오는 간선**을 바꾸는 값은 manifest 캐시 키가 아니라 각 resolver의 기존
+간선 평가 단계에 남긴다. 따라서 같은 패키지 metadata를 재사용하면서도
+부모별 선택 규칙은 보존된다.
+
+### resolver별 적용 지점
+
+- **pip**: `fetchPackageInfo()`의 후보 선택과 Core Metadata/JSON·Simple API
+  조회 결과를 세션으로 감싼다. 이후 extras 및 PEP 508 marker 평가는 현재
+  BFS 호출별로 수행한다.
+- **conda**: `fetchPackageInfoBFS()`의 repodata 후보 선택 결과를 세션으로
+  감싼다. build와 target subdir을 키에 포함한다.
+- **Maven**: 좌표의 POM/선택 결과를 세션으로 감싼다. scope, exclusion,
+  dependency management 적용은 각 부모의 queue processor가 수행한다.
+- **npm**: registry manifest와 선택된 버전 조회를 세션으로 감싼다. hoisting과
+  peer dependency 배치는 기존 root별 tree manager가 구성한다.
+
+각 적용 지점은 세션이 없을 때 기존 producer를 그대로 실행하도록 해 단일
+resolver의 공개 사용 경로와 기존 테스트를 유지한다.
+
+## 처리 흐름
+
+```text
+직접 루트 A, B
+  → resolveAllDependencies가 요청 세션 생성
+  → A가 C의 조회 키를 최초 요청: Promise 생성·후보 선택·manifest 조회
+  → B가 같은 C 조회 키를 요청: 기존 Promise/snapshot 재사용
+  → A/B 각각의 extras·scope·peer 규칙으로 간선을 별도 구성
+  → 기존 결과 병합 및 아티팩트 중복 제거
+  → 요청 종료 시 세션 폐기
+```
+
+## 오류 처리와 호환성
+
+- 서로 다른 키의 조회는 절대 재사용하지 않는다.
+- 동일 키의 실패는 한 번의 원격 조회로 재사용하지만 각 경로의 부모 정보가
+  들어간 기존 오류 메시지와 `failedPackages` 항목은 유지한다.
+- `--no-deps`의 pip source artifact 검증 모드는 키에 포함해, 허용 범위가
+  넓은 조회 결과가 일반 의존성 모드로 새지 않게 한다.
+- 기존 resolver 내부의 순환 의존성, 최대 깊이, 충돌 기록, 최종 패키지 병합
+  정책은 변경하지 않는다.
+
+## 검증 계획
+
+1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, 실패 재사용,
+   서로 다른 키 분리를 검증한다.
+2. pip·conda·Maven·npm resolver 테스트에서 두 직접 루트가 공통 전이
+   의존성을 가질 때 공통 metadata/candidate producer가 한 번만 호출되는지
+   검증한다.
+3. pip index/대상 환경, conda channel/subdir, Maven 좌표, npm 대상 플랫폼이
+   다른 경우 재사용하지 않는 회귀 테스트를 추가한다.
+4. 공통 의존성 실패가 각 직접 루트의 best-effort/`--strict` 정책 및 오류
+   문맥을 유지하는지 `resolveAllDependencies()` 테스트로 검증한다.
+5. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
+
+## 영향 문서
+
+- `docs/shared-dependency.md`: 요청 단위 재사용, 키 격리, 로그 동작을 문서화한다.
+- `docs/resolvers.md`: 라이브러리 resolver 공통 동작과 비범위를 문서화한다.
+- 각 패키지 관리자 문서(pip, conda, Maven, npm): 자기 resolver의 재사용 경계와
+  부모 문맥 보존을 문서화한다.

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -65,6 +65,10 @@ memoizer를 제공한다. 예를 들어 pip의 `latest-version`과 `package-info
   실패를 받지만, 이후 직접 루트는 다시 조회한다. 따라서 일시적 네트워크 실패가
   뒤의 루트 성공 기회를 없애지 않는다. 각 resolver의 기존 오류 감싸기와
   `failedPackages` 기록도 그대로 유지한다.
+- producer가 `null`, 빈 문자열, 또는 해당 operation의 유효성 조건을 만족하지
+  않는 후보를 반환해도 항목을 저장하지 않는다. 후보 없음과 일시적 빈 응답은
+  기존처럼 다음 직접 루트에서 다시 확인한다. resolver는 실제로 유효한 후보와
+  metadata snapshot만 성공 값으로 memoize한다.
 - 세션에는 canonical snapshot만 저장하고, memoizer는 consumer마다 clone-on-read
   값을 반환한다. resolver는 매 호출마다 새 `DependencyNode`와 부모-자식 관계를
   구성하므로 한 트리의 변경이 다른 트리에 새지 않는다.
@@ -151,8 +155,9 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
 
 ## 검증 계획
 
-1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, reject 후 재시도,
-   clone-on-read, resolver type·operation kind·문맥이 다른 키 분리를 검증한다.
+1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, reject·null·빈 값
+   뒤 재시도, clone-on-read, resolver type·operation kind·문맥이 다른 키 분리를
+   검증한다.
 2. pip·conda·Maven·npm resolver 테스트에서 두 직접 루트가 공통 전이
    의존성을 가질 때 `getLatestVersion`을 포함한 공통 metadata/candidate producer가
    한 번만 호출되는지 검증한다.

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -50,7 +50,7 @@
 
 ### 공통 세션
 
-`src/core/shared/resolution-session.ts`에 요청 수명과 같은 `ResolutionSession`을
+`src/core/shared/internal/resolution-session.ts`에 요청 수명과 같은 `ResolutionSession`을
 둔다. 세션은 `resolver type + operation kind + 안정적으로 직렬화한 문맥`으로
 구성한 namespace key와 성공 값을 위한 canonical `Promise<T>`를 저장하는
 memoizer를 제공한다. 예를 들어 pip의 `latest-version`과 `package-info`는 같은
@@ -88,8 +88,10 @@ snapshot으로 복사해 요청 인스턴스에 설정한다. 이 snapshot gette
 반환하고, 새 instance의 옵션 변경은 singleton에 역전파하지 않는다. 따라서 기존
 TTL·cache 설정 동작과 요청 간 상태 격리를 함께 보존한다.
 
-세션은 이 요청 전용 인스턴스의 resolver 옵션으로만 전달하며, 외부 호출자가
-세션을 전달하거나 보존할 수 없게 하여 요청 경계를 강제한다.
+세션은 public `ResolverOptions`나 public resolver constructor로 전달하지 않는다. 내부
+request factory가 module-private 연결(예: `WeakMap`)으로 요청 전용 instance에만
+연결하며, `src/core/shared/index.ts`와 `src/core/index.ts`는 세션·factory를 export하지
+않는다. 따라서 외부 호출자가 세션을 전달하거나 보존할 수 없고 요청 경계가 강제된다.
 
 ### 키 격리
 
@@ -98,10 +100,10 @@ TTL·cache 설정 동작과 요청 간 상태 격리를 함께 보존한다.
 
 | 유형 | 세션 키 문맥 |
 | --- | --- |
-| pip | 정규화 이름, 요청 버전 조건, index URL, 대상 OS/아키텍처, Python 버전, source artifact 검증 모드 |
-| conda | 정규화 이름, 버전 조건·build, channel, subdir/아키텍처, Python·CUDA 버전 |
-| Maven | 원시 POM/BOM에는 group:artifact:version 좌표와 저장소 URL |
-| npm | 정규화 이름, 버전 조건, 현재 resolver가 실제로 받는 registry/host 환경 입력 |
+| pip | PEP 503 정규화 이름, 요청 버전 조건, index URL, 대상 OS/아키텍처, Python 버전, source artifact 검증 모드 |
+| conda | 소문자 정규화 이름, 버전 조건·build, channel, subdir/아키텍처, Python·CUDA 버전 |
+| Maven | 원시 POM/BOM에는 group:artifact:version 좌표와 실제 cache option 적용 후 저장소 URL |
+| npm | 소문자 정규화 이름, 버전 조건, 현재 resolver가 실제로 받는 registry/host 환경 입력 |
 
 extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에서
 나오는 간선**을 바꾸는 값은 manifest 캐시 키가 아니라 각 resolver의 기존
@@ -120,7 +122,8 @@ extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에
   감싼다. 단건 `fetchPomWithCache()`와 비동기 `prefetchPomsParallel()` 모두 같은
   `maven:pom` canonical producer로 등록한다. prefetch는 기존처럼 해결을 실패시키지
   않는 best-effort 동작을 유지하되, 이후 실제 fetch는 같은 in-flight/success
-  snapshot을 사용한다. classifier/type 기반 아티팩트 선택, scope, exclusion,
+  snapshot을 사용한다. POM key의 저장소 URL은 `cacheOptions.repoUrl`가 있으면 그 값을
+  우선 사용한다. classifier/type 기반 아티팩트 선택, scope, exclusion,
   dependency management 적용은 호출별 queue processor가 수행한다.
 - **npm**: registry manifest와 선택된 버전 조회를 세션으로 감싼다. hoisting과
   peer dependency 배치는 기존 root별 tree manager가 구성한다. 공통 resolver가
@@ -161,9 +164,10 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
 2. pip·conda·Maven·npm resolver 테스트에서 두 직접 루트가 공통 전이
    의존성을 가질 때 `getLatestVersion`을 포함한 공통 metadata/candidate producer가
    한 번만 호출되는지 검증한다.
-3. pip index/대상 환경, conda channel/subdir, Maven 좌표·classifier 경계가 다른
-   경우 재사용하지 않거나 원시 POM만 재사용하는 회귀 테스트를 추가한다. npm은
-   현재 전달되는 입력만 키에 반영하는 테스트를 추가한다.
+3. pip PEP 503, conda/npm 소문자 canonical name 재사용과 pip index/대상 환경,
+   conda channel/subdir, Maven 실제 저장소 URL·좌표·classifier 경계가 다른 경우
+   재사용하지 않거나 원시 POM만 재사용하는 회귀 테스트를 추가한다. npm은 현재
+   전달되는 입력만 키에 반영하는 테스트를 추가한다.
 4. 공통 의존성의 일시적 실패가 다음 직접 루트에서 재시도되고, 각 직접 루트의
    best-effort/`--strict` 정책 및 오류 문맥을 유지하는지 검증한다.
 5. Maven prefetch와 이후 단건 fetch가 동일 canonical POM producer를 공유하고,

--- a/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
+++ b/docs/superpowers/specs/2026-08-13-request-scoped-resolution-session-design.md
@@ -51,12 +51,16 @@
 ### 공통 세션
 
 `src/core/shared/resolution-session.ts`에 요청 수명과 같은 `ResolutionSession`을
-둔다. 세션은 문자열 키와 성공 값을 위한 `Promise<T>`를 저장하는 memoizer를
-제공한다.
+둔다. 세션은 `resolver type + operation kind + 안정적으로 직렬화한 문맥`으로
+구성한 namespace key와 성공 값을 위한 canonical `Promise<T>`를 저장하는
+memoizer를 제공한다. 예를 들어 pip의 `latest-version`과 `package-info`는 같은
+패키지 문맥이어도 서로 다른 key다. 따라서 `fetchPackageInfo(latest)`가 내부에서
+`getLatestVersion(latest)`를 호출해도 자기 Promise를 재진입 대기하지 않는다.
 
-- 최초 호출은 producer Promise를 저장하고 실행한다.
-- 후속 호출은 같은 Promise를 반환한다. 완료 전 동시 호출도 중복 네트워크
-  작업을 만들지 않는다.
+- 최초 호출은 canonical producer Promise를 저장하고 실행한다.
+- 후속 호출은 canonical Promise에 연결되지만, `then(clone)`으로 각 consumer에
+  독립 snapshot을 반환한다. 완료 전 동시 호출도 중복 네트워크 작업을 만들지
+  않으며, 어느 consumer도 다른 consumer의 객체를 바꿀 수 없다.
 - producer가 reject되면 캐시 항목을 즉시 제거한다. 같은 시점의 호출자는 같은
   실패를 받지만, 이후 직접 루트는 다시 조회한다. 따라서 일시적 네트워크 실패가
   뒤의 루트 성공 기회를 없애지 않는다. 각 resolver의 기존 오류 감싸기와
@@ -74,6 +78,11 @@
 한 요청에 하나씩 만든다. 이로써 resolver 인스턴스 필드(visited, queue, conflicts,
 tree manager, 대상 환경)가 동시 다운로드 요청 사이에 섞이지 않는다. 원격 metadata
 cache는 기존 모듈 수준 캐시를 계속 사용한다.
+
+pip·Maven factory는 legacy singleton에 `setCacheOptions()`로 설정된 값을 읽기 전용
+snapshot으로 복사해 요청 인스턴스에 설정한다. 이 snapshot getter는 복사본만
+반환하고, 새 instance의 옵션 변경은 singleton에 역전파하지 않는다. 따라서 기존
+TTL·cache 설정 동작과 요청 간 상태 격리를 함께 보존한다.
 
 세션은 이 요청 전용 인스턴스의 resolver 옵션으로만 전달하며, 외부 호출자가
 세션을 전달하거나 보존할 수 없게 하여 요청 경계를 강제한다.
@@ -104,8 +113,11 @@ extras, Maven scope/exclusion, npm peer/optional/dev 플래그처럼 **부모에
   repodata 후보 선택 결과를 세션으로 감싼다. build와 target subdir을 키에
   포함한다.
 - **Maven**: 좌표의 원시 POM/BOM 조회·파싱과 version range 선택을 세션으로
-  감싼다. classifier/type 기반 아티팩트 선택, scope, exclusion, dependency
-  management 적용은 호출별 queue processor가 수행한다.
+  감싼다. 단건 `fetchPomWithCache()`와 비동기 `prefetchPomsParallel()` 모두 같은
+  `maven:pom` canonical producer로 등록한다. prefetch는 기존처럼 해결을 실패시키지
+  않는 best-effort 동작을 유지하되, 이후 실제 fetch는 같은 in-flight/success
+  snapshot을 사용한다. classifier/type 기반 아티팩트 선택, scope, exclusion,
+  dependency management 적용은 호출별 queue processor가 수행한다.
 - **npm**: registry manifest와 선택된 버전 조회를 세션으로 감싼다. hoisting과
   peer dependency 배치는 기존 root별 tree manager가 구성한다. 공통 resolver가
   npm에 `targetOS`/`architecture`를 새로 매핑하지는 않으며, 현재 host 기반 선택
@@ -140,7 +152,7 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
 ## 검증 계획
 
 1. `ResolutionSession` 단위 테스트로 success, in-flight 공유, reject 후 재시도,
-   clone-on-read, 서로 다른 키 분리를 검증한다.
+   clone-on-read, resolver type·operation kind·문맥이 다른 키 분리를 검증한다.
 2. pip·conda·Maven·npm resolver 테스트에서 두 직접 루트가 공통 전이
    의존성을 가질 때 `getLatestVersion`을 포함한 공통 metadata/candidate producer가
    한 번만 호출되는지 검증한다.
@@ -149,9 +161,13 @@ resolver의 공개 사용 경로와 기존 테스트를 유지한다.
    현재 전달되는 입력만 키에 반영하는 테스트를 추가한다.
 4. 공통 의존성의 일시적 실패가 다음 직접 루트에서 재시도되고, 각 직접 루트의
    best-effort/`--strict` 정책 및 오류 문맥을 유지하는지 검증한다.
-5. 서로 다른 환경 옵션으로 동시에 두 `resolveAllDependencies()`를 실행해
+5. Maven prefetch와 이후 단건 fetch가 동일 canonical POM producer를 공유하고,
+   prefetch 오류가 기존 해결 오류 정책을 바꾸지 않는지 검증한다.
+6. legacy singleton에 설정한 pip·Maven cache options가 요청별 인스턴스에
+   snapshot으로 전달되고 역전파되지 않는지 검증한다.
+7. 서로 다른 환경 옵션으로 동시에 두 `resolveAllDependencies()`를 실행해
    요청별 resolver 인스턴스와 세션 상태가 섞이지 않는지 검증한다.
-6. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
+8. 전체 test, lint, typecheck, build와 PR CI를 실행한다.
 
 ## 영향 문서
 

--- a/src/cli/commands/download-session-integration.test.ts
+++ b/src/cli/commands/download-session-integration.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResolutionSession } from '../../core/shared/internal/resolution-session';
+import { downloadCommand } from './download';
+
+const {
+  ensureDir,
+  readFile,
+  reset,
+  addToQueue,
+  on,
+  startDownload,
+  createArchive,
+  generateAllScripts,
+  create,
+  stop,
+  createRequestPipResolver,
+  resolveDependencies,
+  sharedMetadataLookup,
+  sessions,
+} = vi.hoisted(() => ({
+  ensureDir: vi.fn(),
+  readFile: vi.fn(),
+  reset: vi.fn(),
+  addToQueue: vi.fn(),
+  on: vi.fn(),
+  startDownload: vi.fn(),
+  createArchive: vi.fn(),
+  generateAllScripts: vi.fn(),
+  create: vi.fn(() => ({ update: vi.fn() })),
+  stop: vi.fn(),
+  createRequestPipResolver: vi.fn(),
+  resolveDependencies: vi.fn(),
+  sharedMetadataLookup: vi.fn(),
+  sessions: [] as unknown[],
+}));
+
+vi.mock('fs-extra', () => ({
+  default: { ensureDir, readFile },
+  ensureDir,
+  readFile,
+}));
+
+vi.mock('cli-progress', () => ({
+  default: {
+    MultiBar: vi.fn(function MultiBarMock() {
+      return { create, stop };
+    }),
+    Presets: { shades_classic: {} },
+  },
+}));
+
+vi.mock('./download-runner', () => ({
+  DownloadManager: vi.fn(function DownloadManagerMock() {
+    return { reset, addToQueue, on, startDownload };
+  }),
+}));
+
+vi.mock('../../core/packager/archive-packager', () => ({
+  getArchivePackager: vi.fn(() => ({ createArchive })),
+}));
+
+vi.mock('../../core/packager/script-generator', () => ({
+  getScriptGenerator: vi.fn(() => ({ generateAllScripts })),
+}));
+
+vi.mock('../../core/resolver/pip-resolver', () => ({
+  createRequestPipResolver,
+}));
+
+describe('downloadCommand request session integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessions.length = 0;
+    ensureDir.mockResolvedValue(undefined);
+    startDownload.mockResolvedValue({
+      success: true,
+      totalSize: 1024,
+      duration: 1000,
+      items: [],
+    });
+    createArchive.mockResolvedValue(undefined);
+    generateAllScripts.mockResolvedValue(undefined);
+  });
+
+  it('strict 모드는 실제 요청 세션의 재시도 성공 뒤에도 앞선 root 실패를 중단 처리한다', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+    readFile.mockResolvedValue('alpha==1.0.0\nbeta==1.0.0\n');
+    sharedMetadataLookup
+      .mockRejectedValueOnce(new Error('temporary metadata failure'))
+      .mockResolvedValueOnce({ version: '2.0.0' });
+
+    createRequestPipResolver.mockImplementation((session: ResolutionSession) => {
+      sessions.push(session);
+      resolveDependencies.mockImplementation(async (name: string) => {
+        await session.getOrCreate(
+          'pip',
+          'package-info',
+          { name: 'shared', version: '2.0.0' },
+          () => sharedMetadataLookup(),
+        );
+        const root = { type: 'pip' as const, name, version: '1.0.0' };
+        const shared = { type: 'pip' as const, name: 'shared', version: '2.0.0' };
+        return {
+          root: { package: root, dependencies: [{ package: shared, dependencies: [] }] },
+          flatList: [root, shared],
+          conflicts: [],
+          totalSize: 0,
+        };
+      });
+      return { resolveDependencies };
+    });
+
+    await expect(
+      downloadCommand({
+        type: 'pip',
+        pkgVersion: 'latest',
+        arch: 'x86_64',
+        output: './output',
+        format: 'zip',
+        file: 'requirements.txt',
+        deps: true,
+        strict: true,
+        concurrency: '3',
+      } as Parameters<typeof downloadCommand>[0]),
+    ).rejects.toThrow('process.exit');
+
+    expect(createRequestPipResolver).toHaveBeenCalledTimes(1);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toBeInstanceOf(ResolutionSession);
+    expect(resolveDependencies).toHaveBeenCalledTimes(2);
+    expect(sharedMetadataLookup).toHaveBeenCalledTimes(2);
+    expect(addToQueue).not.toHaveBeenCalled();
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(createArchive).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/src/cli/commands/download-session-integration.test.ts
+++ b/src/cli/commands/download-session-integration.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ResolutionSession } from '../../core/shared/internal/resolution-session';
 import { downloadCommand } from './download';
+import { ResolutionSession } from '../../core/shared/internal/resolution-session';
 
 const {
   ensureDir,

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadCommand } from './download';
 import { resolveAllDependencies } from '../../core/shared';
-import { ResolutionSession } from '../../core/shared/internal/resolution-session';
 
 const {
   ensureDir,
@@ -686,124 +685,6 @@ describe('downloadCommand', () => {
       downloadCommand(commandOptions({ strict: true })),
     ).rejects.toThrow('process.exit');
 
-    expect(addToQueue).not.toHaveBeenCalled();
-    expect(startDownload).not.toHaveBeenCalled();
-    expect(createArchive).not.toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
-  });
-
-  it('strict 모드는 공통 의존성 재시도 성공 뒤에도 앞선 root 실패 기록을 중단 처리한다', async () => {
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {
-        throw new Error('process.exit');
-      }) as never);
-    readFile.mockResolvedValue('alpha==1.0.0\nbeta==1.0.0\n');
-
-    const requestSession = new ResolutionSession();
-    const sharedMetadataLookup = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('temporary metadata failure'))
-      .mockResolvedValueOnce({ version: '2.0.0' });
-    const originalPackages = [
-      {
-        id: 'pip-alpha-1.0.0',
-        type: 'pip' as const,
-        name: 'alpha',
-        version: '1.0.0',
-        architecture: 'x86_64',
-      },
-      {
-        id: 'pip-beta-1.0.0',
-        type: 'pip' as const,
-        name: 'beta',
-        version: '1.0.0',
-        architecture: 'x86_64',
-      },
-    ];
-    const allPackages = [...originalPackages];
-    const successfulPackages = [] as typeof originalPackages;
-    const dependencyTrees = [] as Array<{
-      root: { package: { type: 'pip'; name: string; version: string }; dependencies: [] };
-      flatList: Array<{ type: 'pip'; name: string; version: string }>;
-      conflicts: [];
-      totalSize: number;
-    }>;
-    const failedPackages: Array<{ name: string; version: string; error: string }> = [];
-
-    for (const root of originalPackages) {
-      try {
-        await requestSession.getOrCreate(
-          'pip',
-          'package-info',
-          { name: 'shared', version: '2.0.0' },
-          () => sharedMetadataLookup(),
-        );
-        const sharedPackage = {
-          id: 'pip-shared-2.0.0',
-          type: 'pip' as const,
-          name: 'shared',
-          version: '2.0.0',
-          architecture: 'x86_64',
-        };
-        allPackages.push(sharedPackage);
-        successfulPackages.push(root, sharedPackage);
-        dependencyTrees.push({
-          root: { package: root, dependencies: [] },
-          flatList: [root, sharedPackage],
-          conflicts: [],
-          totalSize: 0,
-        });
-      } catch (error) {
-        failedPackages.push({
-          name: root.name,
-          version: root.version,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    expect(sharedMetadataLookup).toHaveBeenCalledTimes(2);
-    expect(failedPackages).toEqual([
-      { name: 'alpha', version: '1.0.0', error: 'temporary metadata failure' },
-    ]);
-    expect(successfulPackages).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'beta', version: '1.0.0' }),
-        expect.objectContaining({ name: 'shared', version: '2.0.0' }),
-      ]),
-    );
-    expect(dependencyTrees.map((tree) => tree.root.package.name)).toEqual(['beta']);
-    vi.mocked(resolveAllDependencies).mockResolvedValueOnce({
-      originalPackages,
-      allPackages,
-      successfulPackages,
-      dependencyTrees,
-      failedPackages,
-    });
-
-    await expect(
-      downloadCommand({
-        type: 'pip',
-        pkgVersion: 'latest',
-        arch: 'x86_64',
-        output: './output',
-        format: 'zip',
-        file: 'requirements.txt',
-        deps: true,
-        strict: true,
-        concurrency: '3',
-      }),
-    ).rejects.toThrow('process.exit');
-
-    expect(resolveAllDependencies).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'alpha' }),
-        expect.objectContaining({ name: 'beta' }),
-      ]),
-      expect.any(Object),
-    );
     expect(addToQueue).not.toHaveBeenCalled();
     expect(startDownload).not.toHaveBeenCalled();
     expect(createArchive).not.toHaveBeenCalled();

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadCommand } from './download';
 import { resolveAllDependencies } from '../../core/shared';
+import { ResolutionSession } from '../../core/shared/internal/resolution-session';
 
 const {
   ensureDir,
@@ -685,6 +686,124 @@ describe('downloadCommand', () => {
       downloadCommand(commandOptions({ strict: true })),
     ).rejects.toThrow('process.exit');
 
+    expect(addToQueue).not.toHaveBeenCalled();
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(createArchive).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('strict 모드는 공통 의존성 재시도 성공 뒤에도 앞선 root 실패 기록을 중단 처리한다', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+    readFile.mockResolvedValue('alpha==1.0.0\nbeta==1.0.0\n');
+
+    const requestSession = new ResolutionSession();
+    const sharedMetadataLookup = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary metadata failure'))
+      .mockResolvedValueOnce({ version: '2.0.0' });
+    const originalPackages = [
+      {
+        id: 'pip-alpha-1.0.0',
+        type: 'pip' as const,
+        name: 'alpha',
+        version: '1.0.0',
+        architecture: 'x86_64',
+      },
+      {
+        id: 'pip-beta-1.0.0',
+        type: 'pip' as const,
+        name: 'beta',
+        version: '1.0.0',
+        architecture: 'x86_64',
+      },
+    ];
+    const allPackages = [...originalPackages];
+    const successfulPackages = [] as typeof originalPackages;
+    const dependencyTrees = [] as Array<{
+      root: { package: { type: 'pip'; name: string; version: string }; dependencies: [] };
+      flatList: Array<{ type: 'pip'; name: string; version: string }>;
+      conflicts: [];
+      totalSize: number;
+    }>;
+    const failedPackages: Array<{ name: string; version: string; error: string }> = [];
+
+    for (const root of originalPackages) {
+      try {
+        await requestSession.getOrCreate(
+          'pip',
+          'package-info',
+          { name: 'shared', version: '2.0.0' },
+          () => sharedMetadataLookup(),
+        );
+        const sharedPackage = {
+          id: 'pip-shared-2.0.0',
+          type: 'pip' as const,
+          name: 'shared',
+          version: '2.0.0',
+          architecture: 'x86_64',
+        };
+        allPackages.push(sharedPackage);
+        successfulPackages.push(root, sharedPackage);
+        dependencyTrees.push({
+          root: { package: root, dependencies: [] },
+          flatList: [root, sharedPackage],
+          conflicts: [],
+          totalSize: 0,
+        });
+      } catch (error) {
+        failedPackages.push({
+          name: root.name,
+          version: root.version,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    expect(sharedMetadataLookup).toHaveBeenCalledTimes(2);
+    expect(failedPackages).toEqual([
+      { name: 'alpha', version: '1.0.0', error: 'temporary metadata failure' },
+    ]);
+    expect(successfulPackages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'beta', version: '1.0.0' }),
+        expect.objectContaining({ name: 'shared', version: '2.0.0' }),
+      ]),
+    );
+    expect(dependencyTrees.map((tree) => tree.root.package.name)).toEqual(['beta']);
+    vi.mocked(resolveAllDependencies).mockResolvedValueOnce({
+      originalPackages,
+      allPackages,
+      successfulPackages,
+      dependencyTrees,
+      failedPackages,
+    });
+
+    await expect(
+      downloadCommand({
+        type: 'pip',
+        pkgVersion: 'latest',
+        arch: 'x86_64',
+        output: './output',
+        format: 'zip',
+        file: 'requirements.txt',
+        deps: true,
+        strict: true,
+        concurrency: '3',
+      }),
+    ).rejects.toThrow('process.exit');
+
+    expect(resolveAllDependencies).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'alpha' }),
+        expect.objectContaining({ name: 'beta' }),
+      ]),
+      expect.any(Object),
+    );
     expect(addToQueue).not.toHaveBeenCalled();
     expect(startDownload).not.toHaveBeenCalled();
     expect(createArchive).not.toHaveBeenCalled();

--- a/src/core/resolver/conda-resolver-target.test.ts
+++ b/src/core/resolver/conda-resolver-target.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CondaRepoDataProcessor } from './conda-repodata-processor';
 import {
   createRequestCondaResolver,
@@ -16,6 +16,207 @@ describe('CondaResolver 요청 session 연결', () => {
 
     expect(getAttachedResolutionSession(requestResolver)).toBe(session);
     expect(getAttachedResolutionSession(legacyResolver)).toBeUndefined();
+  });
+});
+
+describe('CondaResolver 요청 세션 후보 재사용', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('공통 전이 의존성의 최신 후보와 아티팩트 선택을 한 번만 수행한다', async () => {
+    const repodata = {
+      info: { subdir: 'linux-64' },
+      packages: {
+        'alpha-1.0.0-0.tar.bz2': {
+          name: 'alpha',
+          version: '1.0.0',
+          build: '0',
+          build_number: 0,
+          depends: ['Shared >=1.0'],
+          subdir: 'linux-64',
+        },
+        'beta-1.0.0-0.tar.bz2': {
+          name: 'beta',
+          version: '1.0.0',
+          build: '0',
+          build_number: 0,
+          depends: ['shared >=1.0'],
+          subdir: 'linux-64',
+        },
+        'shared-1.0.0-0.tar.bz2': {
+          name: 'shared',
+          version: '1.0.0',
+          build: '0',
+          build_number: 0,
+          depends: [],
+          subdir: 'linux-64',
+        },
+      },
+    };
+    vi.spyOn(CondaRepoDataProcessor.prototype, 'getRepoData').mockResolvedValue(
+      repodata,
+    );
+    const findCandidates = vi.spyOn(
+      CondaRepoDataProcessor.prototype,
+      'findPackageCandidates',
+    );
+    const session = new ResolutionSession();
+
+    const alpha = await createRequestCondaResolver(session).resolveDependencies('alpha', '1.0.0', {
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+    });
+    const beta = await createRequestCondaResolver(session).resolveDependencies('beta', '1.0.0', {
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+    });
+
+    // alpha, beta의 root 선택 2회와 shared의 후보·아티팩트 선택 각 1회
+    expect(findCandidates).toHaveBeenCalledTimes(4);
+    expect(alpha.flatList.find((pkg) => pkg.name === 'Shared')).toBeDefined();
+    expect(beta.flatList.find((pkg) => pkg.name === 'shared')).toBeDefined();
+  });
+
+  it('동일 후보 선택의 in-flight 조회를 합친다', async () => {
+    let release!: (value: string | null) => void;
+    const pending = new Promise<string | null>((resolve) => {
+      release = resolve;
+    });
+    const getLatestVersion = vi
+      .spyOn(CondaRepoDataProcessor.prototype, 'getLatestVersionFromRepoData')
+      .mockReturnValue(pending);
+    const session = new ResolutionSession();
+    const first = createRequestCondaResolver(session);
+    const second = createRequestCondaResolver(session);
+
+    const firstLookup = (first as any).getLatestVersionFromRepoDataWithSession(
+      'Shared',
+      'conda-forge',
+      '>=1.0',
+      'build_*',
+    );
+    const secondLookup = (second as any).getLatestVersionFromRepoDataWithSession(
+      'shared',
+      'conda-forge',
+      '>=1.0',
+      'build_*',
+    );
+    await Promise.resolve();
+
+    expect(getLatestVersion).toHaveBeenCalledTimes(1);
+    release('1.2.3');
+    await expect(Promise.all([firstLookup, secondLookup])).resolves.toEqual([
+      '1.2.3',
+      '1.2.3',
+    ]);
+  });
+
+  it('channel, 대상 환경, build와 version spec이 다르면 후보를 재사용하지 않는다', async () => {
+    const rootRepoData = {
+      info: { subdir: 'linux-64' },
+      packages: {
+        'root-1.0.0-0.tar.bz2': {
+          name: 'root',
+          version: '1.0.0',
+          build: '0',
+          build_number: 0,
+          depends: [],
+          subdir: 'linux-64',
+        },
+      },
+    };
+    vi.spyOn(CondaRepoDataProcessor.prototype, 'getRepoData').mockResolvedValue(
+      rootRepoData,
+    );
+    const getLatestVersion = vi
+      .spyOn(CondaRepoDataProcessor.prototype, 'getLatestVersionFromRepoData')
+      .mockResolvedValue('1.2.3');
+    const session = new ResolutionSession();
+    const linuxX64 = createRequestCondaResolver(session);
+    const linuxArm = createRequestCondaResolver(session);
+    const pythonChanged = createRequestCondaResolver(session);
+    const cudaChanged = createRequestCondaResolver(session);
+
+    await linuxX64.resolveDependencies('root', '1.0.0', {
+      maxDepth: 0,
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+      pythonVersion: '3.12',
+      cudaVersion: '12.4',
+    });
+    await linuxArm.resolveDependencies('root', '1.0.0', {
+      maxDepth: 0,
+      targetPlatform: { system: 'Linux', machine: 'aarch64' },
+      pythonVersion: '3.12',
+      cudaVersion: '12.4',
+    });
+    await pythonChanged.resolveDependencies('root', '1.0.0', {
+      maxDepth: 0,
+      targetPlatform: { system: 'Linux', machine: 'aarch64' },
+      pythonVersion: '3.13',
+      cudaVersion: '12.4',
+    });
+    await cudaChanged.resolveDependencies('root', '1.0.0', {
+      maxDepth: 0,
+      targetPlatform: { system: 'Linux', machine: 'aarch64' },
+      pythonVersion: '3.13',
+      cudaVersion: '11.8',
+    });
+
+    await (linuxX64 as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0', 'build-a',
+    );
+    await (linuxArm as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0', 'build-a',
+    );
+    await (pythonChanged as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0', 'build-a',
+    );
+    await (cudaChanged as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0', 'build-a',
+    );
+    await (cudaChanged as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'other-channel', '>=1.0', 'build-a',
+    );
+    await (cudaChanged as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'other-channel', '>=1.0', 'build-b',
+    );
+    await (cudaChanged as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'other-channel', '>=2.0', 'build-b',
+    );
+
+    expect(getLatestVersion).toHaveBeenCalledTimes(7);
+  });
+
+  it('실패하거나 빈 후보이면 다음 resolver가 다시 조회한다', async () => {
+    const getLatestVersion = vi
+      .spyOn(CondaRepoDataProcessor.prototype, 'getLatestVersionFromRepoData')
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('1.2.3');
+    const session = new ResolutionSession();
+    const lookup = () => (createRequestCondaResolver(session) as any)
+      .getLatestVersionFromRepoDataWithSession('shared', 'conda-forge', '>=1.0');
+
+    await expect(lookup()).rejects.toThrow('temporary failure');
+    await expect(lookup()).resolves.toBeNull();
+    await expect(lookup()).resolves.toBe('1.2.3');
+    expect(getLatestVersion).toHaveBeenCalledTimes(3);
+  });
+
+  it('세션 없는 legacy resolver는 후보를 자체적으로 다시 조회한다', async () => {
+    const getLatestVersion = vi
+      .spyOn(CondaRepoDataProcessor.prototype, 'getLatestVersionFromRepoData')
+      .mockResolvedValue('1.2.3');
+    const resolver = new CondaResolver();
+
+    await (resolver as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0',
+    );
+    await (resolver as any).getLatestVersionFromRepoDataWithSession(
+      'shared', 'conda-forge', '>=1.0',
+    );
+
+    expect(getAttachedResolutionSession(resolver)).toBeUndefined();
+    expect(getLatestVersion).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/core/resolver/conda-resolver-target.test.ts
+++ b/src/core/resolver/conda-resolver-target.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
 import { CondaRepoDataProcessor } from './conda-repodata-processor';
-import { CondaResolver } from './conda-resolver';
+import {
+  createRequestCondaResolver,
+  getCondaResolver,
+  CondaResolver,
+} from './conda-resolver';
+import { ResolutionSession } from '../shared/internal/resolution-session';
+import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
+
+describe('CondaResolver 요청 session 연결', () => {
+  it('request resolver에만 supplied session을 연결하고 legacy singleton은 연결하지 않는다', () => {
+    const session = new ResolutionSession();
+    const legacyResolver = getCondaResolver();
+    const requestResolver = createRequestCondaResolver(session);
+
+    expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+    expect(getAttachedResolutionSession(legacyResolver)).toBeUndefined();
+  });
+});
 
 describe('CondaRepoDataProcessor Python 호환성', () => {
   it('pyhd noarch 빌드의 Python 의존성 범위를 평가한다', () => {

--- a/src/core/resolver/conda-resolver.ts
+++ b/src/core/resolver/conda-resolver.ts
@@ -21,6 +21,8 @@ import {
   CondaRepoDataProcessor,
   PackageCandidate,
 } from './conda-repodata-processor';
+import type { ResolutionSession } from '../shared/internal/resolution-session';
+import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
 
 // Resolver 전용 CondaPackageInfo (files, versions 추가 필드)
 interface CondaPackageInfo {
@@ -568,4 +570,13 @@ export function getCondaResolver(): CondaResolver {
     condaResolverInstance = new CondaResolver();
   }
   return condaResolverInstance;
+}
+
+/** @internal */
+export function createRequestCondaResolver(
+  session: ResolutionSession,
+): CondaResolver {
+  const resolver = new CondaResolver();
+  attachResolutionSession(resolver, session);
+  return resolver;
 }

--- a/src/core/resolver/conda-resolver.ts
+++ b/src/core/resolver/conda-resolver.ts
@@ -19,10 +19,12 @@ import {
 } from '../shared';
 import {
   CondaRepoDataProcessor,
-  PackageCandidate,
 } from './conda-repodata-processor';
 import type { ResolutionSession } from '../shared/internal/resolution-session';
-import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
+import {
+  attachResolutionSession,
+  getAttachedResolutionSession,
+} from '../shared/internal/resolution-session-registry';
 
 // Resolver 전용 CondaPackageInfo (files, versions 추가 필드)
 interface CondaPackageInfo {
@@ -60,6 +62,8 @@ export class CondaResolver implements IResolver {
 
   // Python 버전 설정 (프로세서에도 전달)
   private pythonVersion: string | null = null;
+  private targetArchitecture: string | null = 'x86_64';
+  private cudaVersion: string | null = null;
 
   constructor() {
     this.repoDataProcessor = new CondaRepoDataProcessor({
@@ -99,6 +103,8 @@ export class CondaResolver implements IResolver {
 
     // CUDA 버전 설정
     const cudaVersion = (options as { cudaVersion?: string })?.cudaVersion || null;
+    this.targetArchitecture = arch;
+    this.cudaVersion = cudaVersion;
 
     // RepoData 프로세서 설정 업데이트
     this.repoDataProcessor.updateConfig({
@@ -168,7 +174,7 @@ export class CondaResolver implements IResolver {
         }
 
         // 패키지 정보 조회
-        const pkgInfo = await this.fetchPackageInfoBFS(
+        const pkgInfo = await this.fetchPackageInfoBFSWithSession(
           name,
           ver,
           channel,
@@ -206,11 +212,10 @@ export class CondaResolver implements IResolver {
           if (!parsed || this.isSystemPackage(parsed.name)) continue;
 
           try {
-            const depVersion = await this.repoDataProcessor.getLatestVersionFromRepoData(
+            const depVersion = await this.getLatestVersionFromRepoDataWithSession(
               parsed.name,
               channel,
               parsed.versionSpec,
-              (n, ch, spec) => this.getLatestVersion(n, ch, spec),
               parsed.build,
             );
 
@@ -377,6 +382,94 @@ export class CondaResolver implements IResolver {
     return { packageInfo, depends, isPythonMatch };
   }
 
+  private async fetchPackageInfoBFSWithSession(
+    name: string,
+    version: string,
+    channel: string,
+    buildSpec?: string,
+  ): Promise<{ packageInfo: PackageInfo; depends: string[]; isPythonMatch: boolean }> {
+    const selectedPackage = await this.sessionGet(
+      'package-info',
+      name,
+      version,
+      channel,
+      buildSpec,
+      () => this.fetchPackageInfoBFS(name, version, channel, buildSpec),
+    );
+
+    // 후보 선택은 공유하되, 호출별 package 표기와 repository metadata는 보존한다.
+    return {
+      ...selectedPackage,
+      packageInfo: {
+        ...selectedPackage.packageInfo,
+        name,
+        metadata: {
+          ...selectedPackage.packageInfo.metadata,
+          repository: `${channel}/${name}`,
+        },
+      },
+    };
+  }
+
+  private async getLatestVersionFromRepoDataWithSession(
+    name: string,
+    channel: string,
+    versionSpec?: string,
+    buildSpec?: string,
+  ): Promise<string | null> {
+    return this.sessionGet(
+      'latest-version',
+      name,
+      versionSpec,
+      channel,
+      buildSpec,
+      () => this.repoDataProcessor.getLatestVersionFromRepoData(
+        name,
+        channel,
+        versionSpec,
+        (fallbackName, fallbackChannel, fallbackVersionSpec) =>
+          this.getLatestVersion(fallbackName, fallbackChannel, fallbackVersionSpec),
+        buildSpec,
+      ),
+      Boolean,
+    );
+  }
+
+  private sessionGet<T>(
+    operation: 'latest-version' | 'package-info',
+    name: string,
+    versionOrSpec: string | undefined,
+    channel: string,
+    buildSpec: string | undefined,
+    producer: () => Promise<T>,
+    isCacheable?: (value: T) => boolean,
+  ): Promise<T> {
+    const session = getAttachedResolutionSession(this);
+    if (!session) {
+      return producer();
+    }
+
+    return session.getOrCreate(
+      'conda',
+      operation,
+      {
+        name: name.toLowerCase(),
+        version:
+          operation === 'package-info' ? versionOrSpec ?? null : null,
+        versionSpec:
+          operation === 'latest-version' ? versionOrSpec ?? null : null,
+        buildSpec: buildSpec ?? null,
+        channel,
+        targetSubdir: this.repoDataProcessor.targetSubdir,
+        targetArchitecture: this.targetArchitecture,
+        pythonVersion: this.pythonVersion,
+        cudaVersion: this.cudaVersion,
+      },
+      producer,
+      isCacheable ? { isCacheable } : undefined,
+    );
+  }
+
   /**
    * Anaconda API 폴백 (repodata 조회 실패시)
    */
@@ -517,11 +610,10 @@ export class CondaResolver implements IResolver {
               } else {
                 // 호환 버전 조회
                 const channel = env.channels?.[0] || this.defaultChannel;
-                const compatVersion = await this.repoDataProcessor.getLatestVersionFromRepoData(
+                const compatVersion = await this.getLatestVersionFromRepoDataWithSession(
                   parsed.name,
                   channel,
                   parsed.versionSpec,
-                  (name, ch, spec) => this.getLatestVersion(name, ch, spec),
                   parsed.build,
                 );
                 if (compatVersion) {

--- a/src/core/resolver/maven-resolver.test.ts
+++ b/src/core/resolver/maven-resolver.test.ts
@@ -4,7 +4,7 @@
  * 네트워크 호출 없이 MavenResolver의 핵심 로직을 테스트합니다.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   createRequestMavenResolver,
   getMavenResolver,
@@ -12,6 +12,8 @@ import {
 } from './maven-resolver';
 import { ResolutionSession } from '../shared/internal/resolution-session';
 import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
+import * as mavenCache from '../shared/maven-cache';
+import { MavenCoordinate, PomProject } from '../shared/maven-types';
 // 분리된 유틸리티 함수 import
 import {
   resolveProperty,
@@ -19,6 +21,37 @@ import {
   extractExclusions,
   extractDependencies,
 } from '../shared/maven-pom-utils';
+
+vi.mock('../shared/maven-cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../shared/maven-cache')>();
+
+  return {
+    ...actual,
+    fetchPom: vi.fn(),
+    prefetchPomsParallel: vi.fn(),
+  };
+});
+
+const fetchPomFromCacheMock = vi.mocked(mavenCache.fetchPom);
+const defaultRepoUrl = 'https://repo1.maven.org/maven2';
+const sharedCoordinate: MavenCoordinate = {
+  groupId: 'org.example',
+  artifactId: 'shared',
+  version: '1.0.0',
+};
+
+function createSharedPom(): PomProject {
+  return {
+    groupId: sharedCoordinate.groupId,
+    artifactId: sharedCoordinate.artifactId,
+    version: sharedCoordinate.version,
+    properties: { source: 'registry' },
+  };
+}
+
+function fetchRawPom(resolver: MavenResolver, coordinate: MavenCoordinate): Promise<PomProject> {
+  return (resolver as any).fetchPomWithCache(coordinate);
+}
 
 // MavenResolver 인스턴스 생성
 const createResolver = () => {
@@ -30,6 +63,8 @@ describe('MavenResolver 단위 테스트', () => {
 
   beforeEach(() => {
     resolver = createResolver();
+    fetchPomFromCacheMock.mockReset();
+    getMavenResolver().setCacheOptions({});
   });
 
   it('요청 resolver는 singleton cache options의 독립 snapshot과 session을 사용한다', () => {
@@ -52,6 +87,180 @@ describe('MavenResolver 단위 테스트', () => {
     expect(singleton.getCacheOptions()).toEqual({
       memoryTtl: 120,
       useDiskCache: true,
+    });
+  });
+
+  describe('요청 세션 Maven metadata 재사용', () => {
+    it('동일 GAV의 raw POM은 두 요청 resolver에서 한 번 조회하고 consumer별 clone을 반환한다', async () => {
+      fetchPomFromCacheMock.mockResolvedValue(createSharedPom());
+      const session = new ResolutionSession();
+      const first = createRequestMavenResolver(session);
+      const second = createRequestMavenResolver(session);
+
+      const [firstPom, secondPom] = await Promise.all([
+        fetchRawPom(first, sharedCoordinate),
+        fetchRawPom(second, sharedCoordinate),
+      ]);
+
+      firstPom.properties!.source = 'mutated-by-first-root';
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1);
+      expect(secondPom.properties?.source).toBe('registry');
+    });
+
+    it('classifier가 다른 root는 raw POM은 공유하지만 artifact 선택 결과는 독립적이다', async () => {
+      fetchPomFromCacheMock.mockResolvedValue(createSharedPom());
+      const session = new ResolutionSession();
+      const first = createRequestMavenResolver(session);
+      const second = createRequestMavenResolver(session);
+      const linuxCoordinate = { ...sharedCoordinate, classifier: 'linux-x86_64' };
+      const macCoordinate = { ...sharedCoordinate, classifier: 'osx-aarch_64' };
+
+      await Promise.all([
+        fetchRawPom(first, linuxCoordinate),
+        fetchRawPom(second, macCoordinate),
+      ]);
+
+      const linuxNode = (first as any).createDependencyNode(linuxCoordinate, 'compile');
+      const macNode = (second as any).createDependencyNode(macCoordinate, 'compile');
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1);
+      expect(linuxNode.package.metadata.classifier).toBe('linux-x86_64');
+      expect(macNode.package.metadata.classifier).toBe('osx-aarch_64');
+      expect(linuxNode.package.metadata.filename).toContain('linux-x86_64');
+      expect(macNode.package.metadata.filename).toContain('osx-aarch_64');
+    });
+
+    it('기본 저장소와 명시한 기본 저장소 URL은 같은 raw POM producer를 사용한다', async () => {
+      fetchPomFromCacheMock.mockResolvedValue(createSharedPom());
+      const session = new ResolutionSession();
+      const implicitDefault = createRequestMavenResolver(session);
+      const explicitDefault = createRequestMavenResolver(session);
+      explicitDefault.setCacheOptions({ repoUrl: defaultRepoUrl });
+
+      await Promise.all([
+        fetchRawPom(implicitDefault, sharedCoordinate),
+        fetchRawPom(explicitDefault, sharedCoordinate),
+      ]);
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1);
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        sharedCoordinate,
+        expect.objectContaining({ repoUrl: defaultRepoUrl }),
+      );
+    });
+
+    it('서로 다른 저장소는 같은 GAV raw POM을 공유하지 않는다', async () => {
+      fetchPomFromCacheMock.mockResolvedValue(createSharedPom());
+      const session = new ResolutionSession();
+      const repoA = createRequestMavenResolver(session);
+      const repoB = createRequestMavenResolver(session);
+      repoA.setCacheOptions({ repoUrl: 'https://repo-a.example/maven2' });
+      repoB.setCacheOptions({ repoUrl: 'https://repo-b.example/maven2' });
+
+      await Promise.all([
+        fetchRawPom(repoA, sharedCoordinate),
+        fetchRawPom(repoB, sharedCoordinate),
+      ]);
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(2);
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        sharedCoordinate,
+        expect.objectContaining({ repoUrl: 'https://repo-a.example/maven2' }),
+      );
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        sharedCoordinate,
+        expect.objectContaining({ repoUrl: 'https://repo-b.example/maven2' }),
+      );
+    });
+
+    it('prefetch와 이후 단건 조회는 진행 중인 같은 raw POM producer를 공유한다', async () => {
+      let release!: (pom: PomProject) => void;
+      const pendingPom = new Promise<PomProject>((resolve) => {
+        release = resolve;
+      });
+      fetchPomFromCacheMock.mockReturnValue(pendingPom);
+      const resolver = createRequestMavenResolver(new ResolutionSession());
+
+      (resolver as any).prefetchPomsParallelInternal([sharedCoordinate]);
+      await vi.waitFor(() => expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1));
+      const requestedPom = fetchRawPom(resolver, sharedCoordinate);
+      release(createSharedPom());
+
+      await expect(requestedPom).resolves.toEqual(createSharedPom());
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetch 실패는 소비되며 이후 단건 조회가 다시 시도할 수 있다', async () => {
+      let reject!: (error: Error) => void;
+      const pendingPom = new Promise<PomProject>((_resolve, rejectPromise) => {
+        reject = rejectPromise;
+      });
+      fetchPomFromCacheMock
+        .mockReturnValueOnce(pendingPom)
+        .mockResolvedValueOnce(createSharedPom());
+      const resolver = createRequestMavenResolver(new ResolutionSession());
+
+      (resolver as any).prefetchPomsParallelInternal([sharedCoordinate]);
+      await vi.waitFor(() => expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(1));
+      reject(new Error('prefetch repository failure'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await expect(fetchRawPom(resolver, sharedCoordinate)).resolves.toEqual(createSharedPom());
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('진행 중인 최신 버전 metadata 조회는 요청 resolver 사이에서 한 번만 호출한다', async () => {
+      let release!: (value: { data: string }) => void;
+      const pendingMetadata = new Promise<{ data: string }>((resolve) => {
+        release = resolve;
+      });
+      const get = vi.fn(() => pendingMetadata);
+      const session = new ResolutionSession();
+      const first = createRequestMavenResolver(session);
+      const second = createRequestMavenResolver(session);
+      second.setCacheOptions({ repoUrl: defaultRepoUrl });
+      (first as any).axiosInstance.get = get;
+      (second as any).axiosInstance.get = get;
+
+      const versions = Promise.all([
+        first.getLatestVersion('org.example', 'shared'),
+        second.getLatestVersion('org.example', 'shared'),
+      ]);
+      await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+      release({
+        data: '<metadata><versioning><release>1.0.0</release></versioning></metadata>',
+      });
+
+      await expect(versions).resolves.toEqual(['1.0.0', '1.0.0']);
+    });
+
+    it('실패한 raw POM 조회는 세션에서 제거되어 다음 root가 재시도한다', async () => {
+      fetchPomFromCacheMock
+        .mockRejectedValueOnce(new Error('temporary repository failure'))
+        .mockResolvedValueOnce(createSharedPom());
+      const session = new ResolutionSession();
+
+      await expect(
+        fetchRawPom(createRequestMavenResolver(session), sharedCoordinate),
+      ).rejects.toThrow('temporary repository failure');
+      await expect(
+        fetchRawPom(createRequestMavenResolver(session), sharedCoordinate),
+      ).resolves.toEqual(createSharedPom());
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('legacy singleton은 요청 세션 없이 raw POM 조회를 기존처럼 각각 수행한다', async () => {
+      fetchPomFromCacheMock.mockResolvedValue(createSharedPom());
+      const legacyResolver = getMavenResolver();
+
+      expect(getAttachedResolutionSession(legacyResolver)).toBeUndefined();
+      await fetchRawPom(legacyResolver, sharedCoordinate);
+      await fetchRawPom(legacyResolver, sharedCoordinate);
+
+      expect(fetchPomFromCacheMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/core/resolver/maven-resolver.test.ts
+++ b/src/core/resolver/maven-resolver.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { MavenResolver } from './maven-resolver';
+import {
+  createRequestMavenResolver,
+  getMavenResolver,
+  MavenResolver,
+} from './maven-resolver';
+import { ResolutionSession } from '../shared/internal/resolution-session';
+import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
 // 분리된 유틸리티 함수 import
 import {
   resolveProperty,
@@ -24,6 +30,28 @@ describe('MavenResolver 단위 테스트', () => {
 
   beforeEach(() => {
     resolver = createResolver();
+  });
+
+  it('요청 resolver는 singleton cache options의 독립 snapshot과 session을 사용한다', () => {
+    const singleton = getMavenResolver();
+    singleton.setCacheOptions({ memoryTtl: 120, useDiskCache: true });
+    const session = new ResolutionSession();
+
+    const requestResolver = createRequestMavenResolver(session);
+
+    expect(requestResolver).not.toBe(singleton);
+    expect(requestResolver.getCacheOptions()).toEqual({
+      memoryTtl: 120,
+      useDiskCache: true,
+    });
+    expect(requestResolver.getCacheOptions()).not.toBe(singleton.getCacheOptions());
+    expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+
+    requestResolver.setCacheOptions({ memoryTtl: 60 });
+    expect(singleton.getCacheOptions()).toEqual({
+      memoryTtl: 120,
+      useDiskCache: true,
+    });
   });
 
   describe('resolveProperty (유틸리티 함수)', () => {

--- a/src/core/resolver/maven-resolver.test.ts
+++ b/src/core/resolver/maven-resolver.test.ts
@@ -46,6 +46,7 @@ describe('MavenResolver 단위 테스트', () => {
     });
     expect(requestResolver.getCacheOptions()).not.toBe(singleton.getCacheOptions());
     expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+    expect(getAttachedResolutionSession(singleton)).toBeUndefined();
 
     requestResolver.setCacheOptions({ memoryTtl: 60 });
     expect(singleton.getCacheOptions()).toEqual({

--- a/src/core/resolver/maven-resolver.ts
+++ b/src/core/resolver/maven-resolver.ts
@@ -33,7 +33,6 @@ import {
 import { DependencyResolutionSkipper } from '../shared/maven-dedupe-index';
 import {
   fetchPom as fetchPomFromCache,
-  prefetchPomsParallel,
   clearMemoryCache as clearMavenCache,
   MavenCacheOptions,
 } from '../shared/maven-cache';
@@ -50,7 +49,10 @@ import { MavenBomProcessor } from '../shared/maven-bom-processor';
 import { MAVEN_CONSTANTS } from '../constants/maven';
 import { isNativeArtifact } from '../shared/maven-utils';
 import type { ResolutionSession } from '../shared/internal/resolution-session';
-import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
+import {
+  attachResolutionSession,
+  getAttachedResolutionSession,
+} from '../shared/internal/resolution-session-registry';
 
 /** Maven Resolver 옵션 */
 export interface MavenResolverOptions extends ResolverOptions {
@@ -398,31 +400,52 @@ export class MavenResolver implements IResolver {
    * POM 캐시와 함께 조회 (공유 캐시 모듈 사용)
    */
   private async fetchPomWithCache(coordinate: MavenCoordinate): Promise<PomProject> {
-    return fetchPomFromCache(coordinate, {
-      repoUrl: this.repoUrl,
-      memoryTtl: this.defaultOptions.pomCacheTtl,
-      ...this.cacheOptions,
-    });
+    const effectiveRepoUrl = this.getEffectiveRepoUrl();
+    return this.sessionGet(
+      'pom',
+      {
+        repoUrl: effectiveRepoUrl,
+        groupId: coordinate.groupId,
+        artifactId: coordinate.artifactId,
+        version: coordinate.version,
+      },
+      () => fetchPomFromCache(coordinate, this.getPomCacheOptions()),
+    );
   }
 
   /**
    * 여러 POM 병렬 프리페치
    */
   private prefetchPomsParallelInternal(coordinates: MavenCoordinate[]): void {
-    prefetchPomsParallel(coordinates, {
-      repoUrl: this.repoUrl,
-      memoryTtl: this.defaultOptions.pomCacheTtl,
-      batchSize: this.defaultOptions.parallelThreads,
-      ...this.cacheOptions,
-    });
+    const limit = pLimit(this.defaultOptions.parallelThreads ?? 5);
+
+    for (const coordinate of coordinates) {
+      void limit(() => this.fetchPomWithCache(coordinate)).catch((error) => {
+        logger.debug('Maven POM 프리페치 실패', { coordinate: coordinateToString(coordinate), error });
+      });
+    }
   }
 
   /**
    * 최신 버전 조회
    */
   async getLatestVersion(groupId: string, artifactId: string): Promise<string> {
+    const effectiveRepoUrl = this.getEffectiveRepoUrl();
+    return this.sessionGet(
+      'latest-version',
+      { repoUrl: effectiveRepoUrl, groupId, artifactId },
+      () => this.getLatestVersionUncached(groupId, artifactId, effectiveRepoUrl),
+      Boolean,
+    );
+  }
+
+  private async getLatestVersionUncached(
+    groupId: string,
+    artifactId: string,
+    effectiveRepoUrl: string,
+  ): Promise<string> {
     const groupPath = groupId.replace(/\./g, '/');
-    const url = `${this.repoUrl}/${groupPath}/${artifactId}/maven-metadata.xml`;
+    const url = `${effectiveRepoUrl}/${groupPath}/${artifactId}/maven-metadata.xml`;
 
     try {
       const response = await this.axiosInstance.get<string>(url);
@@ -433,6 +456,38 @@ export class MavenResolver implements IResolver {
     } catch {
       throw new Error(`버전 조회 실패: ${groupId}:${artifactId}`);
     }
+  }
+
+  private getEffectiveRepoUrl(): string {
+    return this.cacheOptions.repoUrl ?? this.repoUrl;
+  }
+
+  private getPomCacheOptions(): MavenCacheOptions {
+    return {
+      ...this.cacheOptions,
+      memoryTtl: this.cacheOptions.memoryTtl ?? this.defaultOptions.pomCacheTtl,
+      repoUrl: this.getEffectiveRepoUrl(),
+    };
+  }
+
+  private sessionGet<T>(
+    operation: 'pom' | 'latest-version',
+    context: Record<string, string>,
+    producer: () => Promise<T>,
+    isCacheable?: (value: T) => boolean,
+  ): Promise<T> {
+    const session = getAttachedResolutionSession(this);
+    if (!session) {
+      return producer();
+    }
+
+    return session.getOrCreate(
+      'maven',
+      operation,
+      context,
+      producer,
+      isCacheable ? { isCacheable } : undefined,
+    );
   }
 
   /**

--- a/src/core/resolver/maven-resolver.ts
+++ b/src/core/resolver/maven-resolver.ts
@@ -49,6 +49,8 @@ import {
 import { MavenBomProcessor } from '../shared/maven-bom-processor';
 import { MAVEN_CONSTANTS } from '../constants/maven';
 import { isNativeArtifact } from '../shared/maven-utils';
+import type { ResolutionSession } from '../shared/internal/resolution-session';
+import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
 
 /** Maven Resolver 옵션 */
 export interface MavenResolverOptions extends ResolverOptions {
@@ -598,7 +600,14 @@ export class MavenResolver implements IResolver {
    * 캐시 옵션 설정
    */
   setCacheOptions(options: MavenCacheOptions): void {
-    this.cacheOptions = options;
+    this.cacheOptions = { ...options };
+  }
+
+  /**
+   * 캐시 옵션 조회
+   */
+  getCacheOptions(): MavenCacheOptions {
+    return { ...this.cacheOptions };
   }
 
   /**
@@ -617,4 +626,14 @@ export function getMavenResolver(): MavenResolver {
     mavenResolverInstance = new MavenResolver();
   }
   return mavenResolverInstance;
+}
+
+/** @internal */
+export function createRequestMavenResolver(
+  session: ResolutionSession,
+): MavenResolver {
+  const resolver = new MavenResolver();
+  resolver.setCacheOptions(getMavenResolver().getCacheOptions());
+  attachResolutionSession(resolver, session);
+  return resolver;
 }

--- a/src/core/resolver/npm-resolver.test.ts
+++ b/src/core/resolver/npm-resolver.test.ts
@@ -5,10 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { NpmResolver } from './npm-resolver';
+import { createRequestNpmResolver, NpmResolver } from './npm-resolver';
 import { NpmVersionResolver } from './npm-version-resolver';
 import { NpmTreeManager } from './npm-tree-manager';
 import { NpmPackument, NpmNode, DependencyType, DepsQueueItem, NpmPackageVersion, NpmFlatPackage, NpmResolvedNode, NpmDist } from '../shared/npm-types';
+import { ResolutionSession } from '../shared/internal/resolution-session';
+import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
 
 /**
  * 테스트용 NpmResolver 인터페이스
@@ -104,6 +106,21 @@ describe('NpmResolver 단위 테스트', () => {
 
   beforeEach(() => {
     resolver = createResolver();
+  });
+
+  it('요청 factory는 npm resolver와 private version resolver 모두에 session을 연결한다', () => {
+    const session = new ResolutionSession();
+    const requestResolver = createRequestNpmResolver(session);
+    const legacyResolver = new NpmResolver();
+
+    expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+    expect(
+      getAttachedResolutionSession(asTestable(requestResolver).versionResolver),
+    ).toBe(session);
+    expect(getAttachedResolutionSession(legacyResolver)).toBeUndefined();
+    expect(
+      getAttachedResolutionSession(asTestable(legacyResolver).versionResolver),
+    ).toBeUndefined();
   });
 
   describe('resolveVersion', () => {

--- a/src/core/resolver/npm-resolver.test.ts
+++ b/src/core/resolver/npm-resolver.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createRequestNpmResolver, NpmResolver } from './npm-resolver';
+import {
+  createRequestNpmResolver,
+  getNpmResolver,
+  NpmResolver,
+} from './npm-resolver';
 import { NpmVersionResolver } from './npm-version-resolver';
 import { NpmTreeManager } from './npm-tree-manager';
 import { NpmPackument, NpmNode, DependencyType, DepsQueueItem, NpmPackageVersion, NpmFlatPackage, NpmResolvedNode, NpmDist } from '../shared/npm-types';
@@ -108,10 +112,10 @@ describe('NpmResolver 단위 테스트', () => {
     resolver = createResolver();
   });
 
-  it('요청 factory는 npm resolver와 private version resolver 모두에 session을 연결한다', () => {
+  it('요청 factory는 legacy singleton을 건드리지 않고 npm resolver와 private version resolver에 session을 연결한다', () => {
     const session = new ResolutionSession();
+    const legacyResolver = getNpmResolver();
     const requestResolver = createRequestNpmResolver(session);
-    const legacyResolver = new NpmResolver();
 
     expect(getAttachedResolutionSession(requestResolver)).toBe(session);
     expect(

--- a/src/core/resolver/npm-resolver.test.ts
+++ b/src/core/resolver/npm-resolver.test.ts
@@ -12,9 +12,14 @@ import {
 } from './npm-resolver';
 import { NpmVersionResolver } from './npm-version-resolver';
 import { NpmTreeManager } from './npm-tree-manager';
+import { fetchPackument } from '../shared/npm-cache';
 import { NpmPackument, NpmNode, DependencyType, DepsQueueItem, NpmPackageVersion, NpmFlatPackage, NpmResolvedNode, NpmDist } from '../shared/npm-types';
 import { ResolutionSession } from '../shared/internal/resolution-session';
 import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
+
+vi.mock('../shared/npm-cache', () => ({
+  fetchPackument: vi.fn(),
+}));
 
 /**
  * 테스트용 NpmResolver 인터페이스
@@ -105,6 +110,8 @@ const createResolver = () => {
   return new NpmResolver();
 };
 
+const fetchPackumentMock = vi.mocked(fetchPackument);
+
 describe('NpmResolver 단위 테스트', () => {
   let resolver: NpmResolver;
 
@@ -125,6 +132,59 @@ describe('NpmResolver 단위 테스트', () => {
     expect(
       getAttachedResolutionSession(asTestable(legacyResolver).versionResolver),
     ).toBeUndefined();
+  });
+
+  it('공통 transitive dependency를 처리할 때 request resolver 두 개가 remote packument와 candidate 선택을 재사용한다', async () => {
+    const shared = createPackument('shared', {
+      '1.2.0': {
+        name: 'shared',
+        dist: { tarball: 'https://registry.example/shared-1.2.0.tgz', shasum: 'shared' },
+      },
+    });
+    const rootA = createPackument('root-a', {
+      '1.0.0': {
+        name: 'root-a',
+        dependencies: { shared: '^1.0.0' },
+        dist: { tarball: 'https://registry.example/root-a-1.0.0.tgz', shasum: 'root-a' },
+      },
+    });
+    const rootB = createPackument('root-b', {
+      '1.0.0': {
+        name: 'root-b',
+        dependencies: { shared: '^1.0.0' },
+        dist: { tarball: 'https://registry.example/root-b-1.0.0.tgz', shasum: 'root-b' },
+      },
+    });
+    const packuments = new Map([
+      ['root-a', rootA],
+      ['root-b', rootB],
+      ['shared', shared],
+    ]);
+    fetchPackumentMock.mockImplementation(async (name) => {
+      const packument = packuments.get(name.toLowerCase());
+      if (!packument) {
+        throw new Error(`Unknown package: ${name}`);
+      }
+      return structuredClone(packument);
+    });
+    const resolveVersion = vi.spyOn(NpmVersionResolver.prototype, 'resolveVersion');
+    const session = new ResolutionSession();
+    const first = createRequestNpmResolver(session);
+    const second = createRequestNpmResolver(session);
+
+    const firstResult = await first.resolveDependencies('root-a', '1.0.0');
+    const secondResult = await second.resolveDependencies('root-b', '1.0.0');
+
+    expect(firstResult.flatList).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'shared', version: '1.2.0' })]),
+    );
+    expect(secondResult.flatList).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'shared', version: '1.2.0' })]),
+    );
+    expect(fetchPackumentMock.mock.calls.filter(([name]) => name.toLowerCase() === 'shared')).toHaveLength(1);
+    expect(
+      resolveVersion.mock.calls.filter(([, packument]) => packument.name === 'shared'),
+    ).toHaveLength(1);
   });
 
   describe('resolveVersion', () => {

--- a/src/core/resolver/npm-resolver.ts
+++ b/src/core/resolver/npm-resolver.ts
@@ -138,7 +138,7 @@ export class NpmResolver {
     try {
       // 1. 루트 패키지 정보 조회
       const packument = await this.versionResolver.fetchPackument(packageName);
-      const resolvedVersion = this.versionResolver.resolveVersion(version, packument);
+      const resolvedVersion = await this.versionResolver.resolveVersionForRequest(version, packument);
 
       if (!resolvedVersion) {
         throw new Error(`버전을 찾을 수 없습니다: ${packageName}@${version}`);
@@ -250,7 +250,7 @@ export class NpmResolver {
 
     // 패키지 정보 조회
     const packument = await this.versionResolver.fetchPackument(name);
-    const resolvedVersion = this.versionResolver.resolveVersion(spec, packument);
+    const resolvedVersion = await this.versionResolver.resolveVersionForRequest(spec, packument);
 
     if (!resolvedVersion) {
       throw new Error(`호환 버전을 찾을 수 없습니다: ${name}@${spec}`);

--- a/src/core/resolver/npm-resolver.ts
+++ b/src/core/resolver/npm-resolver.ts
@@ -25,6 +25,8 @@ import { NpmTreeManager, TreeManagerOptions } from './npm-tree-manager';
 import { NpmVersionResolver } from './npm-version-resolver';
 import { NPM_CONSTANTS } from '../constants/npm';
 import logger from '../../utils/logger';
+import type { ResolutionSession } from '../shared/internal/resolution-session';
+import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
 
 /**
  * 플랫폼 매핑 (설정값 → npm 값)
@@ -96,6 +98,12 @@ export class NpmResolver {
   constructor(registryUrl = 'https://registry.npmjs.org') {
     this.versionResolver = new NpmVersionResolver(registryUrl);
     this.treeManager = new NpmTreeManager();
+  }
+
+  /** @internal */
+  attachRequestSession(session: ResolutionSession): void {
+    attachResolutionSession(this, session);
+    attachResolutionSession(this.versionResolver, session);
   }
 
   /**
@@ -529,6 +537,15 @@ export function getNpmResolver(): NpmResolver {
     npmResolverInstance = new NpmResolver();
   }
   return npmResolverInstance;
+}
+
+/** @internal */
+export function createRequestNpmResolver(
+  session: ResolutionSession,
+): NpmResolver {
+  const resolver = new NpmResolver();
+  resolver.attachRequestSession(session);
+  return resolver;
 }
 
 export { npmResolverInstance };

--- a/src/core/resolver/pip-resolver-download.test.ts
+++ b/src/core/resolver/pip-resolver-download.test.ts
@@ -24,9 +24,13 @@ vi.mock('./pip-simple-api', async (importOriginal) => {
   };
 });
 
-import { PipResolver } from './pip-resolver';
+import {
+  createRequestPipResolver,
+  PipResolver,
+} from './pip-resolver';
 import logger from '../../utils/logger';
 import { PipDownloader } from '../downloaders/pip';
+import { ResolutionSession } from '../shared/internal/resolution-session';
 
 async function expectSelectedArtifactIsDownloaded(
   packageInfo: Awaited<
@@ -2913,5 +2917,180 @@ describe('PipResolver에서 PipDownloader까지 선택 아티팩트 전달', () 
       filename: 'demo-1.0.0-cp312-cp312-manylinux_2_17_x86_64.whl',
       downloadUrl: 'https://files.example/demo-x86_64.whl',
     });
+  });
+});
+
+describe('PipResolver 요청 세션 조회 재사용', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const release = (name: string, version: string) => ({
+    filename: `${name}-${version}-py3-none-any.whl`,
+    url: `https://files.example/${name}-${version}.whl`,
+    packagetype: 'bdist_wheel',
+    python_version: 'py3',
+    digests: { sha256: `${name}-${version}-sha` },
+    size: 80,
+  });
+
+  it('요청 세션에서 PEP 503 별칭의 공통 전이 의존성 후보와 metadata를 한 번만 조회한다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockImplementation(
+      async (name: string, version?: string) => {
+        if (name === 'alpha' || name === 'beta') {
+          return {
+            data: {
+              info: {
+                name,
+                version,
+                requires_dist: [
+                  name === 'alpha' ? 'Shared_Pkg>=1.0.0' : 'shared.pkg>=1.0.0',
+                ],
+              },
+              urls: [release(name, version ?? '1.0.0')],
+            },
+          };
+        }
+
+        if (['shared_pkg', 'shared.pkg'].includes(name) && version === undefined) {
+          return {
+            data: {
+              info: { name: 'shared-pkg', version: '1.0.0' },
+              releases: { '1.0.0': [release('shared-pkg', '1.0.0')] },
+            },
+          };
+        }
+
+        if (['shared_pkg', 'shared.pkg'].includes(name) && version === '1.0.0') {
+          return {
+            data: {
+              info: {
+                name: 'shared-pkg',
+                version: '1.0.0',
+                requires_dist: [],
+              },
+              urls: [release('shared-pkg', '1.0.0')],
+            },
+          };
+        }
+
+        throw new Error(`unexpected package lookup: ${name}@${version}`);
+      },
+    );
+    const session = new ResolutionSession();
+
+    await createRequestPipResolver(session).resolveDependencies('alpha', '1.0.0');
+    await createRequestPipResolver(session).resolveDependencies('beta', '1.0.0');
+
+    const sharedLookups = pipCacheMock.fetchPackageMetadata.mock.calls.filter(
+      ([name]) => ['shared_pkg', 'shared.pkg'].includes(name),
+    );
+    expect(sharedLookups.filter(([, version]) => version === undefined)).toHaveLength(1);
+    expect(sharedLookups.filter(([, version]) => version === '1.0.0')).toHaveLength(1);
+  });
+
+  it('요청 세션에서 같은 artifact metadata의 동시 조회를 합친다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockResolvedValue({
+      data: {
+        info: { name: 'shared', version: '1.0.0', requires_dist: [] },
+        urls: [release('shared', '1.0.0')],
+      },
+    });
+    const session = new ResolutionSession();
+    const first = createRequestPipResolver(session);
+    const second = createRequestPipResolver(session);
+
+    await Promise.all([
+      (first as any).fetchPackageInfo('shared', '1.0.0'),
+      (second as any).fetchPackageInfo('shared', '1.0.0'),
+    ]);
+
+    expect(pipCacheMock.fetchPackageMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('대상 Python 버전이 다르면 요청 세션에서 artifact metadata를 재사용하지 않는다', async () => {
+    pipCacheMock.fetchPackageMetadata.mockResolvedValue({
+      data: {
+        info: { name: 'shared', version: '1.0.0', requires_dist: [] },
+        urls: [release('shared', '1.0.0')],
+      },
+    });
+    const session = new ResolutionSession();
+
+    await createRequestPipResolver(session).resolveDependencies('shared', '1.0.0', {
+      targetPlatform: { system: 'Linux', machine: 'x86_64' },
+      pythonVersion: '3.12',
+    });
+    await createRequestPipResolver(session).resolveDependencies('shared', '1.0.0', {
+      targetPlatform: { system: 'Linux', machine: 'aarch64' },
+      pythonVersion: '3.13',
+    });
+
+    expect(pipCacheMock.fetchPackageMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it('index URL과 source artifact 검증 모드가 다르면 조회를 재사용하지 않는다', async () => {
+    simpleApiMock.fetchPackageFiles.mockResolvedValue([
+      {
+        filename: 'shared-1.0.0-py3-none-any.whl',
+        url: 'https://index.example/shared-1.0.0.whl',
+      },
+    ]);
+    simpleApiMock.fetchWheelMetadata.mockResolvedValue({
+      status: 'available',
+      requiresDist: [],
+    });
+    const session = new ResolutionSession();
+    const first = createRequestPipResolver(session);
+    const second = createRequestPipResolver(session);
+    const third = createRequestPipResolver(session);
+
+    await (first as any).fetchPackageInfo(
+      'shared',
+      '1.0.0',
+      'https://first.example/simple',
+      false,
+    );
+    await (second as any).fetchPackageInfo(
+      'shared',
+      '1.0.0',
+      'https://second.example/simple',
+      false,
+    );
+    await (third as any).fetchPackageInfo(
+      'shared',
+      '1.0.0',
+      'https://second.example/simple',
+      true,
+    );
+
+    expect(simpleApiMock.fetchPackageFiles).toHaveBeenCalledTimes(3);
+  });
+
+  it('실패한 후보 조회는 세션에 남기지 않아 다음 resolver가 재시도한다', async () => {
+    pipCacheMock.fetchPackageMetadata
+      .mockRejectedValueOnce(new Error('temporary registry failure'))
+      .mockResolvedValueOnce({
+        data: {
+          info: { name: 'retry-pkg', version: '1.0.0' },
+          releases: { '1.0.0': [release('retry-pkg', '1.0.0')] },
+        },
+      });
+    const session = new ResolutionSession();
+
+    await expect(
+      (createRequestPipResolver(session) as any).getLatestVersion(
+        'retry-pkg',
+        undefined,
+      ),
+    ).rejects.toThrow('temporary registry failure');
+
+    await expect(
+      (createRequestPipResolver(session) as any).getLatestVersion(
+        'retry_pkg',
+        undefined,
+      ),
+    ).resolves.toBe('1.0.0');
+    expect(pipCacheMock.fetchPackageMetadata).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/core/resolver/pip-resolver.test.ts
+++ b/src/core/resolver/pip-resolver.test.ts
@@ -5,7 +5,13 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { PipResolver } from './pip-resolver';
+import {
+  createRequestPipResolver,
+  getPipResolver,
+  PipResolver,
+} from './pip-resolver';
+import { ResolutionSession } from '../shared/internal/resolution-session';
+import { getAttachedResolutionSession } from '../shared/internal/resolution-session-registry';
 
 // PipResolver 인스턴스 생성 및 targetPlatform 설정
 const createResolver = (options?: {
@@ -541,6 +547,28 @@ describe('PipResolver 단위 테스트', () => {
 
     it('setCacheOptions 호출 시 에러 없음', () => {
       expect(() => resolver.setCacheOptions({ maxSize: 100 })).not.toThrow();
+    });
+
+    it('요청 resolver는 singleton cache options의 독립 snapshot과 session을 사용한다', () => {
+      const singleton = getPipResolver();
+      singleton.setCacheOptions({ memoryTtl: 120, useDiskCache: true });
+      const session = new ResolutionSession();
+
+      const requestResolver = createRequestPipResolver(session);
+
+      expect(requestResolver).not.toBe(singleton);
+      expect(requestResolver.getCacheOptions()).toEqual({
+        memoryTtl: 120,
+        useDiskCache: true,
+      });
+      expect(requestResolver.getCacheOptions()).not.toBe(singleton.getCacheOptions());
+      expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+
+      requestResolver.setCacheOptions({ memoryTtl: 60 });
+      expect(singleton.getCacheOptions()).toEqual({
+        memoryTtl: 120,
+        useDiskCache: true,
+      });
     });
   });
 

--- a/src/core/resolver/pip-resolver.test.ts
+++ b/src/core/resolver/pip-resolver.test.ts
@@ -563,6 +563,7 @@ describe('PipResolver 단위 테스트', () => {
       });
       expect(requestResolver.getCacheOptions()).not.toBe(singleton.getCacheOptions());
       expect(getAttachedResolutionSession(requestResolver)).toBe(session);
+      expect(getAttachedResolutionSession(singleton)).toBeUndefined();
 
       requestResolver.setCacheOptions({ memoryTtl: 60 });
       expect(singleton.getCacheOptions()).toEqual({

--- a/src/core/resolver/pip-resolver.ts
+++ b/src/core/resolver/pip-resolver.ts
@@ -36,7 +36,10 @@ import {
   normalizeExtraName,
 } from '../shared/pep508-marker';
 import type { ResolutionSession } from '../shared/internal/resolution-session';
-import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
+import {
+  attachResolutionSession,
+  getAttachedResolutionSession,
+} from '../shared/internal/resolution-session-registry';
 
 // 의존성 파싱 결과
 interface ParsedDependency {
@@ -145,6 +148,10 @@ function isPipVersionCompatible(
         comparePep440Versions(version, lessThanMatch[1]) < 0,
     );
   });
+}
+
+function normalizePep503PackageName(name: string): string {
+  return name.trim().toLowerCase().replace(/[-_.]+/g, '-');
 }
 
 function getSimpleApiChecksum(
@@ -541,6 +548,27 @@ export class PipResolver implements IResolver {
     indexUrl?: string,
     allowUnverifiedSourceArtifact = false,
   ): Promise<FetchedPackageInfo | null> {
+    return this.sessionGet(
+      'package-info',
+      name,
+      version,
+      indexUrl,
+      allowUnverifiedSourceArtifact,
+      () => this.fetchPackageInfoUncached(
+        name,
+        version,
+        indexUrl,
+        allowUnverifiedSourceArtifact,
+      ),
+    );
+  }
+
+  private async fetchPackageInfoUncached(
+    name: string,
+    version: string,
+    indexUrl?: string,
+    allowUnverifiedSourceArtifact = false,
+  ): Promise<FetchedPackageInfo | null> {
     logger.debug('📦 패키지 정보 조회', {
       name,
       version,
@@ -868,6 +896,22 @@ export class PipResolver implements IResolver {
   private async getLatestVersion(
     name: string,
     versionSpec?: string,
+    indexUrl?: string,
+  ): Promise<string | null> {
+    return this.sessionGet(
+      'latest-version',
+      name,
+      versionSpec,
+      indexUrl,
+      false,
+      () => this.getLatestVersionUncached(name, versionSpec, indexUrl),
+      (version) => Boolean(version),
+    );
+  }
+
+  private async getLatestVersionUncached(
+    name: string,
+    versionSpec?: string,
     indexUrl?: string
   ): Promise<string | null> {
     try {
@@ -1021,6 +1065,62 @@ export class PipResolver implements IResolver {
       });
       throw error;
     }
+  }
+
+  private sessionGet<T>(
+    operation: 'latest-version' | 'package-info',
+    name: string,
+    versionSpec: string | undefined,
+    indexUrl: string | undefined,
+    allowUnverifiedSourceArtifact: boolean,
+    producer: () => Promise<T>,
+    isCacheable?: (value: T) => boolean,
+  ): Promise<T> {
+    const session = getAttachedResolutionSession(this);
+    if (!session) {
+      return producer();
+    }
+
+    return session.getOrCreate(
+      'pip',
+      operation,
+      this.getSessionContext(
+        name,
+        versionSpec,
+        indexUrl,
+        allowUnverifiedSourceArtifact,
+      ),
+      producer,
+      isCacheable ? { isCacheable } : undefined,
+    );
+  }
+
+  private getSessionContext(
+    name: string,
+    versionSpec: string | undefined,
+    indexUrl: string | undefined,
+    allowUnverifiedSourceArtifact: boolean,
+  ) {
+    const target = this.pipTargetPlatform;
+
+    return {
+      name: normalizePep503PackageName(name),
+      versionSpec: versionSpec ?? null,
+      indexUrl: indexUrl ?? null,
+      target: target
+        ? {
+            os: target.os,
+            arch: target.arch,
+            pythonVersion: target.pythonVersion ?? null,
+            linuxDistro: target.linuxDistro ?? null,
+            glibcVersion: target.glibcVersion ?? null,
+            macosVersion: target.macosVersion ?? null,
+          }
+        : null,
+      pythonVersion: this.pythonVersion ?? null,
+      baseUrl: this.cacheOptions.baseUrl ?? this.baseUrl,
+      allowUnverifiedSourceArtifact,
+    };
   }
 
   /**

--- a/src/core/resolver/pip-resolver.ts
+++ b/src/core/resolver/pip-resolver.ts
@@ -35,6 +35,8 @@ import {
   evaluatePep508Marker,
   normalizeExtraName,
 } from '../shared/pep508-marker';
+import type { ResolutionSession } from '../shared/internal/resolution-session';
+import { attachResolutionSession } from '../shared/internal/resolution-session-registry';
 
 // 의존성 파싱 결과
 interface ParsedDependency {
@@ -211,7 +213,14 @@ export class PipResolver implements IResolver {
    * 캐시 옵션 설정
    */
   setCacheOptions(options: PipCacheOptions): void {
-    this.cacheOptions = options;
+    this.cacheOptions = { ...options };
+  }
+
+  /**
+   * 캐시 옵션 조회
+   */
+  getCacheOptions(): PipCacheOptions {
+    return { ...this.cacheOptions };
   }
 
   /**
@@ -1505,4 +1514,14 @@ export function getPipResolver(): PipResolver {
     pipResolverInstance = new PipResolver();
   }
   return pipResolverInstance;
+}
+
+/** @internal */
+export function createRequestPipResolver(
+  session: ResolutionSession,
+): PipResolver {
+  const resolver = new PipResolver();
+  resolver.setCacheOptions(getPipResolver().getCacheOptions());
+  attachResolutionSession(resolver, session);
+  return resolver;
 }

--- a/src/core/shared/dependency-resolver.test.ts
+++ b/src/core/shared/dependency-resolver.test.ts
@@ -349,6 +349,177 @@ describe('dependency-resolver', () => {
       });
     });
 
+    it('한 요청의 모든 라이브러리 root는 같은 session을 공유하고 요청 간에는 분리한다', async () => {
+      const sessions: ResolutionSession[] = [];
+      const resolutionResult = (type: 'pip' | 'conda' | 'maven', name: string) => ({
+        root: { package: { type, name, version: '1.0.0' }, dependencies: [] },
+        flatList: [{ type, name, version: '1.0.0' }],
+        conflicts: [],
+        totalSize: 0,
+      });
+
+      vi.mocked(createRequestPipResolver).mockImplementation((session) => {
+        sessions.push(session);
+        return {
+          resolveDependencies: vi.fn((name: string) =>
+            Promise.resolve(resolutionResult('pip', name)),
+          ),
+        } as any;
+      });
+      vi.mocked(createRequestCondaResolver).mockImplementation((session) => {
+        sessions.push(session);
+        return {
+          resolveDependencies: vi.fn((name: string) =>
+            Promise.resolve(resolutionResult('conda', name)),
+          ),
+        } as any;
+      });
+      vi.mocked(createRequestMavenResolver).mockImplementation((session) => {
+        sessions.push(session);
+        return {
+          resolveDependencies: vi.fn((name: string) =>
+            Promise.resolve(resolutionResult('maven', name)),
+          ),
+        } as any;
+      });
+      vi.mocked(createRequestNpmResolver).mockImplementation((session) => {
+        sessions.push(session);
+        return {
+          resolveDependencies: vi.fn((name: string) =>
+            Promise.resolve({
+              root: { name, version: '1.0.0' },
+              flatList: [
+                {
+                  name,
+                  version: '1.0.0',
+                  hoistedPath: `node_modules/${name}`,
+                  size: 0,
+                },
+              ],
+              conflicts: [],
+              totalSize: 0,
+            }),
+          ),
+        } as any;
+      });
+
+      await resolveAllDependencies([
+        { id: 'pip', type: 'pip', name: 'pip-root', version: '1.0.0' },
+        { id: 'conda', type: 'conda', name: 'conda-root', version: '1.0.0' },
+        { id: 'maven', type: 'maven', name: 'maven-root', version: '1.0.0' },
+        { id: 'npm', type: 'npm', name: 'npm-root', version: '1.0.0' },
+      ]);
+      await resolveAllDependencies([
+        { id: 'next-pip', type: 'pip', name: 'next-root', version: '1.0.0' },
+      ]);
+
+      expect(sessions).toHaveLength(8);
+      expect(sessions[0]).toBeInstanceOf(ResolutionSession);
+      expect(new Set(sessions.slice(0, 4))).toEqual(new Set([sessions[0]]));
+      expect(new Set(sessions.slice(4, 8))).toEqual(new Set([sessions[4]]));
+      expect(sessions[4]).not.toBe(sessions[0]);
+    });
+
+    it('공통 의존성 snapshot은 root별 트리를 보존하면서 한 번만 다운로드 목록에 포함하고 재사용 통계를 남긴다', async () => {
+      let session: ResolutionSession | undefined;
+      const sharedMetadataLookup = vi.fn().mockResolvedValue({ version: '2.0.0' });
+      const requestResolver = {
+        resolveDependencies: vi.fn(async (name: string) => {
+          await session?.getOrCreate(
+            'pip',
+            'package-info',
+            { name: 'shared', version: '2.0.0' },
+            () => sharedMetadataLookup(),
+          );
+          const root = { type: 'pip' as const, name, version: '1.0.0' };
+          const shared = { type: 'pip' as const, name: 'shared', version: '2.0.0' };
+          return {
+            root: { package: root, dependencies: [{ package: shared, dependencies: [] }] },
+            flatList: [root, shared],
+            conflicts: [],
+            totalSize: 0,
+          };
+        }),
+      };
+      vi.mocked(createRequestPipResolver).mockImplementation((requestSession) => {
+        session = requestSession;
+        return requestResolver as any;
+      });
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      const result = await resolveAllDependencies([
+        { id: 'alpha', type: 'pip', name: 'alpha', version: '1.0.0' },
+        { id: 'beta', type: 'pip', name: 'beta', version: '1.0.0' },
+      ]);
+
+      expect(sharedMetadataLookup).toHaveBeenCalledTimes(1);
+      expect(result.dependencyTrees.map((tree) => tree.root.package.name)).toEqual([
+        'alpha',
+        'beta',
+      ]);
+      expect(result.allPackages.filter((pkg) => pkg.name === 'shared')).toHaveLength(1);
+      expect(result.successfulPackages?.filter((pkg) => pkg.name === 'shared')).toHaveLength(1);
+      expect(infoSpy).toHaveBeenCalledWith('의존성 요청 세션 통계', {
+        hits: 1,
+        misses: 1,
+        joins: 0,
+      });
+    });
+
+    it('첫 root의 일시적 공통 의존성 조회 실패 뒤 다음 root가 같은 session에서 재시도해 성공한다', async () => {
+      let session: ResolutionSession | undefined;
+      const sharedMetadataLookup = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('temporary metadata failure'))
+        .mockResolvedValueOnce({ version: '2.0.0' });
+      const requestResolver = {
+        resolveDependencies: vi.fn(async (name: string) => {
+          await session?.getOrCreate(
+            'pip',
+            'package-info',
+            { name: 'shared', version: '2.0.0' },
+            () => sharedMetadataLookup(),
+          );
+          const root = { type: 'pip' as const, name, version: '1.0.0' };
+          const shared = { type: 'pip' as const, name: 'shared', version: '2.0.0' };
+          return {
+            root: { package: root, dependencies: [{ package: shared, dependencies: [] }] },
+            flatList: [root, shared],
+            conflicts: [],
+            totalSize: 0,
+          };
+        }),
+      };
+      vi.mocked(createRequestPipResolver).mockImplementation((requestSession) => {
+        session = requestSession;
+        return requestResolver as any;
+      });
+
+      const result = await resolveAllDependencies([
+        { id: 'alpha', type: 'pip', name: 'alpha', version: '1.0.0' },
+        { id: 'beta', type: 'pip', name: 'beta', version: '1.0.0' },
+      ]);
+
+      expect(sharedMetadataLookup).toHaveBeenCalledTimes(2);
+      expect(result.failedPackages).toEqual([
+        {
+          name: 'alpha',
+          version: '1.0.0',
+          error: 'temporary metadata failure',
+        },
+      ]);
+      expect(result.dependencyTrees.map((tree) => tree.root.package.name)).toEqual(['beta']);
+      expect(result.successfulPackages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'beta', version: '1.0.0' }),
+          expect.objectContaining({ name: 'shared', version: '2.0.0' }),
+        ]),
+      );
+      expect(result.successfulPackages).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'alpha' })]),
+      );
+    });
+
     it('pip 패키지에 targetOS와 pythonVersion 옵션 전달', async () => {
       const mockPipResult = {
         root: {

--- a/src/core/shared/dependency-resolver.test.ts
+++ b/src/core/shared/dependency-resolver.test.ts
@@ -9,25 +9,39 @@ import {
   DependencyProgressCallback,
 } from './dependency-resolver';
 import { DownloadPackage } from './types';
+import { ResolutionSession } from './internal/resolution-session';
+import logger from '../../utils/logger';
 
 // Mock all resolvers
-vi.mock('../resolver/pip-resolver', () => ({
-  getPipResolver: vi.fn(() => ({
+vi.mock('../resolver/pip-resolver', () => {
+  const getPipResolver = vi.fn(() => ({
     resolveDependencies: vi.fn(),
-  })),
-}));
+  }));
+  return {
+    getPipResolver,
+    createRequestPipResolver: vi.fn(() => getPipResolver()),
+  };
+});
 
-vi.mock('../resolver/maven-resolver', () => ({
-  getMavenResolver: vi.fn(() => ({
+vi.mock('../resolver/maven-resolver', () => {
+  const getMavenResolver = vi.fn(() => ({
     resolveDependencies: vi.fn(),
-  })),
-}));
+  }));
+  return {
+    getMavenResolver,
+    createRequestMavenResolver: vi.fn(() => getMavenResolver()),
+  };
+});
 
-vi.mock('../resolver/conda-resolver', () => ({
-  getCondaResolver: vi.fn(() => ({
+vi.mock('../resolver/conda-resolver', () => {
+  const getCondaResolver = vi.fn(() => ({
     resolveDependencies: vi.fn(),
-  })),
-}));
+  }));
+  return {
+    getCondaResolver,
+    createRequestCondaResolver: vi.fn(() => getCondaResolver()),
+  };
+});
 
 vi.mock('../resolver/yum-resolver', () => ({
   getYumResolver: vi.fn(() => ({
@@ -35,22 +49,42 @@ vi.mock('../resolver/yum-resolver', () => ({
   })),
 }));
 
-vi.mock('../resolver/npm-resolver', () => ({
-  getNpmResolver: vi.fn(() => ({
+vi.mock('../resolver/npm-resolver', () => {
+  const getNpmResolver = vi.fn(() => ({
     resolveDependencies: vi.fn(),
-  })),
-}));
+  }));
+  return {
+    getNpmResolver,
+    createRequestNpmResolver: vi.fn(() => getNpmResolver()),
+  };
+});
 
 // Import mocked modules
-import { getPipResolver } from '../resolver/pip-resolver';
-import { getMavenResolver } from '../resolver/maven-resolver';
-import { getCondaResolver } from '../resolver/conda-resolver';
+import {
+  createRequestPipResolver,
+  getPipResolver,
+} from '../resolver/pip-resolver';
+import {
+  createRequestMavenResolver,
+  getMavenResolver,
+} from '../resolver/maven-resolver';
+import {
+  createRequestCondaResolver,
+  getCondaResolver,
+} from '../resolver/conda-resolver';
 import { getYumResolver } from '../resolver/yum-resolver';
-import { getNpmResolver } from '../resolver/npm-resolver';
+import {
+  createRequestNpmResolver,
+  getNpmResolver,
+} from '../resolver/npm-resolver';
 
 describe('dependency-resolver', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(createRequestPipResolver).mockImplementation(() => getPipResolver());
+    vi.mocked(createRequestMavenResolver).mockImplementation(() => getMavenResolver());
+    vi.mocked(createRequestCondaResolver).mockImplementation(() => getCondaResolver());
+    vi.mocked(createRequestNpmResolver).mockImplementation(() => getNpmResolver());
   });
 
   afterEach(() => {
@@ -161,6 +195,80 @@ describe('dependency-resolver', () => {
       expect(result.dependencyTrees).toHaveLength(1);
     });
 
+    it('한 요청의 여러 pip root는 하나의 request resolver를 공유한다', async () => {
+      const createResult = (name: string, version: string) => ({
+        root: { package: { type: 'pip' as const, name, version }, dependencies: [] },
+        flatList: [{ type: 'pip' as const, name, version }],
+        conflicts: [],
+        totalSize: 0,
+      });
+      const requestResolver = {
+        resolveDependencies: vi.fn(async (name: string, version: string) =>
+          createResult(name, version),
+        ),
+      };
+      vi.mocked(createRequestPipResolver).mockReturnValue(requestResolver as any);
+
+      await resolveAllDependencies([
+        { id: 'pip-1', type: 'pip', name: 'requests', version: '2.28.0' },
+        { id: 'pip-2', type: 'pip', name: 'flask', version: '2.2.0' },
+      ]);
+
+      expect(createRequestPipResolver).toHaveBeenCalledTimes(1);
+      expect(requestResolver.resolveDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it('동시 요청은 서로 다른 request resolver와 target environment options를 사용한다', async () => {
+      const createResult = (name: string, version: string) => ({
+        root: { package: { type: 'pip' as const, name, version }, dependencies: [] },
+        flatList: [{ type: 'pip' as const, name, version }],
+        conflicts: [],
+        totalSize: 0,
+      });
+      const firstResolver = {
+        resolveDependencies: vi.fn(async (name: string, version: string) =>
+          createResult(name, version),
+        ),
+      };
+      const secondResolver = {
+        resolveDependencies: vi.fn(async (name: string, version: string) =>
+          createResult(name, version),
+        ),
+      };
+      vi.mocked(createRequestPipResolver)
+        .mockReturnValueOnce(firstResolver as any)
+        .mockReturnValueOnce(secondResolver as any);
+
+      await Promise.all([
+        resolveAllDependencies(
+          [{ id: 'linux', type: 'pip', name: 'linux-root', version: '1.0.0' }],
+          { targetOS: 'linux', architecture: 'x86_64', pythonVersion: '3.11' },
+        ),
+        resolveAllDependencies(
+          [{ id: 'windows', type: 'pip', name: 'windows-root', version: '1.0.0' }],
+          { targetOS: 'windows', architecture: 'arm64', pythonVersion: '3.12' },
+        ),
+      ]);
+
+      expect(createRequestPipResolver).toHaveBeenCalledTimes(2);
+      expect(firstResolver.resolveDependencies).toHaveBeenCalledWith(
+        'linux-root',
+        '1.0.0',
+        expect.objectContaining({
+          pythonVersion: '3.11',
+          targetPlatform: { system: 'Linux', machine: 'x86_64' },
+        }),
+      );
+      expect(secondResolver.resolveDependencies).toHaveBeenCalledWith(
+        'windows-root',
+        '1.0.0',
+        expect.objectContaining({
+          pythonVersion: '3.12',
+          targetPlatform: { system: 'Windows', machine: 'arm64' },
+        }),
+      );
+    });
+
     it('latest root는 해석된 실제 버전으로 교체한다', async () => {
       const mockResolver = {
         resolveDependencies: vi.fn().mockResolvedValue({
@@ -208,6 +316,37 @@ describe('dependency-resolver', () => {
       expect(result.allPackages).toEqual(packages);
       expect(result.dependencyTrees).toEqual([]);
       expect(result.failedPackages).toEqual([]);
+      expect(createRequestPipResolver).not.toHaveBeenCalled();
+      expect(createRequestCondaResolver).not.toHaveBeenCalled();
+      expect(createRequestMavenResolver).not.toHaveBeenCalled();
+      expect(createRequestNpmResolver).not.toHaveBeenCalled();
+    });
+
+    it('zero-hit request session statistics는 로그로 남기지 않는다', async () => {
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      await resolveAllDependencies([]);
+
+      expect(
+        infoSpy.mock.calls.some(([message]) => message === '의존성 요청 세션 통계'),
+      ).toBe(false);
+    });
+
+    it('hit이 있는 request session statistics는 종료 시 로그로 남긴다', async () => {
+      vi.spyOn(ResolutionSession.prototype, 'getStats').mockReturnValue({
+        hits: 1,
+        misses: 2,
+        joins: 3,
+      });
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      await resolveAllDependencies([]);
+
+      expect(infoSpy).toHaveBeenCalledWith('의존성 요청 세션 통계', {
+        hits: 1,
+        misses: 2,
+        joins: 3,
+      });
     });
 
     it('pip 패키지에 targetOS와 pythonVersion 옵션 전달', async () => {

--- a/src/core/shared/dependency-resolver.ts
+++ b/src/core/shared/dependency-resolver.ts
@@ -1,8 +1,8 @@
 // 공통 의존성 해결 모듈
-import { getPipResolver } from '../resolver/pip-resolver';
-import { getMavenResolver } from '../resolver/maven-resolver';
-import { getCondaResolver } from '../resolver/conda-resolver';
-import { getNpmResolver } from '../resolver/npm-resolver';
+import { createRequestPipResolver } from '../resolver/pip-resolver';
+import { createRequestMavenResolver } from '../resolver/maven-resolver';
+import { createRequestCondaResolver } from '../resolver/conda-resolver';
+import { createRequestNpmResolver } from '../resolver/npm-resolver';
 import { getYumResolver } from '../resolver/yum-resolver';
 import { getAptResolver } from '../resolver/apt-resolver';
 import { getApkResolver } from '../resolver/apk-resolver';
@@ -17,6 +17,7 @@ import { NpmResolutionResult } from './npm-types';
 import type { OSPackageInfo, OSArchitecture } from '../downloaders/os-shared/types';
 import logger from '../../utils/logger';
 import { getPackageArtifactKey } from './dependency-tree-utils';
+import { ResolutionSession } from './internal/resolution-session';
 
 /**
  * 의존성 해결 진행 상황 콜백
@@ -204,16 +205,26 @@ export interface DependencyResolverOptions {
 /**
  * 패키지 타입별 리졸버 반환
  */
-function getResolverByType(type: string) {
+type RequestLibraryResolvers = {
+  pip: ReturnType<typeof createRequestPipResolver>;
+  conda: ReturnType<typeof createRequestCondaResolver>;
+  maven: ReturnType<typeof createRequestMavenResolver>;
+  npm: ReturnType<typeof createRequestNpmResolver>;
+};
+
+function getResolverByType(
+  type: string,
+  requestResolvers: RequestLibraryResolvers,
+) {
   switch (type) {
     case 'pip':
-      return getPipResolver();
+      return requestResolvers.pip;
     case 'conda':
-      return getCondaResolver();
+      return requestResolvers.conda;
     case 'maven':
-      return getMavenResolver();
+      return requestResolvers.maven;
     case 'npm':
-      return getNpmResolver();
+      return requestResolvers.npm;
     // OS 패키지 (yum, apt, apk)는 distribution 정보가 필요하므로
     // 별도 IPC 핸들러(os:resolveDependencies)에서 처리됨
     // 여기서는 null을 반환하여 패키지만 결과에 포함되고 의존성은 건너뜀
@@ -267,6 +278,14 @@ export async function resolveAllDependencies(
     };
   }
 
+  const resolutionSession = new ResolutionSession();
+  const requestResolvers: RequestLibraryResolvers = {
+    pip: createRequestPipResolver(resolutionSession),
+    conda: createRequestCondaResolver(resolutionSession),
+    maven: createRequestMavenResolver(resolutionSession),
+    npm: createRequestNpmResolver(resolutionSession),
+  };
+
   // targetOS를 targetPlatform으로 변환 (pip/conda 환경 마커 평가용)
   const targetPlatformMap: Record<string, { system?: 'Linux' | 'Windows' | 'Darwin' }> = {
     any: {},
@@ -287,7 +306,7 @@ export async function resolveAllDependencies(
     resolvedSet.set(key, pkg);
 
     // 타입별 리졸버 선택
-    const resolver = getResolverByType(pkg.type);
+    const resolver = getResolverByType(pkg.type, requestResolvers);
     if (!resolver) {
       // OS 패키지(yum, apt, apk) 처리 - osPackageInfo가 있으면 의존성 해결
       const osTypes = ['yum', 'apt', 'apk'];
@@ -753,6 +772,11 @@ export async function resolveAllDependencies(
       });
       // 실패해도 원본 패키지는 이미 추가되어 있으므로 계속 진행
     }
+  }
+
+  const sessionStats = resolutionSession.getStats();
+  if (sessionStats.hits > 0) {
+    logger.info('의존성 요청 세션 통계', { ...sessionStats });
   }
 
   return {

--- a/src/core/shared/internal/resolution-session-registry.test.ts
+++ b/src/core/shared/internal/resolution-session-registry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ResolutionSession } from './resolution-session';
+import {
+  attachResolutionSession,
+  getAttachedResolutionSession,
+} from './resolution-session-registry';
+
+describe('resolution-session-registry', () => {
+  it('owner별 ResolutionSession 연결을 격리한다', () => {
+    const firstOwner = {};
+    const secondOwner = {};
+    const firstSession = new ResolutionSession();
+    const secondSession = new ResolutionSession();
+
+    attachResolutionSession(firstOwner, firstSession);
+    attachResolutionSession(secondOwner, secondSession);
+
+    expect(getAttachedResolutionSession(firstOwner)).toBe(firstSession);
+    expect(getAttachedResolutionSession(secondOwner)).toBe(secondSession);
+  });
+
+  it('연결되지 않은 owner에는 undefined를 반환한다', () => {
+    expect(getAttachedResolutionSession({})).toBeUndefined();
+  });
+});

--- a/src/core/shared/internal/resolution-session-registry.ts
+++ b/src/core/shared/internal/resolution-session-registry.ts
@@ -1,0 +1,11 @@
+import { ResolutionSession } from './resolution-session';
+
+const attachedResolutionSessions = new WeakMap<object, ResolutionSession>();
+
+export function attachResolutionSession(owner: object, session: ResolutionSession): void {
+  attachedResolutionSessions.set(owner, session);
+}
+
+export function getAttachedResolutionSession(owner: object): ResolutionSession | undefined {
+  return attachedResolutionSessions.get(owner);
+}

--- a/src/core/shared/internal/resolution-session.test.ts
+++ b/src/core/shared/internal/resolution-session.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { ResolutionSession } from './resolution-session';
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+
+  return { promise, resolve };
+}
+
+describe('ResolutionSession', () => {
+  it('같은 resolver, operation, context의 in-flight producer를 한 번만 실행한다', async () => {
+    const session = new ResolutionSession();
+    const deferred = createDeferred();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      await deferred.promise;
+      return { package: { name: 'requests', version: '2.32.0' } };
+    };
+
+    const first = session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer);
+    const second = session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer);
+
+    deferred.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { package: { name: 'requests', version: '2.32.0' } },
+      { package: { name: 'requests', version: '2.32.0' } },
+    ]);
+    expect(producerCalls).toBe(1);
+  });
+
+  it('consumer마다 독립적으로 clone한 값을 반환한다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return { package: { metadata: { requiresPython: '>=3.9' } } };
+    };
+
+    const first = await session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer);
+    first.package.metadata.requiresPython = '>=3.12';
+    const second = await session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer);
+
+    expect(second).toEqual({ package: { metadata: { requiresPython: '>=3.9' } } });
+    expect(second).not.toBe(first);
+    expect(second.package).not.toBe(first.package);
+    expect(producerCalls).toBe(1);
+  });
+
+  it('resolver 또는 operation namespace가 다르면 같은 context를 재사용하지 않는다', async () => {
+    const session = new ResolutionSession();
+    const context = { name: 'requests' };
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return producerCalls;
+    };
+
+    const pipPackageInfo = await session.getOrCreate('pip', 'package-info', context, producer);
+    const npmPackageInfo = await session.getOrCreate('npm', 'package-info', context, producer);
+    const pipLatestVersion = await session.getOrCreate('pip', 'latest-version', context, producer);
+
+    expect([pipPackageInfo, npmPackageInfo, pipLatestVersion]).toEqual([1, 2, 3]);
+    expect(producerCalls).toBe(3);
+  });
+
+  it('object key 순서가 다른 context는 같은 cache key로 처리한다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return { version: '2.32.0' };
+    };
+
+    await session.getOrCreate(
+      'pip',
+      'latest-version',
+      { name: 'requests', target: { os: 'linux', arch: 'x64' } },
+      producer,
+    );
+    const result = await session.getOrCreate(
+      'pip',
+      'latest-version',
+      { target: { arch: 'x64', os: 'linux' }, name: 'requests' },
+      producer,
+    );
+
+    expect(result).toEqual({ version: '2.32.0' });
+    expect(producerCalls).toBe(1);
+  });
+
+  it('undefined context 값은 누락된 key와 구분한다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return producerCalls;
+    };
+
+    const withoutVersion = await session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer);
+    const withUndefinedVersion = await session.getOrCreate(
+      'pip',
+      'latest-version',
+      { name: 'requests', version: undefined },
+      producer,
+    );
+
+    expect([withoutVersion, withUndefinedVersion]).toEqual([1, 2]);
+  });
+
+  it('reject된 producer 결과를 저장하지 않는다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async (): Promise<string> => {
+      producerCalls += 1;
+      throw new Error('metadata request failed');
+    };
+
+    await expect(session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer)).rejects.toThrow(
+      'metadata request failed',
+    );
+    await expect(session.getOrCreate('pip', 'package-info', { name: 'requests' }, producer)).rejects.toThrow(
+      'metadata request failed',
+    );
+
+    expect(producerCalls).toBe(2);
+  });
+
+  it('기본 cacheable 정책은 null과 undefined를 저장하지 않는다', async () => {
+    const nullSession = new ResolutionSession();
+    let nullProducerCalls = 0;
+    const nullProducer = async (): Promise<null> => {
+      nullProducerCalls += 1;
+      return null;
+    };
+
+    await nullSession.getOrCreate('pip', 'package-info', { name: 'missing' }, nullProducer);
+    await nullSession.getOrCreate('pip', 'package-info', { name: 'missing' }, nullProducer);
+
+    const undefinedSession = new ResolutionSession();
+    let undefinedProducerCalls = 0;
+    const undefinedProducer = async (): Promise<undefined> => {
+      undefinedProducerCalls += 1;
+      return undefined;
+    };
+
+    await undefinedSession.getOrCreate('pip', 'package-info', { name: 'missing' }, undefinedProducer);
+    await undefinedSession.getOrCreate('pip', 'package-info', { name: 'missing' }, undefinedProducer);
+
+    expect(nullProducerCalls).toBe(2);
+    expect(undefinedProducerCalls).toBe(2);
+  });
+
+  it('operation-specific isCacheable가 거부한 빈 문자열을 저장하지 않는다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async (): Promise<string> => {
+      producerCalls += 1;
+      return '';
+    };
+
+    await session.getOrCreate('npm', 'latest-version', { name: 'empty-version' }, producer, {
+      isCacheable: Boolean,
+    });
+    await session.getOrCreate('npm', 'latest-version', { name: 'empty-version' }, producer, {
+      isCacheable: Boolean,
+    });
+
+    expect(producerCalls).toBe(2);
+  });
+
+  it('기본 cacheable 정책은 빈 문자열을 저장한다', async () => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async (): Promise<string> => {
+      producerCalls += 1;
+      return '';
+    };
+
+    await session.getOrCreate('npm', 'latest-version', { name: 'empty-version' }, producer);
+    await session.getOrCreate('npm', 'latest-version', { name: 'empty-version' }, producer);
+
+    expect(producerCalls).toBe(1);
+  });
+
+  it('cache hit, miss, in-flight join 통계를 제공한다', async () => {
+    const session = new ResolutionSession();
+    const deferred = createDeferred();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      await deferred.promise;
+      return { version: '2.32.0' };
+    };
+
+    const first = session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer);
+    const second = session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer);
+    deferred.resolve();
+    await Promise.all([first, second]);
+    await session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer);
+
+    expect(producerCalls).toBe(1);
+    expect(session.getStats()).toEqual({ hits: 1, misses: 1, joins: 1 });
+  });
+});

--- a/src/core/shared/internal/resolution-session.test.ts
+++ b/src/core/shared/internal/resolution-session.test.ts
@@ -26,10 +26,15 @@ describe('ResolutionSession', () => {
 
     deferred.resolve();
 
-    await expect(Promise.all([first, second])).resolves.toEqual([
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect([firstResult, secondResult]).toEqual([
       { package: { name: 'requests', version: '2.32.0' } },
       { package: { name: 'requests', version: '2.32.0' } },
     ]);
+    firstResult.package.version = '2.33.0';
+    expect(secondResult.package.version).toBe('2.32.0');
+    expect(secondResult.package).not.toBe(firstResult.package);
     expect(producerCalls).toBe(1);
   });
 
@@ -112,6 +117,56 @@ describe('ResolutionSession', () => {
     expect([withoutVersion, withUndefinedVersion]).toEqual([1, 2]);
   });
 
+  it.each([
+    ['Date', { value: new Date('2026-01-01T00:00:00.000Z') }],
+    ['Map', { value: new Map([['name', 'requests']]) }],
+    ['Set', { value: new Set(['requests']) }],
+    ['Symbol', { value: Symbol('requests') }],
+    ['function', { value: () => 'requests' }],
+  ])('%s context를 거부하고 producer를 실행하지 않는다', async (_kind, invalidContext) => {
+    const session = new ResolutionSession();
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return { version: '2.32.0' };
+    };
+
+    expect(() =>
+      session.getOrCreate(
+        'pip',
+        'latest-version',
+        invalidContext as never,
+        producer,
+      ),
+    ).toThrow('Resolution context must be JSON-like');
+    await Promise.resolve();
+
+    expect(producerCalls).toBe(0);
+  });
+
+  it('cyclic context를 거부하고 producer를 실행하지 않는다', async () => {
+    const session = new ResolutionSession();
+    const cyclicContext: Record<string, unknown> = { name: 'requests' };
+    cyclicContext.self = cyclicContext;
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return { version: '2.32.0' };
+    };
+
+    expect(() =>
+      session.getOrCreate(
+        'pip',
+        'latest-version',
+        cyclicContext as never,
+        producer,
+      ),
+    ).toThrow('Resolution context must not contain cyclic references');
+    await Promise.resolve();
+
+    expect(producerCalls).toBe(0);
+  });
+
   it('reject된 producer 결과를 저장하지 않는다', async () => {
     const session = new ResolutionSession();
     let producerCalls = 0;
@@ -185,6 +240,30 @@ describe('ResolutionSession', () => {
     await session.getOrCreate('npm', 'latest-version', { name: 'empty-version' }, producer);
 
     expect(producerCalls).toBe(1);
+  });
+
+  it('isCacheable predicate 오류를 consumer에 전파하고 entry를 제거한다', async () => {
+    const session = new ResolutionSession();
+    const predicateError = new Error('cacheability check failed');
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      return { version: '2.32.0' };
+    };
+    const options = {
+      isCacheable: () => {
+        throw predicateError;
+      },
+    };
+
+    await expect(
+      session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer, options),
+    ).rejects.toBe(predicateError);
+    await expect(
+      session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer, options),
+    ).rejects.toBe(predicateError);
+
+    expect(producerCalls).toBe(2);
   });
 
   it('cache hit, miss, in-flight join 통계를 제공한다', async () => {

--- a/src/core/shared/internal/resolution-session.test.ts
+++ b/src/core/shared/internal/resolution-session.test.ts
@@ -121,6 +121,8 @@ describe('ResolutionSession', () => {
     ['Date', { value: new Date('2026-01-01T00:00:00.000Z') }],
     ['Map', { value: new Map([['name', 'requests']]) }],
     ['Set', { value: new Set(['requests']) }],
+    ['RegExp', { value: /requests/i }],
+    ['class instance', { value: new (class PackageContext {})() }],
     ['Symbol', { value: Symbol('requests') }],
     ['function', { value: () => 'requests' }],
   ])('%s context를 거부하고 producer를 실행하지 않는다', async (_kind, invalidContext) => {
@@ -264,6 +266,64 @@ describe('ResolutionSession', () => {
     ).rejects.toBe(predicateError);
 
     expect(producerCalls).toBe(2);
+  });
+
+  it('in-flight consumer 모두에 isCacheable predicate 오류를 전파하고 entry를 제거한다', async () => {
+    const session = new ResolutionSession();
+    const deferred = createDeferred();
+    const predicateError = new Error('cacheability check failed');
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    let producerCalls = 0;
+    const producer = async () => {
+      producerCalls += 1;
+      await deferred.promise;
+      return { version: '2.32.0' };
+    };
+    const options = {
+      isCacheable: () => {
+        throw predicateError;
+      },
+    };
+
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const first = session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer, options);
+      const second = session.getOrCreate('pip', 'latest-version', { name: 'requests' }, producer, options);
+      const firstError = first.then(
+        () => undefined,
+        (error) => error,
+      );
+      const secondError = second.then(
+        () => undefined,
+        (error) => error,
+      );
+
+      deferred.resolve();
+
+      const [firstReason, secondReason] = await Promise.all([firstError, secondError]);
+      expect(firstReason).toBe(predicateError);
+      expect(secondReason).toBe(predicateError);
+      expect((firstReason as Error).message).toBe('cacheability check failed');
+      expect((secondReason as Error).message).toBe('cacheability check failed');
+      expect(producerCalls).toBe(1);
+
+      const retryReason = await session
+        .getOrCreate('pip', 'latest-version', { name: 'requests' }, producer, options)
+        .then(
+          () => undefined,
+          (error) => error,
+        );
+      expect(retryReason).toBe(predicateError);
+      expect(producerCalls).toBe(2);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 
   it('cache hit, miss, in-flight join 통계를 제공한다', async () => {

--- a/src/core/shared/internal/resolution-session.ts
+++ b/src/core/shared/internal/resolution-session.ts
@@ -2,13 +2,33 @@ export type ResolutionOperation = 'latest-version' | 'package-info' | 'packument
 
 type ResolverName = 'pip' | 'conda' | 'maven' | 'npm';
 
+type ResolutionContextPrimitive = string | number | boolean | null | undefined;
+
+export type ResolutionContextValue =
+  | ResolutionContextPrimitive
+  | ResolutionContextValue[]
+  | ResolutionContext;
+
+export interface ResolutionContext {
+  [key: string]: ResolutionContextValue;
+}
+
 interface ResolutionSessionStats {
   hits: number;
   misses: number;
   joins: number;
 }
 
-function stableSerialize(value: unknown): string {
+function unsupportedContextValue(): never {
+  throw new TypeError('Resolution context must be JSON-like');
+}
+
+function isArrayIndex(key: string): boolean {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 2 ** 32 - 1 && String(index) === key;
+}
+
+function stableSerialize(value: unknown, ancestors = new WeakSet<object>()): string {
   if (value === undefined) {
     return 'undefined';
   }
@@ -30,35 +50,79 @@ function stableSerialize(value: unknown): string {
       return `number:${value}`;
     case 'string':
       return `string:${JSON.stringify(value)}`;
-    case 'bigint':
-      return `bigint:${value}`;
-    case 'symbol':
-      return `symbol:${String(value)}`;
-    case 'function':
-      return `function:${String(value)}`;
     case 'object':
-      if (Array.isArray(value)) {
-        return `array:[${Array.from(value, stableSerialize).join(',')}]`;
+      if (ancestors.has(value)) {
+        throw new TypeError('Resolution context must not contain cyclic references');
       }
 
-      return `object:{${Object.keys(value)
-        .sort()
-        .map((key) => `${stableSerialize(key)}:${stableSerialize(value[key as keyof typeof value])}`)
-        .join(',')}}`;
+      ancestors.add(value);
+      try {
+        if (Array.isArray(value)) {
+          if (Object.getPrototypeOf(value) !== Array.prototype) {
+            return unsupportedContextValue();
+          }
+
+          for (const key of Reflect.ownKeys(value)) {
+            if (key === 'length') {
+              continue;
+            }
+
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (
+              typeof key !== 'string' ||
+              !isArrayIndex(key) ||
+              !descriptor?.enumerable ||
+              !('value' in descriptor)
+            ) {
+              return unsupportedContextValue();
+            }
+          }
+
+          return `array:[${Array.from({ length: value.length }, (_, index) => {
+            const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+            if (!descriptor?.enumerable || !('value' in descriptor)) {
+              return unsupportedContextValue();
+            }
+
+            return stableSerialize(descriptor.value, ancestors);
+          }).join(',')}]`;
+        }
+
+        const prototype = Object.getPrototypeOf(value);
+        if (prototype !== Object.prototype && prototype !== null) {
+          return unsupportedContextValue();
+        }
+
+        const plainObject = value as Record<string, unknown>;
+        for (const key of Reflect.ownKeys(value)) {
+          const descriptor = Object.getOwnPropertyDescriptor(value, key);
+          if (typeof key !== 'string' || !descriptor?.enumerable || !('value' in descriptor)) {
+            return unsupportedContextValue();
+          }
+        }
+
+        return `object:{${Object.keys(value)
+          .sort()
+          .map((key) => `${stableSerialize(key)}:${stableSerialize(plainObject[key], ancestors)}`)
+          .join(',')}}`;
+      } finally {
+        ancestors.delete(value);
+      }
     default:
-      throw new TypeError('Unsupported context value type');
+      return unsupportedContextValue();
   }
 }
 
 export class ResolutionSession {
   private readonly entries = new Map<string, Promise<unknown>>();
   private readonly inFlightKeys = new Set<string>();
+  private readonly cacheabilityFailures = new WeakMap<Promise<unknown>, { error: unknown }>();
   private readonly stats: ResolutionSessionStats = { hits: 0, misses: 0, joins: 0 };
 
   getOrCreate<T>(
     resolver: ResolverName,
     operation: ResolutionOperation,
-    context: Record<string, unknown>,
+    context: ResolutionContext,
     producer: () => Promise<T>,
     options?: { isCacheable?: (value: T) => boolean },
   ): Promise<T> {
@@ -72,7 +136,7 @@ export class ResolutionSession {
         this.stats.hits += 1;
       }
 
-      return cached.then((value) => structuredClone(value));
+      return this.cloneForConsumer(cached);
     }
 
     this.stats.misses += 1;
@@ -84,8 +148,15 @@ export class ResolutionSession {
     void canonical.then(
       (value) => {
         this.inFlightKeys.delete(key);
-        if (!isCacheable(value) && this.entries.get(key) === canonical) {
-          this.entries.delete(key);
+        try {
+          if (!isCacheable(value) && this.entries.get(key) === canonical) {
+            this.entries.delete(key);
+          }
+        } catch (error) {
+          this.cacheabilityFailures.set(canonical, { error });
+          if (this.entries.get(key) === canonical) {
+            this.entries.delete(key);
+          }
         }
       },
       () => {
@@ -96,10 +167,21 @@ export class ResolutionSession {
       },
     );
 
-    return canonical.then((value) => structuredClone(value));
+    return this.cloneForConsumer(canonical);
   }
 
   getStats(): ResolutionSessionStats {
     return { ...this.stats };
+  }
+
+  private cloneForConsumer<T>(canonical: Promise<T>): Promise<T> {
+    return canonical.then((value) => {
+      const cacheabilityFailure = this.cacheabilityFailures.get(canonical);
+      if (cacheabilityFailure) {
+        throw cacheabilityFailure.error;
+      }
+
+      return structuredClone(value);
+    });
   }
 }

--- a/src/core/shared/internal/resolution-session.ts
+++ b/src/core/shared/internal/resolution-session.ts
@@ -1,0 +1,105 @@
+export type ResolutionOperation = 'latest-version' | 'package-info' | 'packument' | 'pom';
+
+type ResolverName = 'pip' | 'conda' | 'maven' | 'npm';
+
+interface ResolutionSessionStats {
+  hits: number;
+  misses: number;
+  joins: number;
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  switch (typeof value) {
+    case 'boolean':
+      return `boolean:${value}`;
+    case 'number':
+      if (Number.isNaN(value)) {
+        return 'number:NaN';
+      }
+      if (Object.is(value, -0)) {
+        return 'number:-0';
+      }
+      return `number:${value}`;
+    case 'string':
+      return `string:${JSON.stringify(value)}`;
+    case 'bigint':
+      return `bigint:${value}`;
+    case 'symbol':
+      return `symbol:${String(value)}`;
+    case 'function':
+      return `function:${String(value)}`;
+    case 'object':
+      if (Array.isArray(value)) {
+        return `array:[${Array.from(value, stableSerialize).join(',')}]`;
+      }
+
+      return `object:{${Object.keys(value)
+        .sort()
+        .map((key) => `${stableSerialize(key)}:${stableSerialize(value[key as keyof typeof value])}`)
+        .join(',')}}`;
+    default:
+      throw new TypeError('Unsupported context value type');
+  }
+}
+
+export class ResolutionSession {
+  private readonly entries = new Map<string, Promise<unknown>>();
+  private readonly inFlightKeys = new Set<string>();
+  private readonly stats: ResolutionSessionStats = { hits: 0, misses: 0, joins: 0 };
+
+  getOrCreate<T>(
+    resolver: ResolverName,
+    operation: ResolutionOperation,
+    context: Record<string, unknown>,
+    producer: () => Promise<T>,
+    options?: { isCacheable?: (value: T) => boolean },
+  ): Promise<T> {
+    const key = `${resolver}:${operation}:${stableSerialize(context)}`;
+    const cached = this.entries.get(key) as Promise<T> | undefined;
+
+    if (cached) {
+      if (this.inFlightKeys.has(key)) {
+        this.stats.joins += 1;
+      } else {
+        this.stats.hits += 1;
+      }
+
+      return cached.then((value) => structuredClone(value));
+    }
+
+    this.stats.misses += 1;
+    const canonical = Promise.resolve().then(producer);
+    this.entries.set(key, canonical);
+    this.inFlightKeys.add(key);
+
+    const isCacheable = options?.isCacheable ?? ((value: T) => value !== null && value !== undefined);
+    void canonical.then(
+      (value) => {
+        this.inFlightKeys.delete(key);
+        if (!isCacheable(value) && this.entries.get(key) === canonical) {
+          this.entries.delete(key);
+        }
+      },
+      () => {
+        this.inFlightKeys.delete(key);
+        if (this.entries.get(key) === canonical) {
+          this.entries.delete(key);
+        }
+      },
+    );
+
+    return canonical.then((value) => structuredClone(value));
+  }
+
+  getStats(): ResolutionSessionStats {
+    return { ...this.stats };
+  }
+}

--- a/src/core/shared/npm-version-resolver.test.ts
+++ b/src/core/shared/npm-version-resolver.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequestNpmResolver, NpmResolver } from '../resolver/npm-resolver';
+import { NpmVersionResolver } from './npm-version-resolver';
+import { fetchPackument } from './npm-cache';
+import type { NpmPackageVersion, NpmPackument } from './npm-types';
+import { ResolutionSession } from './internal/resolution-session';
+import { attachResolutionSession } from './internal/resolution-session-registry';
+
+vi.mock('./npm-cache', () => ({
+  fetchPackument: vi.fn(),
+}));
+
+interface NpmResolverTestable {
+  versionResolver: NpmVersionResolver;
+}
+
+const asTestable = (resolver: NpmResolver): NpmResolverTestable =>
+  resolver as unknown as NpmResolverTestable;
+
+const createPackument = (name = 'shared'): NpmPackument => ({
+  name,
+  'dist-tags': { latest: '1.2.0' },
+  versions: {
+    '1.0.0': { name, version: '1.0.0' } as NpmPackageVersion,
+    '1.2.0': { name, version: '1.2.0' } as NpmPackageVersion,
+    '2.0.0': { name, version: '2.0.0' } as NpmPackageVersion,
+  },
+});
+
+const fetchPackumentMock = vi.mocked(fetchPackument);
+
+describe('NpmVersionResolver 요청 세션', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('같은 요청의 요청 resolver 두 개가 in-flight packument 조회를 한 번만 수행하고 consumer snapshot을 분리한다', async () => {
+    let release!: (packument: NpmPackument) => void;
+    const pending = new Promise<NpmPackument>((resolve) => {
+      release = resolve;
+    });
+    fetchPackumentMock.mockReturnValue(pending);
+
+    const session = new ResolutionSession();
+    const first = asTestable(createRequestNpmResolver(session)).versionResolver;
+    const second = asTestable(createRequestNpmResolver(session)).versionResolver;
+
+    const firstResult = first.fetchPackument('@Scope/Shared');
+    const secondResult = second.fetchPackument('@scope/shared');
+    release(createPackument('@scope/shared'));
+
+    const [firstPackument, secondPackument] = await Promise.all([firstResult, secondResult]);
+    firstPackument.versions['1.2.0'].version = 'changed';
+
+    const thirdPackument = await second.fetchPackument('@SCOPE/SHARED');
+    expect(fetchPackumentMock).toHaveBeenCalledTimes(1);
+    expect(secondPackument.versions['1.2.0'].version).toBe('1.2.0');
+    expect(thirdPackument.versions['1.2.0'].version).toBe('1.2.0');
+  });
+
+  it('같은 요청에서 package name/spec version candidate 선택을 한 번만 수행한다', async () => {
+    const session = new ResolutionSession();
+    const first = asTestable(createRequestNpmResolver(session)).versionResolver;
+    const second = asTestable(createRequestNpmResolver(session)).versionResolver;
+    const resolveVersion = vi.spyOn(NpmVersionResolver.prototype, 'resolveVersion');
+    const packument = createPackument('shared');
+
+    await expect(first.resolveVersionForRequest('^1.0.0', packument)).resolves.toBe('1.2.0');
+    await expect(second.resolveVersionForRequest('^1.0.0', packument)).resolves.toBe('1.2.0');
+
+    expect(resolveVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('registry URL 또는 version spec이 다르면 session 결과를 재사용하지 않는다', async () => {
+    const session = new ResolutionSession();
+    const first = new NpmVersionResolver('https://registry-one.example');
+    const second = new NpmVersionResolver('https://registry-two.example');
+    attachResolutionSession(first, session);
+    attachResolutionSession(second, session);
+    fetchPackumentMock.mockResolvedValue(createPackument('shared'));
+    const resolveVersion = vi.spyOn(NpmVersionResolver.prototype, 'resolveVersion');
+
+    await first.fetchPackument('Shared');
+    await second.fetchPackument('shared');
+    await first.resolveVersionForRequest('^1.0.0', createPackument('shared'));
+    await first.resolveVersionForRequest('^2.0.0', createPackument('shared'));
+
+    expect(fetchPackumentMock).toHaveBeenCalledTimes(2);
+    expect(resolveVersion).toHaveBeenCalledTimes(2);
+  });
+
+  it('failed packument lookup is evicted so a later root retries it', async () => {
+    const session = new ResolutionSession();
+    const resolver = asTestable(createRequestNpmResolver(session)).versionResolver;
+    fetchPackumentMock
+      .mockRejectedValueOnce(new Error('temporary registry failure'))
+      .mockResolvedValueOnce(createPackument('shared'));
+
+    await expect(resolver.fetchPackument('shared')).rejects.toThrow('temporary registry failure');
+    await expect(resolver.fetchPackument('shared')).resolves.toEqual(createPackument('shared'));
+
+    expect(fetchPackumentMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('없는 version candidate는 저장하지 않아 다음 root가 다시 선택한다', async () => {
+    const session = new ResolutionSession();
+    const first = asTestable(createRequestNpmResolver(session)).versionResolver;
+    const second = asTestable(createRequestNpmResolver(session)).versionResolver;
+    const resolveVersion = vi.spyOn(NpmVersionResolver.prototype, 'resolveVersion');
+
+    await expect(
+      first.resolveVersionForRequest('^2.0.0', {
+        ...createPackument('shared'),
+        versions: {
+          '1.2.0': { name: 'shared', version: '1.2.0' } as NpmPackageVersion,
+        },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      second.resolveVersionForRequest('^2.0.0', {
+        ...createPackument('shared'),
+        versions: {
+          '2.0.0': { name: 'shared', version: '2.0.0' } as NpmPackageVersion,
+        },
+      }),
+    ).resolves.toBe('2.0.0');
+
+    expect(resolveVersion).toHaveBeenCalledTimes(2);
+  });
+
+  it('session 없는 legacy resolver는 반복 조회를 그대로 수행한다', async () => {
+    const resolver = new NpmVersionResolver();
+    fetchPackumentMock.mockResolvedValue(createPackument('shared'));
+
+    await resolver.fetchPackument('shared');
+    await resolver.fetchPackument('shared');
+
+    expect(fetchPackumentMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/shared/npm-version-resolver.ts
+++ b/src/core/shared/npm-version-resolver.ts
@@ -5,9 +5,10 @@
  */
 
 import * as semver from 'semver';
-import { fetchPackument } from './npm-cache';
+import { fetchPackument as fetchPackumentFromCache } from './npm-cache';
 import { NpmPackument, NpmPackageVersion } from './npm-types';
 import { NPM_CONSTANTS } from '../constants/npm';
+import { getAttachedResolutionSession } from './internal/resolution-session-registry';
 
 // 로거 타입 (프로젝트 공통 로거 사용)
 const logger = {
@@ -45,7 +46,19 @@ export class NpmVersionResolver {
    * packument 조회 (캐싱)
    */
   async fetchPackument(name: string): Promise<NpmPackument> {
-    return fetchPackument(name, { registryUrl: this.registryUrl });
+    const fetch = () => fetchPackumentFromCache(name, { registryUrl: this.registryUrl });
+    const session = getAttachedResolutionSession(this);
+
+    if (!session) {
+      return fetch();
+    }
+
+    return session.getOrCreate(
+      'npm',
+      'packument',
+      { registryUrl: this.registryUrl, name: name.toLowerCase() },
+      fetch,
+    );
   }
 
   /**
@@ -80,6 +93,29 @@ export class NpmVersionResolver {
     }
 
     return resolved;
+  }
+
+  /**
+   * 요청 범위에서 버전 스펙을 실제 버전으로 해결한다.
+   *
+   * 세션이 없는 공개 사용 경로에서는 기존 synchronous resolveVersion()과 같은
+   * 결과를 Promise로 반환한다.
+   */
+  async resolveVersionForRequest(spec: string, packument: NpmPackument): Promise<string | null> {
+    const resolve = async () => this.resolveVersion(spec, packument);
+    const session = getAttachedResolutionSession(this);
+
+    if (!session) {
+      return resolve();
+    }
+
+    return session.getOrCreate(
+      'npm',
+      'latest-version',
+      { registryUrl: this.registryUrl, name: packument.name.toLowerCase(), spec },
+      resolve,
+      { isCacheable: Boolean },
+    );
   }
 
   /**


### PR DESCRIPTION
## 요약
- 한 번의 의존성 해석 요청 안에서 pip·conda·Maven·npm의 중복 원격 메타데이터/후보 조회를 재사용합니다.
- 동시 조회 합류, 소비자별 복제, 실패·빈 후보 재시도와 요청 간 격리를 보장합니다.
- resolver별 경계와 공통 strict 실패 정책을 회귀 테스트 및 문서로 보강했습니다.

## 배경
- requirements.txt 등 여러 라이브러리를 함께 내려받을 때 공통 전이 의존성의 원격 탐색이 반복됐습니다.

## 변경 사항
- 내부 ResolutionSession 및 요청별 resolver factory를 추가했습니다.
- pip·conda·Maven·npm의 후보/메타데이터 조회 경로만 요청 범위에서 공유합니다.
- OS/Docker, 최종 의존성 그래프, 실제 아티팩트 다운로드는 공유 범위에서 제외합니다.

## 검증
- bash scripts/verify-worktree.sh: 1,915 passed, 186 skipped
- npm run lint: 0 errors (기존 경고 557개)
- npx tsc --noEmit
- git diff --check origin/main...HEAD

## 문서
- docs/shared-dependency.md
- docs/resolvers.md
- docs/pip-dependency-resolution.md
- docs/conda-dependency-resolution.md
- docs/maven-dependency-resolution.md
- docs/npm-dependency-resolution.md