### PR TITLE
동작을 유지하며 다운로드·패키지 후보의 반복 계산 최적화

### DIFF
--- a/docs/electron-renderer.md
+++ b/docs/electron-renderer.md
@@ -138,6 +138,7 @@
 - SMTP 테스트 버튼은 `testSmtpConnection` IPC가 있으면 실제 연결 테스트를 실행하고, 브라우저 개발 환경에서는 시뮬레이션, IPC가 빠진 Electron 빌드에서는 경고와 비활성화 상태를 노출합니다.
 - 히스토리 store는 `window.electronAPI.history.*`를 통해 `~/.depssmuggler/history.json`과 직접 동기화되며, renderer localStorage persist를 source of truth로 사용하지 않습니다.
 - 다운로드 화면 오케스트레이션은 `use-download-page-controller.test.tsx`에서 jsdom + mocked `window.electronAPI` 조합으로 시작/일시정지/재개/취소/완료/오류 시나리오를 회귀 고정합니다.
+- 다운로드 표의 의존성 그룹은 목록 변경 시 부모 ID로 한 번 인덱싱하고 재사용합니다. 행마다 전체 목록을 검색하던 비용을 `O(원본 수 × 전체 항목 수)`에서 `O(전체 항목 수)`로 줄이며, 기존 순서와 상태 집계는 유지합니다. `download-page/utils.test.ts`가 결과 동등성과 조회 횟수를 검증합니다.
 
 ## 사용자 흐름
 

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -633,6 +633,8 @@ const deps = resolver.parseFromText(`
 
 ## YumResolver
 
+YUM/APT/APK의 후보 병합은 호출별 `Set`으로 기존 패키지 키의 재검색을 없앱니다. 이름 검색 결과의 순서·중복과 providers의 첫 항목 선택은 유지합니다. APK의 `so:`/`cmd:`도 동일 provides 조회 한 번으로 처리합니다. 공통 와일드카드 검색은 패키지마다 만들던 정규식을 검색당 한 번 생성하며, 빈 목록과 잘못된 패턴의 오류 처리는 유지합니다. 검증: `src/core/resolver/os-resolvers.test.ts`, `os-resolver-utils.test.ts`.
+
 ### 개요
 - 목적: YUM/RPM 패키지 의존성 해결
 - 위치: `src/core/resolver/yumResolver.ts`

--- a/docs/shared-pip.md
+++ b/docs/shared-pip.md
@@ -260,6 +260,8 @@ if (result.success) {
 
 ### CandidateEvaluator
 
+후보 정렬 키는 `getApplicableCandidates()` 호출 안에서 후보 객체별로 한 번만 계산합니다. 반복 비교 때 wheel 태그·해시 검사와 키 객체 생성을 줄이며, 정렬 비교기와 결과 순서는 그대로입니다. 캐시는 호출 후 해제되어 다음 호출의 후보 변경도 반영합니다. `src/core/shared/pip-candidate.test.ts`에서 기존 비교 결과와 키 계산 횟수를 검증합니다.
+
 wheel/sdist 후보를 평가하고 최적 파일을 선택하는 클래스
 
 ```typescript

--- a/src/core/resolver/apk-resolver.ts
+++ b/src/core/resolver/apk-resolver.ts
@@ -148,42 +148,21 @@ export class ApkDependencyResolver extends BaseOSDependencyResolver {
     if (byName) {
       candidates.push(...byName);
     }
+    const candidateKeys = new Set(candidates.map((pkg) => this.getPackageKey(pkg)));
 
     // 2. provides로 검색
     const byProvides = this.providesMap.get(dep.name);
     if (byProvides) {
       for (const pkg of byProvides) {
-        if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
+        const key = this.getPackageKey(pkg);
+        if (!candidateKeys.has(key)) {
           candidates.push(pkg);
+          candidateKeys.add(key);
         }
       }
     }
 
-    // 3. so: 의존성 처리 (예: so:libc.musl-x86_64.so.1)
-    if (dep.name.startsWith('so:')) {
-      const soName = dep.name;
-      const bySo = this.providesMap.get(soName);
-      if (bySo) {
-        for (const pkg of bySo) {
-          if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
-            candidates.push(pkg);
-          }
-        }
-      }
-    }
-
-    // 4. cmd: 의존성 처리 (예: cmd:sh)
-    if (dep.name.startsWith('cmd:')) {
-      const cmdName = dep.name;
-      const byCmd = this.providesMap.get(cmdName);
-      if (byCmd) {
-        for (const pkg of byCmd) {
-          if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
-            candidates.push(pkg);
-          }
-        }
-      }
-    }
+    // so:/cmd: 접두사도 위의 동일 provides 키 조회에 포함된다.
 
     return candidates;
   }

--- a/src/core/resolver/apt-resolver.ts
+++ b/src/core/resolver/apt-resolver.ts
@@ -185,13 +185,16 @@ export class AptDependencyResolver extends BaseOSDependencyResolver {
     if (byName) {
       candidates.push(...byName);
     }
+    const candidateKeys = new Set(candidates.map((pkg) => this.getPackageKey(pkg)));
 
     // 2. provides로 검색 (virtual packages)
     const byProvides = this.providesMap.get(dep.name);
     if (byProvides) {
       for (const pkg of byProvides) {
-        if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
+        const key = this.getPackageKey(pkg);
+        if (!candidateKeys.has(key)) {
           candidates.push(pkg);
+          candidateKeys.add(key);
         }
       }
     }
@@ -202,8 +205,10 @@ export class AptDependencyResolver extends BaseOSDependencyResolver {
       const byBaseName = this.metadataCache.packages.get(baseName);
       if (byBaseName) {
         for (const pkg of byBaseName) {
-          if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
+          const key = this.getPackageKey(pkg);
+          if (!candidateKeys.has(key)) {
             candidates.push(pkg);
+            candidateKeys.add(key);
           }
         }
       }

--- a/src/core/resolver/os-resolver-utils.test.ts
+++ b/src/core/resolver/os-resolver-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { matchPackagesByQuery } from './os-resolver-utils';
+import type { OSPackageInfo } from '../downloaders/os-shared/types';
+
+const packages = ['libssl', 'libxml', 'curl', 'libssl'].map((name) => ({ name } as OSPackageInfo));
+
+describe('OS package query matching', () => {
+  it('검색 모드별 순서와 중복을 유지한다', () => {
+    expect(matchPackagesByQuery(packages, 'libssl', 'exact')).toEqual([packages[0], packages[3]]);
+    expect(matchPackagesByQuery(packages, 'lib', 'partial')).toEqual([packages[0], packages[1], packages[3]]);
+    expect(matchPackagesByQuery(packages, 'lib???', 'wildcard')).toEqual([packages[0], packages[1], packages[3]]);
+    expect(matchPackagesByQuery(packages, 'lib(ssl|xml)', 'wildcard')).toEqual([packages[0], packages[1], packages[3]]);
+  });
+
+  it('빈 목록에서는 잘못된 패턴도 평가하지 않고, 후보가 있으면 기존 오류를 유지한다', () => {
+    expect(matchPackagesByQuery([], '[', 'wildcard')).toEqual([]);
+    expect(() => matchPackagesByQuery(packages, '[', 'wildcard')).toThrow(SyntaxError);
+  });
+
+  it('와일드카드 정규식은 검색당 한 번만 생성한다', () => {
+    const OriginalRegExp = RegExp;
+    const constructor = vi.fn(function (pattern: string, flags?: string) {
+      return new OriginalRegExp(pattern, flags);
+    });
+    vi.stubGlobal('RegExp', constructor);
+    try {
+      matchPackagesByQuery(packages, 'lib*', 'wildcard');
+      expect(constructor).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/core/resolver/os-resolver-utils.ts
+++ b/src/core/resolver/os-resolver-utils.ts
@@ -20,6 +20,7 @@ export function matchPackagesByQuery(
   query: string,
   matchType: 'exact' | 'partial' | 'wildcard' = 'partial'
 ): OSPackageInfo[] {
+  let wildcardRegex: RegExp | undefined;
   return packages.filter((pkg) => {
     switch (matchType) {
       case 'exact':
@@ -27,10 +28,10 @@ export function matchPackagesByQuery(
       case 'partial':
         return pkg.name.includes(query);
       case 'wildcard': {
-        const regex = new RegExp(
+        wildcardRegex ??= new RegExp(
           '^' + query.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
         );
-        return regex.test(pkg.name);
+        return wildcardRegex.test(pkg.name);
       }
       default:
         return false;

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -73,6 +73,31 @@ describe('OS dependency resolvers', () => {
     vi.restoreAllMocks();
   });
 
+  it.each([
+    ['APT', AptDependencyResolver], ['APK', ApkDependencyResolver], ['YUM', YumDependencyResolver],
+  ] as const)(
+    '%s 후보 병합은 원본 순서·중복을 유지하고 키를 선형 횟수로 계산한다',
+    async (_name, Resolver) => {
+      const resolver = accessResolverForTest(new Resolver(createOptions(repo)));
+      const internals = resolver as unknown as {
+        metadataCache: { packages: Map<string, OSPackageInfo[]> };
+        providesMap: Map<string, OSPackageInfo[]>;
+        getPackageKey(pkg: OSPackageInfo): string;
+      };
+      const byName = createPackage('virtual', '1');
+      const providers = Array.from({ length: 100 }, (_, index) => createPackage(`provider-${index}`, '1'));
+      internals.metadataCache.packages.set('virtual', [byName, byName]);
+      internals.providesMap.set('virtual', [byName, ...providers, ...providers]);
+      const keySpy = vi.spyOn(internals, 'getPackageKey');
+
+      const result = await resolver.findPackagesForDependency({ name: 'virtual' });
+
+      expect(result).toEqual([byName, byName, ...providers]);
+      expect(result[2]).toBe(providers[0]);
+      expect(keySpy.mock.calls.length).toBeLessThanOrEqual(203);
+    }
+  );
+
   it('APT resolver는 컴포넌트 URL, provides, 아키텍처 접미사 검색을 모두 처리한다', async () => {
     const aptRepo = {
       ...repo,

--- a/src/core/resolver/yum-resolver.ts
+++ b/src/core/resolver/yum-resolver.ts
@@ -164,13 +164,16 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
     if (byName) {
       candidates.push(...byName);
     }
+    const candidateKeys = new Set(candidates.map((pkg) => this.getPackageKey(pkg)));
 
     // 2. provides로 검색
     const byProvides = this.providesMap.get(dep.name);
     if (byProvides) {
       for (const pkg of byProvides) {
-        if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
+        const key = this.getPackageKey(pkg);
+        if (!candidateKeys.has(key)) {
           candidates.push(pkg);
+          candidateKeys.add(key);
         }
       }
     }
@@ -181,8 +184,10 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
       const byLib = this.providesMap.get(libName);
       if (byLib) {
         for (const pkg of byLib) {
-          if (!candidates.find((c) => this.getPackageKey(c) === this.getPackageKey(pkg))) {
+          const key = this.getPackageKey(pkg);
+          if (!candidateKeys.has(key)) {
             candidates.push(pkg);
+            candidateKeys.add(key);
           }
         }
       }

--- a/src/core/shared/pip-candidate.test.ts
+++ b/src/core/shared/pip-candidate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CandidateEvaluator, type InstallationCandidate } from './pip-candidate';
+import { parseWheelFilename } from './pip-wheel';
+
+function createCandidates(): InstallationCandidate[] {
+  return Array.from({ length: 40 }, (_, index) => {
+    const filename = `sample-${1 + index % 4}-${index % 3 ? 'py3-none-any' : 'cp312-cp312-manylinux_2_17_x86_64'}.whl`;
+    return {
+      name: 'sample', version: String(1 + index % 4), filename, url: filename,
+      packageType: 'wheel', wheelInfo: parseWheelFilename(filename)!,
+      hash: index % 5 ? 'other' : 'allowed', isYanked: index % 7 === 0,
+    };
+  });
+}
+
+describe('CandidateEvaluator sort cost', () => {
+  it.each([true, false])('binary 선호=%s에서 기존 비교 순서와 후보 객체를 유지한다', (preferBinary) => {
+    const evaluator = new CandidateEvaluator({
+      pythonVersion: '3.12', platform: 'linux', arch: 'x86_64', preferBinary,
+      allowedHashes: new Set(['allowed']), allowYanked: true,
+    });
+    const candidates = createCandidates();
+    candidates.push({ name: 'sample', version: '5', filename: 'sample-5.tar.gz', url: 'sdist', packageType: 'sdist' });
+    const snapshot = [...candidates];
+    const expected = candidates.filter((candidate) => evaluator.isApplicable(candidate)).sort((a, b) =>
+      evaluator.compareSortingKeys(evaluator.getSortingKey(a), evaluator.getSortingKey(b))
+    );
+    const keySpy = vi.spyOn(evaluator, 'getSortingKey');
+
+    const actual = evaluator.getApplicableCandidates(candidates);
+
+    expect(actual).toHaveLength(expected.length);
+    actual.forEach((candidate, index) => expect(candidate).toBe(expected[index]));
+    expect(candidates).toEqual(snapshot);
+    expect(keySpy.mock.calls.length).toBeLessThanOrEqual(candidates.length);
+  });
+
+  it('다음 호출에서는 바뀐 후보 값을 다시 평가한다', () => {
+    const evaluator = new CandidateEvaluator({ pythonVersion: '3.12', platform: 'linux', arch: 'x86_64' });
+    const candidates = createCandidates().slice(1, 3);
+    expect(evaluator.sortBestCandidate(candidates)).toBe(candidates[1]);
+    candidates[0].version = '100';
+    expect(evaluator.sortBestCandidate(candidates)).toBe(candidates[0]);
+    expect(evaluator.sortBestCandidate([])).toBeNull();
+  });
+});

--- a/src/core/shared/pip-candidate.ts
+++ b/src/core/shared/pip-candidate.ts
@@ -313,10 +313,19 @@ export class CandidateEvaluator {
     // 필터링
     const applicable = candidates.filter((c) => this.isApplicable(c));
 
-    // 정렬
+    // 같은 후보의 태그·해시 정렬 키는 이번 정렬에서 한 번만 계산한다.
+    const keys = new Map<InstallationCandidate, CandidateSortingKey>();
+    const getKey = (candidate: InstallationCandidate): CandidateSortingKey => {
+      let key = keys.get(candidate);
+      if (!key) {
+        key = this.getSortingKey(candidate);
+        keys.set(candidate, key);
+      }
+      return key;
+    };
     return applicable.sort((a, b) => {
-      const keyA = this.getSortingKey(a);
-      const keyB = this.getSortingKey(b);
+      const keyA = getKey(a);
+      const keyB = getKey(b);
       return this.compareSortingKeys(keyA, keyB);
     });
   }

--- a/src/renderer/pages/download-page/components/DownloadItemsTable.tsx
+++ b/src/renderer/pages/download-page/components/DownloadItemsTable.tsx
@@ -2,7 +2,7 @@ import { BranchesOutlined, ReloadOutlined, RightOutlined } from '@ant-design/ico
 import { Button, Collapse, List, Progress, Space, Table, Tag, Typography } from 'antd';
 import { useMemo } from 'react';
 import { statusColors, statusIcons, statusLabels } from '../presentation';
-import { formatBytes, getPackageDependencies, getPackageGroupStatus } from '../utils';
+import { formatBytes, groupDownloadItems } from '../utils';
 import type { DownloadStoreItem, DownloadStoreStatus } from '../../../stores/download-store';
 
 const { Panel } = Collapse;
@@ -21,6 +21,10 @@ export function DownloadItemsTable({
   onRetry,
   paginate = false,
 }: DownloadItemsTableProps) {
+  const groups = useMemo(
+    () => showDependenciesTree ? groupDownloadItems(downloadItems) : [],
+    [downloadItems, showDependenciesTree]
+  );
   const columns = useMemo(
     () => [
       {
@@ -126,8 +130,6 @@ export function DownloadItemsTable({
     );
   }
 
-  const originalPackages = downloadItems.filter((item) => !item.isDependency);
-
   return (
     <Collapse
       bordered={false}
@@ -135,12 +137,9 @@ export function DownloadItemsTable({
         <RightOutlined rotate={isActive ? 90 : 0} style={{ fontSize: 12 }} />
       )}
       style={{ background: 'transparent' }}
-      defaultActiveKey={originalPackages.map((pkg) => pkg.id)}
+      defaultActiveKey={groups.map(({ parent }) => parent.id)}
     >
-      {originalPackages.map((pkg) => {
-        const deps = getPackageDependencies(downloadItems, pkg.id);
-        const groupStatus = getPackageGroupStatus(downloadItems, pkg);
-
+      {groups.map(({ parent: pkg, dependencies: deps, status: groupStatus }) => {
         return (
           <Panel
             key={pkg.id}

--- a/src/renderer/pages/download-page/utils.test.ts
+++ b/src/renderer/pages/download-page/utils.test.ts
@@ -5,10 +5,38 @@ import {
   hasMatchingCartSnapshot,
   getPackageGroupStatus,
   getPackageDependencies,
+  groupDownloadItems,
   persistHistoryAndMaybeClearCart,
 } from './utils';
+import type { DownloadStoreItem, DownloadStoreStatus } from '../../stores/download-store';
 
 describe('download-page/utils', () => {
+  it('그룹 인덱스가 입력 순서·상태 집계를 유지하면서 전체 목록의 반복 스캔을 피한다', () => {
+    let dependencyReads = 0;
+    const statuses: DownloadStoreStatus[] = ['pending', 'downloading', 'completed', 'failed', 'skipped', 'paused', 'cancelled'];
+    const items: DownloadStoreItem[] = Array.from({ length: 80 }, (_, index) => ({
+      id: `item-${index}`, name: `item-${index}`, version: '1',
+      status: statuses[index % statuses.length], progress: 0, downloadedBytes: 0,
+      totalBytes: 0, speed: 0,
+      get isDependency() { dependencyReads++; return index >= 20; },
+      parentId: index >= 20 ? `item-${index % 21}` : undefined,
+    }));
+    const expected = items.filter((item) => !item.isDependency).map((parent) => ({
+      parent, dependencies: getPackageDependencies(items, parent.id),
+      status: getPackageGroupStatus(items, parent),
+    }));
+    dependencyReads = 0;
+
+    const actual = groupDownloadItems(items);
+    const reads = dependencyReads;
+
+    expect(actual).toEqual(expected);
+    expect(actual[0].parent).toBe(items[0]);
+    expect(actual[0].dependencies[0]).toBe(items[21]);
+    expect(reads).toBeLessThanOrEqual(items.length * 2);
+    expect(groupDownloadItems([])).toEqual([]);
+  });
+
   it('pending download item 생성 시 기본 진행 상태를 채워야 함', () => {
     const items = createPendingDownloadItems([
       {

--- a/src/renderer/pages/download-page/utils.ts
+++ b/src/renderer/pages/download-page/utils.ts
@@ -205,6 +205,26 @@ export function getPackageGroupStatus(items: DownloadStoreItem[], parentItem: Do
   };
 }
 
+/** 원본 순서를 유지하며 의존성 조회를 전체 목록당 한 번의 인덱싱으로 처리한다. */
+export function groupDownloadItems(items: DownloadStoreItem[]) {
+  const parents: DownloadStoreItem[] = [];
+  const dependenciesByParent = new Map<string, DownloadStoreItem[]>();
+  for (const item of items) {
+    if (!item.isDependency) {
+      parents.push(item);
+    } else if (item.parentId !== undefined) {
+      const dependencies = dependenciesByParent.get(item.parentId);
+      if (dependencies) dependencies.push(item);
+      else dependenciesByParent.set(item.parentId, [item]);
+    }
+  }
+
+  return parents.map((parent) => {
+    const dependencies = dependenciesByParent.get(parent.id) ?? [];
+    return { parent, dependencies, status: getPackageGroupStatus(dependencies, parent) };
+  });
+}
+
 export async function persistHistoryAndMaybeClearCart({
   persistHistory,
   clearCart,


### PR DESCRIPTION
대형 의존성 목록에서 다운로드 표가 행마다 전체 목록을 재검색하고, 패키지 후보 평가가 비교마다 같은 키를 다시 계산하던 비용을 줄입니다. 입력 순서·후보 선택 기준·중복 처리·오류 처리는 유지합니다.

## 변경 지점과 이유
- 다운로드 표: 부모 ID로 한 번 그룹화하고 목록이 같으면 재사용. 전체 목록의 행별 반복 검색을 제거합니다.
- pip 후보 평가: 호출 내부에서 후보별 정렬 키를 재사용해 태그·해시 검사와 임시 객체 생성을 줄입니다. 기존 비교기는 유지합니다.
- YUM/APT/APK: 후보 키 Set으로 중복 검사를 선형화합니다. 이름 검색 결과의 중복과 첫 provider 선택을 유지하며 APK의 같은 provides 재조회도 제거합니다.
- OS 와일드카드 검색: 정규식을 검색당 한 번만 생성합니다. 빈 입력의 지연 평가와 잘못된 패턴 오류를 유지합니다.

## 검증
- `bash scripts/verify-worktree.sh`로 관련 15개 파일, 371개 테스트 통과
- `npx tsc --noEmit`, `npm run lint -- --quiet`, `git diff --check` 통과
- 회귀 테스트로 기존 결과·객체 참조·동일 우선순위 순서·후보 변경의 다음 호출 반영을 확인했습니다.
- 연산 수 테스트: pip 후보 41개의 키 계산 336→최대 41회, OS 후보 병합 키 계산 20,802→203회.
- 변경 전 커밋 `d4d341e`와 현재 함수에 같은 입력을 넣은 로컬 미세측정(7회 중앙값, 모든 결과 동일):
  - 다운로드 그룹 1,000개 + 의존성 10,000개: 161.367→1.256ms
  - OS 와일드카드 30,000개: 5.202→0.785ms
  - pip wheel 후보 1,200개: 1.616→1.150ms
- 위 시간은 계산 구간의 합성 입력 측정이며 앱 전체의 속도 향상 수치가 아닙니다.
- CI 7개 검사 통과: 3개 OS의 전체 단위 테스트, 커버리지, 타입, 린트, Playwright E2E.
- E2E 최초 실행은 취소 시나리오의 재시작 버튼 대기에서 시간 초과했습니다. 해당 테스트는 의존성 트리를 사용하지 않으며, 모의 다운로드가 600ms 뒤 자동 완료됩니다. 실패 스냅샷은 장바구니가 비워진 화면으로, 취소 클릭과 자동 완료의 타이밍 충돌로 판단했습니다. 코드 변경 없이 실패 job을 재실행하여 통과했습니다.
- E2E 재실행 세부 결과는 10 passed / 4 flaky(내장 재시도에서 성공)입니다. 테스트 타이밍 불안정성은 남아 있으며 이번 성능 개선 범위에서 테스트 동작은 변경하지 않았습니다.
- `jsdom@^29.0.2`는 이미 `main`의 devDependencies와 lockfile에 있습니다. 로컬 공유 node_modules의 설치 누락이므로 의존성 추가 변경은 하지 않았고 전체 UI 테스트는 CI의 정상 설치 환경에서 검증했습니다.

관련 문서: `docs/electron-renderer.md`, `docs/shared-pip.md`, `docs/resolvers.md`.
