### PR TITLE
핵심 기능·실패·입력/권한 오류 테스트 전반 보강

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,11 +37,11 @@ npm audit
 ### 1. 단위 테스트
 
 - 설정 파일: `vitest.config.ts`
-- 기본 include: `src/**/*.test.ts`, `src/**/*.test.tsx`, `tests/unit/**/*.test.ts`, `tests/unit/**/*.test.tsx`
+- 기본 include: `src/**/*.test.ts`, `src/**/*.test.tsx`, `electron/**/*.test.ts`, `tests/unit/**/*.test.ts`, `tests/unit/**/*.test.tsx`
 - 기본 exclude: `node_modules`, `dist`, `tests/e2e/**`
 - 기본 실행 환경: `node`
 
-렌더러 훅처럼 DOM이 필요한 일부 테스트는 파일 상단 `// @vitest-environment jsdom` 주석으로 개별 override 합니다. 현재 `src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx`가 이 방식을 사용하며, Electron preload API/Ant Design modal/router hook을 mock한 상태에서 다운로드 시작·일시정지·재개·취소·완료·오류 플로우를 고정합니다.
+렌더러 훅처럼 DOM이 필요한 일부 테스트는 파일 상단 `// @vitest-environment jsdom` 주석으로 개별 override 합니다. 다운로드 페이지 controller, `use-os-download-flow`, `use-settings-form-actions` 테스트가 이 방식을 사용합니다. Electron preload API와 외부 경계는 mock하고 실제 React 훅의 상태 전이와 정리 동작을 검증합니다. 실행에는 `package.json`에 선언된 `jsdom`과 `@testing-library/react`가 필요하며, 일부 의존성이 빠진 기존 `node_modules`를 재사용한 결과를 전체 테스트 통과로 간주하지 않습니다.
 
 대상 예시:
 
@@ -62,6 +62,25 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 - `src/renderer/stores/download-store.test.ts`
 - `src/renderer/stores/settings-store.test.ts`
 - `src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx`
+
+### 기능·오류·경계값 회귀 범위
+
+기존 동작을 기준으로 다음 공백을 보강합니다. 서비스 로직을 테스트에 맞추어 변경하지 않으며, 아래 테스트는 실제 레지스트리나 SMTP 서버에 접속하지 않습니다.
+
+| 영역               | 테스트 위치                                                                                                                             | 주요 검증                                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| CLI 설정·캐시      | `src/cli/commands/{config,cache}.test.ts`                                                                                               | 값 변환, 조회·초기화, 빈 캐시, 삭제 확인 거부, 디렉토리 소실, EACCES/EPERM, 실패 후 삭제 방지                    |
+| Electron 저장·조회 | `electron/{config,cache,history,version}-handlers.test.ts`                                                                              | JSON 오류, 파일 권한·용량 오류, 히스토리 상한·순서, 빈 결과, 버전 캐시와 재시도                                  |
+| Electron 다운로드  | `electron/services/{dependency-resolve-service,download-progress,os-search-service,os-package-router,os-download-orchestrator}.test.ts` | 미지원 입력, 의존성·검색 실패, 진행률 제한, 취소, 패키징 실패와 임시 파일 정리                                   |
+| Docker             | `src/core/downloaders/docker-{auth,blob-downloader,catalog-cache,manifest-service,search-service}.test.ts`                              | 인증 거부·토큰 만료, 빈 목록, 플랫폼별 manifest 선택, 체크섬 불일치, 파일 권한, 캐시 복구                        |
+| OS 패키지          | `src/core/downloaders/os-shared/{archive-packager,dependency-tree}.test.ts`, `src/core/resolver/os-resolver-utils.test.ts`              | 압축 형식·스크립트, 누락 파일, 순환·중복 의존성, 버전·아키텍처 필터, 요청 간 상태 격리                           |
+| Python             | `src/core/shared/{pip-candidate,pip-tags,pip-provider,pypi-utils}.test.ts`                                                              | ABI·플랫폼, Python/패키지 버전 제약, 철회·시험 배포, 후보 없음, 의존성·캐시·실패 후 재시도                       |
+| Conda·Maven        | `src/core/shared/{conda-utils,conda-validator,maven-utils}.test.ts`                                                                     | 압축 인덱스/일반 인덱스/API fallback, noarch, Python 빌드, 채널 거부, classifier, 잘못된·빈 응답                 |
+| HTTP·파일·캐시     | `src/core/shared/{axios-http-client,file-utils}.test.ts`, `src/core/shared/cache/cache-store.test.ts`                                   | 상태·오류·진행률 전달, 바이트 전송, redirect, pause/cancel 정리, TTL 경계, 동시 실패·재시도, 손상 JSON·권한 오류 |
+| 메일               | `src/core/mailer/email-sender-errors.test.ts`                                                                                           | 첨부 제한과 같은 크기/초과, 인증·수신자·파일 접근 오류, 부분 발송 중단, 연결 재시도                              |
+| 렌더러 훅          | `src/renderer/pages/settings/use-settings-form-actions.test.ts`, `src/renderer/pages/download-page/hooks/use-os-download-flow.test.ts`  | 입력 검증·미저장 이동 방지, SMTP·캐시 실패, OS 선택, 늦은 응답, 히스토리·장바구니 보존, 구독 해제                |
+
+커버리지는 `npm run test:coverage`로 확인합니다. 현재 커버리지 집계 대상은 `src/core/**/*.ts`이므로 CLI, Electron, 렌더러, E2E 테스트의 검증 범위와 구분해야 합니다. 외부 레지스트리 실제 연동 및 OS별 파일시스템 동작 전체를 mock 테스트가 보장하지는 않습니다.
 
 ### 2. 통합 테스트
 
@@ -95,6 +114,8 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 - `tests/e2e/download-smoke.spec.ts`: 장바구니에서 일반 다운로드 완료 화면까지의 smoke flow
 - `tests/e2e/history-email-restore.spec.ts`: 이메일 전달 히스토리 재다운로드 시 수신자 복원과 전역 설정 보존
 - `tests/e2e/os-package-download.spec.ts`: OS 패키지 전용 검색/다운로드 흐름
+- `tests/e2e/cart-input-regression.spec.ts`: 빈 장바구니·입력, requirements 중복·주석·파일 업로드, 최신 버전 조회 실패, package.json 오류·scoped/dev 의존성, Maven JAR/POM 구분과 저장 복원
+- `tests/e2e/download-cancel-retry.spec.ts`: 실제 시작·패키지 완료 상태를 기다린 뒤 취소와 새 세션 재시도를 검증
 
 구성 동작:
 
@@ -154,6 +175,9 @@ UI 수동 검증과 E2E 전환 계획은 별도 문서로 관리합니다.
 - CLI/Electron 경계는 thin handler wiring 테스트와 service/helper 단위 테스트를 분리해 검증합니다.
 - Electron handler 테스트는 IPC 채널 등록과 service 위임만 확인하고, package type 분기/패키징/OS 전용 흐름은 `electron/services/*.test.ts`에서 검증합니다.
 - renderer 다운로드 흐름처럼 상태 전이가 많은 코드는 page 컴포넌트 전체보다 store/hook 단위 characterization test를 우선 추가합니다.
+- 권한 오류는 `chmod`나 실행 사용자의 권한에 의존하지 않고 파일/전송 경계에서 재현하며, 거절 이후 불필요한 저장·삭제·발송이 발생하지 않는지도 확인합니다.
+- 타이머는 fake clock 또는 명시적 완료 신호로 제어합니다. E2E 취소 테스트는 취소 버튼 표시뿐 아니라 시나리오에 필요한 다운로드 시작·완료 상태를 먼저 확인합니다.
+- 실패한 테스트를 통과시키기 위해 서비스 검증을 제거하거나 테스트의 최종 결과 검증을 약화하지 않습니다.
 
 ## 현재 문서화 포인트
 

--- a/docs/ui-testing-playwright-conversion.md
+++ b/docs/ui-testing-playwright-conversion.md
@@ -6,16 +6,19 @@
 
 ## 현재 자동화된 회귀 범위
 
-| 수동 케이스 | 현재 Playwright 파일 | 검증 포인트 |
-| --- | --- | --- |
-| `UI-DL-001` | `tests/e2e/download-smoke.spec.ts` | 장바구니에서 일반 다운로드 완료 화면까지, preflight 출력 형식 표시, 로컬 저장 옵션 전달 |
-| `UI-DL-004` | `tests/e2e/download-cancel-retry.spec.ts` | 느린 다운로드 취소 유지, overwrite 대기 중 늦은 취소 completion 보존, delayed start failure 후 이전 outcome 복구, 실패 후 개별 재시도, 전달 실패가 남은 취소 화면에서의 새 세션 재시도, runtime download/cancel 시도 횟수 |
-| `UI-SET-001`, `UI-SET-002(성공 경로만)` | `tests/e2e/settings-regression.spec.ts` | SMTP 값 입력, 연결 테스트 성공 경로, 저장 후 새로고침 복원 |
-| `UI-CFG-001` | `tests/e2e/settings-cache-breakdown.spec.ts` | 캐시 총합, 타입별 breakdown, 캐시 비우기 후 0 값 갱신 |
-| `UI-HIS-001` | `tests/e2e/history-email-restore.spec.ts` | 이메일 히스토리 재다운로드, 저장된 수신자 복원, 파일 분할 안내 표시, 전역 설정 보존 |
-| `UI-OS-001` | `tests/e2e/os-package-download.spec.ts` | OS 패키지 검색, 전용 다운로드 화면, 출력 옵션 결과 반영 |
+| 수동 케이스                             | 현재 Playwright 파일                         | 검증 포인트                                                                                                                                                                                                               |
+| --------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UI-DL-001`                             | `tests/e2e/download-smoke.spec.ts`           | 장바구니에서 일반 다운로드 완료 화면까지, preflight 출력 형식 표시, 로컬 저장 옵션 전달                                                                                                                                   |
+| `UI-DL-004`                             | `tests/e2e/download-cancel-retry.spec.ts`    | 느린 다운로드 취소 유지, overwrite 대기 중 늦은 취소 completion 보존, delayed start failure 후 이전 outcome 복구, 실패 후 개별 재시도, 전달 실패가 남은 취소 화면에서의 새 세션 재시도, runtime download/cancel 시도 횟수 |
+| `UI-SET-001`, `UI-SET-002(성공 경로만)` | `tests/e2e/settings-regression.spec.ts`      | SMTP 값 입력, 연결 테스트 성공 경로, 저장 후 새로고침 복원                                                                                                                                                                |
+| `UI-CFG-001`                            | `tests/e2e/settings-cache-breakdown.spec.ts` | 캐시 총합, 타입별 breakdown, 캐시 비우기 후 0 값 갱신                                                                                                                                                                     |
+| `UI-HIS-001`                            | `tests/e2e/history-email-restore.spec.ts`    | 이메일 히스토리 재다운로드, 저장된 수신자 복원, 파일 분할 안내 표시, 전역 설정 보존                                                                                                                                       |
+| `UI-OS-001`                             | `tests/e2e/os-package-download.spec.ts`      | OS 패키지 검색, 전용 다운로드 화면, 출력 옵션 결과 반영                                                                                                                                                                   |
+| 장바구니 텍스트·파일 입력 및 빈 상태    | `tests/e2e/cart-input-regression.spec.ts`    | 빈 입력 거부, requirements 중복·주석 제외와 저장 복원, 최신 버전 조회 실패, package.json 파싱 오류·scoped/dev 의존성, 파일 업로드, Maven JAR/POM 구분                                                                     |
 
 현재 회귀 세트는 `tests/e2e/fixtures/mock-electron-app.ts`와 `window.electronAPI` stub을 이용해 preload/IPC를 브라우저 쪽에서 모킹합니다.
+
+설정의 필수 입력 검증·SMTP 실패/재시도·캐시 권한 오류·미저장 이동 방지와 OS 다운로드의 입력·취소·히스토리·구독 정리는 Vitest의 `use-settings-form-actions.test.ts`, `use-os-download-flow.test.ts`에서도 검증합니다. 훅 단위 검증과 아래 DOM/버튼 상태 E2E 후보는 별도 범위입니다.
 
 ## 다음 자동화 우선순위
 
@@ -72,9 +75,9 @@
 
 다음 항목은 자동화 가능하더라도 플랫폼 특성 또는 비용 때문에 수동 확인 비중을 더 크게 둡니다.
 
-| 수동 케이스 | 수동 우선 이유 |
-| --- | --- |
-| `UI-CFG-001` | 캐시 크기와 정리 결과는 로컬 파일 상태에 따라 달라질 수 있음 |
+| 수동 케이스    | 수동 우선 이유                                                          |
+| -------------- | ----------------------------------------------------------------------- |
+| `UI-CFG-001`   | 캐시 크기와 정리 결과는 로컬 파일 상태에 따라 달라질 수 있음            |
 | `UI-ROUTE-001` | 새로고침, 창 크기 변경, 라우트 왕복은 조합이 많고 탐색적 확인 가치가 큼 |
 
 ## Playwright 작성 원칙
@@ -84,6 +87,7 @@
 - 다운로드 검증은 UI 제목만 보지 말고 `runtime.downloadCalls` payload까지 확인합니다.
 - 다운로드 취소/재시도 회귀는 `downloadScenario` 기반 fixture 상태 머신과 `sessionId` 태깅을 함께 사용해, 취소 후 늦은 완료 이벤트, overwrite 대기, delayed start failure를 포함한 재시작 세션 경계를 모두 검증합니다.
 - OS 패키지 시나리오는 일반 다운로드와 별도 파일로 유지해 분기 가독성을 지킵니다.
+- 아이콘이 버튼 접근성 이름에 포함되는 경우 실제 role/name을 기준으로 선택자를 작성합니다. 취소/재시도는 임의 sleep 대신 IPC 호출 기록과 패키지 상태로 사전 조건을 확인합니다.
 
 ## 신규 스펙 템플릿
 

--- a/electron/cache-handlers.test.ts
+++ b/electron/cache-handlers.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerCacheHandlers } from './cache-handlers';
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  pipStats: vi.fn(),
+  npmStats: vi.fn(),
+  mavenStats: vi.fn(),
+  condaStats: vi.fn(),
+  clearPip: vi.fn(),
+  clearNpm: vi.fn(),
+  clearMavenMemory: vi.fn(),
+  clearMavenDisk: vi.fn(),
+  clearConda: vi.fn(),
+  refreshDocker: vi.fn(),
+  dockerStatus: vi.fn(),
+  clearDocker: vi.fn(),
+}));
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }));
+vi.mock('./utils/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), debug: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../src/core/shared/pip-cache', () => ({
+  getCacheStats: mocks.pipStats,
+  clearAllCache: mocks.clearPip,
+}));
+vi.mock('../src/core/shared/npm-cache', () => ({
+  getNpmCacheStats: mocks.npmStats,
+  clearNpmCache: mocks.clearNpm,
+}));
+vi.mock('../src/core/shared/maven-cache', () => ({
+  getMavenCacheStats: mocks.mavenStats,
+  clearMemoryCache: mocks.clearMavenMemory,
+  clearDiskCache: mocks.clearMavenDisk,
+}));
+vi.mock('../src/core/shared/conda-cache', () => ({
+  getCacheStats: mocks.condaStats,
+  clearCache: mocks.clearConda,
+}));
+vi.mock('../src/core', () => ({
+  getDockerDownloader: () => ({
+    refreshCatalogCache: mocks.refreshDocker,
+    getCatalogCacheStatus: mocks.dockerStatus,
+    clearCatalogCache: mocks.clearDocker,
+  }),
+}));
+
+function invoke(channel: string, ...args: unknown[]) {
+  const handler = mocks.handle.mock.calls.find(([name]) => name === channel)?.[1];
+  expect(handler).toBeTypeOf('function');
+  return handler({}, ...args);
+}
+
+describe('cache IPC handlers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.pipStats.mockReturnValue({ memoryEntries: 5, diskEntries: 8, diskSize: 100 });
+    mocks.npmStats.mockReturnValue({ entries: 3 });
+    mocks.mavenStats.mockReturnValue({ memoryEntries: 4, diskEntries: 2, diskSize: 200 });
+    mocks.condaStats.mockResolvedValue({ entries: [{ key: 'a' }, { key: 'b' }], totalSize: 300 });
+    registerCacheHandlers();
+  });
+
+  it('aggregates metadata sizes and avoids counting memory/disk entries twice', async () => {
+    await expect(invoke('cache:stats')).resolves.toEqual({
+      scope: 'package-metadata',
+      excludes: ['version caches', 'renderer localStorage'],
+      totalSize: 600,
+      entryCount: 17,
+      details: {
+        pip: { memoryEntries: 5, diskEntries: 8, diskSize: 100 },
+        npm: { entries: 3 },
+        maven: { memoryEntries: 4, diskEntries: 2, diskSize: 200 },
+        conda: { entries: [{ key: 'a' }, { key: 'b' }], totalSize: 300 },
+      },
+    });
+    await expect(invoke('cache:get-size')).resolves.toBe(600);
+  });
+
+  it('treats absent cache counters and sizes as zero', async () => {
+    mocks.pipStats.mockReturnValue({});
+    mocks.npmStats.mockReturnValue({});
+    mocks.mavenStats.mockReturnValue({});
+    mocks.condaStats.mockResolvedValue({});
+    await expect(invoke('cache:stats')).resolves.toMatchObject({ totalSize: 0, entryCount: 0 });
+  });
+
+  it.each(['cache:stats', 'cache:get-size'])(
+    '%s propagates statistics read failure without deleting caches',
+    async (channel) => {
+      const error = new Error('EACCES: cache metadata');
+      mocks.condaStats.mockRejectedValue(error);
+      await expect(invoke(channel)).rejects.toBe(error);
+      expect(mocks.clearPip).not.toHaveBeenCalled();
+      expect(mocks.clearMavenDisk).not.toHaveBeenCalled();
+      expect(mocks.clearConda).not.toHaveBeenCalled();
+    }
+  );
+
+  it('waits for every metadata cache clear before reporting success', async () => {
+    let finish!: () => void;
+    mocks.clearConda.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      })
+    );
+    const completed = vi.fn();
+    const result = invoke('cache:clear').then(completed);
+    await Promise.resolve();
+    for (const clear of [
+      mocks.clearPip,
+      mocks.clearNpm,
+      mocks.clearMavenMemory,
+      mocks.clearMavenDisk,
+      mocks.clearConda,
+    ]) {
+      expect(clear).toHaveBeenCalledOnce();
+    }
+    expect(completed).not.toHaveBeenCalled();
+    expect(mocks.clearDocker).not.toHaveBeenCalled();
+    finish();
+    await result;
+    expect(completed).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('propagates asynchronous deletion failure', async () => {
+    const error = new Error('EACCES: maven cache');
+    mocks.clearMavenDisk.mockRejectedValue(error);
+    await expect(invoke('cache:clear')).rejects.toBe(error);
+  });
+
+  it.each([undefined, 'ghcr.io'])(
+    'refreshes Docker catalogue for registry %s',
+    async (registry) => {
+      await expect(invoke('docker:cache:refresh', registry)).resolves.toEqual({ success: true });
+      expect(mocks.refreshDocker).toHaveBeenCalledWith(registry ?? 'docker.io');
+    }
+  );
+
+  it('exposes Docker catalogue state separately from metadata caches', async () => {
+    const status = { cached: true, count: 12 };
+    mocks.dockerStatus.mockReturnValue(status);
+    await expect(invoke('docker:cache:status')).resolves.toEqual(status);
+    await expect(invoke('docker:cache:clear')).resolves.toEqual({ success: true });
+    expect(mocks.clearDocker).toHaveBeenCalledOnce();
+    expect(mocks.clearPip).not.toHaveBeenCalled();
+  });
+
+  it('propagates Docker refresh errors without clearing the catalogue', async () => {
+    const error = new Error('registry unavailable');
+    mocks.refreshDocker.mockRejectedValue(error);
+    await expect(invoke('docker:cache:refresh')).rejects.toBe(error);
+    expect(mocks.clearDocker).not.toHaveBeenCalled();
+  });
+});

--- a/electron/config-handlers.test.ts
+++ b/electron/config-handlers.test.ts
@@ -1,0 +1,130 @@
+import * as path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSettingsPath, registerConfigHandlers } from './config-handlers';
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  homedir: vi.fn(),
+  pathExists: vi.fn(),
+  ensureDir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }));
+vi.mock('os', () => ({ homedir: mocks.homedir }));
+vi.mock('fs-extra', () => mocks);
+vi.mock('./utils/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), error: vi.fn() }),
+}));
+
+function invoke(channel: string, ...args: unknown[]) {
+  const handler = mocks.handle.mock.calls.find(([name]) => name === channel)?.[1];
+  expect(handler).toBeTypeOf('function');
+  return handler({}, ...args);
+}
+
+describe('config IPC persistence', () => {
+  const home = path.resolve('test-home');
+  const settingsPath = path.join(home, '.depssmuggler', 'settings.json');
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.homedir.mockReturnValue(home);
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.ensureDir.mockResolvedValue(undefined);
+    mocks.writeFile.mockResolvedValue(undefined);
+    mocks.remove.mockResolvedValue(undefined);
+    registerConfigHandlers();
+  });
+
+  it('uses the current home directory for both path lookup and persisted JSON', async () => {
+    const config = { concurrentDownloads: 5, cache: { enabled: false }, label: '설정' };
+    expect(getSettingsPath()).toBe(settingsPath);
+    expect(invoke('config:getPath')).toBe(settingsPath);
+    await expect(invoke('config:set', config)).resolves.toEqual({ success: true });
+    expect(mocks.ensureDir).toHaveBeenCalledWith(path.dirname(settingsPath));
+    expect(mocks.writeFile).toHaveBeenCalledWith(
+      settingsPath,
+      JSON.stringify(config, null, 2),
+      'utf-8'
+    );
+    mocks.readFile.mockResolvedValue(JSON.stringify(config));
+    await expect(invoke('config:get')).resolves.toEqual(config);
+    expect(mocks.readFile).toHaveBeenCalledWith(settingsPath, 'utf-8');
+  });
+
+  it('returns null for missing settings without attempting to read or create a file', async () => {
+    mocks.pathExists.mockResolvedValue(false);
+    await expect(invoke('config:get')).resolves.toBeNull();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    expect(mocks.ensureDir).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '{broken'])('falls back to null for malformed JSON %j', async (data) => {
+    mocks.readFile.mockResolvedValue(data);
+    await expect(invoke('config:get')).resolves.toBeNull();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+
+  it.each(['pathExists', 'readFile'] as const)(
+    'falls back on %s permission errors',
+    async (operation) => {
+      mocks[operation].mockRejectedValue(new Error('EACCES'));
+      await expect(invoke('config:get')).resolves.toBeNull();
+      if (operation === 'pathExists') expect(mocks.readFile).not.toHaveBeenCalled();
+      expect(mocks.writeFile).not.toHaveBeenCalled();
+    }
+  );
+
+  it('reports directory permission failure without attempting a write', async () => {
+    mocks.ensureDir.mockRejectedValue(new Error('EACCES: mkdir'));
+    await expect(invoke('config:set', {})).resolves.toEqual({
+      success: false,
+      error: 'Error: EACCES: mkdir',
+    });
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('reports write errors without returning success', async () => {
+    mocks.writeFile.mockRejectedValue(new Error('ENOSPC'));
+    await expect(invoke('config:set', {})).resolves.toEqual({
+      success: false,
+      error: 'Error: ENOSPC',
+    });
+  });
+
+  it('rejects circular data before writing the settings file', async () => {
+    const config: Record<string, unknown> = {};
+    config.self = config;
+    await expect(invoke('config:set', config)).resolves.toEqual({
+      success: false,
+      error: expect.stringContaining('circular'),
+    });
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('persists null without imposing an IPC configuration schema', async () => {
+    await expect(invoke('config:set', null)).resolves.toEqual({ success: true });
+    expect(mocks.writeFile).toHaveBeenCalledWith(settingsPath, 'null', 'utf-8');
+  });
+
+  it.each([true, false])('reset succeeds when file existence is %s', async (exists) => {
+    mocks.pathExists.mockResolvedValue(exists);
+    await expect(invoke('config:reset')).resolves.toEqual({ success: true });
+    expect(mocks.remove).toHaveBeenCalledTimes(exists ? 1 : 0);
+    if (exists) expect(mocks.remove).toHaveBeenCalledWith(settingsPath);
+  });
+
+  it.each(['pathExists', 'remove'] as const)('reports reset %s failures', async (operation) => {
+    mocks[operation].mockRejectedValue(new Error('EACCES'));
+    await expect(invoke('config:reset')).resolves.toEqual({
+      success: false,
+      error: 'Error: EACCES',
+    });
+    if (operation === 'pathExists') expect(mocks.remove).not.toHaveBeenCalled();
+  });
+});

--- a/electron/history-handlers.test.ts
+++ b/electron/history-handlers.test.ts
@@ -1,0 +1,149 @@
+import * as path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerHistoryHandlers } from './history-handlers';
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  ensureDir: vi.fn(),
+  pathExists: vi.fn(),
+  readJson: vi.fn(),
+  writeJson: vi.fn(),
+}));
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }));
+vi.mock('os', () => ({ homedir: () => 'test-home' }));
+vi.mock('fs-extra', () => mocks);
+vi.mock('./utils/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), error: vi.fn() }),
+}));
+
+function invoke(channel: string, ...args: unknown[]) {
+  const handler = mocks.handle.mock.calls.find(([name]) => name === channel)?.[1];
+  expect(handler).toBeTypeOf('function');
+  return handler({}, ...args);
+}
+
+describe('history IPC persistence', () => {
+  const historyFile = path.join('test-home', '.depssmuggler', 'history.json');
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.ensureDir.mockResolvedValue(undefined);
+    mocks.pathExists.mockResolvedValue(true);
+    mocks.readJson.mockResolvedValue([]);
+    mocks.writeJson.mockResolvedValue(undefined);
+    registerHistoryHandlers();
+  });
+
+  it('initializes a missing history file before loading it', async () => {
+    mocks.pathExists.mockResolvedValue(false);
+    await expect(invoke('history:load')).resolves.toEqual([]);
+    expect(mocks.ensureDir).toHaveBeenCalledWith(path.dirname(historyFile));
+    expect(mocks.writeJson).toHaveBeenCalledWith(historyFile, [], { spaces: 2 });
+    expect(mocks.writeJson.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.readJson.mock.invocationCallOrder[0]
+    );
+    expect(mocks.readJson).toHaveBeenCalledWith(historyFile);
+  });
+
+  it('loads existing histories without overwriting them', async () => {
+    const histories = [{ id: 'latest', packages: ['requests'] }];
+    mocks.readJson.mockResolvedValue(histories);
+    await expect(invoke('history:load')).resolves.toEqual(histories);
+    expect(mocks.writeJson).not.toHaveBeenCalled();
+  });
+
+  it.each(['ensureDir', 'readJson'] as const)(
+    'returns an empty history on %s failure',
+    async (operation) => {
+      mocks[operation].mockRejectedValue(new Error('EACCES'));
+      await expect(invoke('history:load')).resolves.toEqual([]);
+      expect(mocks.writeJson).not.toHaveBeenCalled();
+      if (operation === 'ensureDir') expect(mocks.readJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([{ histories: [] }, { histories: [{ id: 'replacement' }] }])(
+    'save replaces history with $histories',
+    async ({ histories }) => {
+      await expect(invoke('history:save', histories)).resolves.toEqual({ success: true });
+      expect(mocks.writeJson).toHaveBeenCalledWith(historyFile, histories, { spaces: 2 });
+      expect(mocks.readJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it('prepends new records and retains only the latest 100', async () => {
+    const oldHistories = Array.from({ length: 100 }, (_, index) => ({ id: `old-${index}` }));
+    mocks.readJson.mockResolvedValue([...oldHistories]);
+    const newest = { id: 'newest' };
+    await expect(invoke('history:add', newest)).resolves.toEqual({ success: true });
+    expect(mocks.writeJson).toHaveBeenCalledWith(
+      historyFile,
+      [newest, ...oldHistories.slice(0, 99)],
+      { spaces: 2 }
+    );
+  });
+
+  it('adds the first record to empty history', async () => {
+    await invoke('history:add', { id: 'first' });
+    expect(mocks.writeJson).toHaveBeenCalledWith(historyFile, [{ id: 'first' }], { spaces: 2 });
+  });
+
+  it('deletes all matching IDs while preserving remaining record order', async () => {
+    mocks.readJson.mockResolvedValue([
+      { id: 'remove' },
+      { id: 'keep-a' },
+      { id: 'remove' },
+      { id: 'keep-b' },
+    ]);
+    await expect(invoke('history:delete', 'remove')).resolves.toEqual({ success: true });
+    expect(mocks.writeJson).toHaveBeenCalledWith(
+      historyFile,
+      [{ id: 'keep-a' }, { id: 'keep-b' }],
+      { spaces: 2 }
+    );
+  });
+
+  it('deleting an unknown ID retains existing history', async () => {
+    mocks.readJson.mockResolvedValue([{ id: 'keep' }]);
+    await invoke('history:delete', 'missing');
+    expect(mocks.writeJson).toHaveBeenCalledWith(historyFile, [{ id: 'keep' }], { spaces: 2 });
+  });
+
+  it('clear writes an empty list without reading old records', async () => {
+    await expect(invoke('history:clear')).resolves.toEqual({ success: true });
+    expect(mocks.writeJson).toHaveBeenCalledWith(historyFile, [], { spaces: 2 });
+    expect(mocks.readJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['history:save', []],
+    ['history:add', { id: 'new' }],
+    ['history:delete', 'old'],
+    ['history:clear', undefined],
+  ])(
+    '%s propagates initialization permission errors without further IO',
+    async (channel, payload) => {
+      const error = new Error('EACCES: history directory');
+      mocks.ensureDir.mockRejectedValue(error);
+      await expect(invoke(channel as string, payload)).rejects.toBe(error);
+      expect(mocks.pathExists).not.toHaveBeenCalled();
+      expect(mocks.readJson).not.toHaveBeenCalled();
+      expect(mocks.writeJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['history:add', 'history:delete'])(
+    '%s does not overwrite malformed history',
+    async (channel) => {
+      mocks.readJson.mockResolvedValue({ invalid: 'object instead of array' });
+      await expect(invoke(channel, { id: 'new' })).rejects.toBeInstanceOf(TypeError);
+      expect(mocks.writeJson).not.toHaveBeenCalled();
+    }
+  );
+
+  it('propagates write errors from history mutations', async () => {
+    const error = new Error('ENOSPC');
+    mocks.writeJson.mockRejectedValue(error);
+    await expect(invoke('history:save', [])).rejects.toBe(error);
+  });
+});

--- a/electron/services/dependency-resolve-service.test.ts
+++ b/electron/services/dependency-resolve-service.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveAllDependencies } from '../../src/core/shared';
+import { createDependencyResolveService } from './dependency-resolve-service';
+
+vi.mock('../../src/core/shared', () => ({ resolveAllDependencies: vi.fn() }));
+vi.mock('../utils/logger', () => ({ createScopedLogger: () => ({ info: vi.fn() }) }));
+
+describe('dependency resolution service boundary', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('preserves original requests, partial failures and trees while forwarding all resolution options and progress', async () => {
+    const packages = [
+      { id: 'requests', type: 'pip' as const, name: 'requests', version: '2.32.0' },
+    ];
+    const allPackages = [
+      ...packages,
+      { id: 'certifi', type: 'pip' as const, name: 'certifi', version: '2024.1.0' },
+    ];
+    const failedPackages = [{ name: 'missing', error: 'not found' }];
+    const dependencyTrees = [{ package: packages[0], dependencies: [] }];
+    const progress = {
+      current: 1,
+      total: 1,
+      packageName: 'requests',
+      packageType: 'pip',
+      status: 'success' as const,
+    };
+    const options = {
+      includeDependencies: true,
+      targetOS: 'linux',
+      architecture: 'arm64',
+      pythonVersion: '3.12',
+      cudaVersion: null,
+      yumDistribution: { id: 'rocky-9', architecture: 'aarch64' },
+      aptDistribution: { id: 'ubuntu-24.04', architecture: 'arm64' },
+      apkDistribution: { id: 'alpine-3.20', architecture: 'aarch64' },
+      includeRecommends: true,
+    };
+    vi.mocked(resolveAllDependencies).mockImplementation(async (_packages, forwarded) => {
+      forwarded?.onProgress?.(progress);
+      return { originalPackages: [], allPackages, dependencyTrees, failedPackages } as never;
+    });
+    const sender = { send: vi.fn() };
+    const result = await createDependencyResolveService().resolveDependencies(
+      packages,
+      options,
+      sender
+    );
+
+    expect(resolveAllDependencies).toHaveBeenCalledWith(packages, {
+      ...options,
+      onProgress: expect.any(Function),
+    });
+    expect(result).toEqual({
+      originalPackages: packages,
+      allPackages,
+      dependencyTrees,
+      failedPackages,
+    });
+    expect(result.originalPackages).toBe(packages);
+    expect(sender.send).toHaveBeenCalledExactlyOnceWith('dependency:progress', progress);
+  });
+
+  it('accepts an empty request with omitted options and returns empty resolution collections', async () => {
+    vi.mocked(resolveAllDependencies).mockResolvedValue({
+      originalPackages: [],
+      allPackages: [],
+      dependencyTrees: [],
+      failedPackages: [],
+    });
+    const sender = { send: vi.fn() };
+    await expect(
+      createDependencyResolveService().resolveDependencies([], undefined, sender)
+    ).resolves.toEqual({
+      originalPackages: [],
+      allPackages: [],
+      dependencyTrees: [],
+      failedPackages: [],
+    });
+    expect(resolveAllDependencies).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        includeDependencies: undefined,
+        cudaVersion: undefined,
+        onProgress: expect.any(Function),
+      })
+    );
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolver rejection without emitting a fabricated progress event', async () => {
+    const error = new Error('repository unavailable');
+    vi.mocked(resolveAllDependencies).mockRejectedValue(error);
+    const sender = { send: vi.fn() };
+    await expect(createDependencyResolveService().resolveDependencies([], {}, sender)).rejects.toBe(
+      error
+    );
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/download-progress.test.ts
+++ b/electron/services/download-progress.test.ts
@@ -1,0 +1,117 @@
+import type { BrowserWindow } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDownloadProgressEmitter } from './download-progress';
+
+describe('download progress IPC emission', () => {
+  const payload = {
+    sessionId: 4,
+    status: 'downloading',
+    progress: 10,
+    downloadedBytes: 10,
+    totalBytes: 100,
+  };
+  const osProgress = {
+    currentPackage: 'curl',
+    currentIndex: 1,
+    totalPackages: 2,
+    bytesDownloaded: 10,
+    totalBytes: 100,
+    speed: 5,
+    phase: 'downloading' as const,
+  };
+  let send: ReturnType<typeof vi.fn>;
+  let window: BrowserWindow | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    send = vi.fn();
+    window = { webContents: { send } } as unknown as BrowserWindow;
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('throttles each package independently and permits the exact interval boundary', () => {
+    const emitter = createDownloadProgressEmitter(() => window, 1000);
+    emitter.emitPackageProgress('a', payload);
+    emitter.emitPackageProgress('b', payload);
+    vi.advanceTimersByTime(999);
+    emitter.emitPackageProgress('a', { ...payload, progress: 20 });
+    expect(send).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1);
+    emitter.emitPackageProgress('a', { ...payload, progress: 30 });
+    expect(send).toHaveBeenLastCalledWith('download:progress', {
+      packageId: 'a',
+      ...payload,
+      progress: 30,
+    });
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('forced completion bypasses throttling and establishes the next throttle interval', () => {
+    const emitter = createDownloadProgressEmitter(() => window, 1000);
+    emitter.emitPackageProgress('a', payload);
+    vi.advanceTimersByTime(500);
+    emitter.emitPackageProgress('a', { ...payload, status: 'completed', progress: 100 }, true);
+    vi.advanceTimersByTime(500);
+    emitter.emitPackageProgress('a', payload);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenLastCalledWith('download:progress', {
+      packageId: 'a',
+      ...payload,
+      status: 'completed',
+      progress: 100,
+    });
+  });
+
+  it('clears individual and all package throttle state without affecting other packages', () => {
+    const emitter = createDownloadProgressEmitter(() => window);
+    emitter.emitPackageProgress('a', payload);
+    emitter.emitPackageProgress('b', payload);
+    emitter.clearPackageProgress('a');
+    emitter.emitPackageProgress('a', payload);
+    emitter.emitPackageProgress('b', payload);
+    expect(send).toHaveBeenCalledTimes(3);
+    emitter.clearAllPackageProgress();
+    emitter.emitPackageProgress('a', payload);
+    emitter.emitPackageProgress('b', payload);
+    expect(send).toHaveBeenCalledTimes(5);
+  });
+
+  it('uses the current main window and preserves payloads on all unthrottled channels', () => {
+    const emitter = createDownloadProgressEmitter(() => window);
+    const status = { sessionId: 4, phase: 'packaging', message: '압축 중' };
+    const complete = { sessionId: 4, success: false, cancelled: true };
+    const resolve = { message: 'curl', current: 1, total: 2 };
+    emitter.emitDownloadStatus(status);
+    emitter.emitAllComplete(complete);
+    emitter.emitOSProgress(osProgress);
+    emitter.emitOSResolveDependenciesProgress(resolve);
+    expect(send.mock.calls).toEqual([
+      ['download:status', status],
+      ['download:all-complete', complete],
+      ['os:download:progress', osProgress],
+      ['os:resolveDependencies:progress', resolve],
+    ]);
+    const replacementSend = vi.fn();
+    window = { webContents: { send: replacementSend } } as unknown as BrowserWindow;
+    emitter.emitDownloadStatus(status);
+    expect(replacementSend).toHaveBeenCalledWith('download:status', status);
+    expect(send).toHaveBeenCalledTimes(4);
+  });
+
+  it('silently skips delivery when no main window exists', () => {
+    window = null;
+    const emitter = createDownloadProgressEmitter(() => window);
+    expect(() => {
+      emitter.emitDownloadStatus({ phase: 'done', message: '' });
+      emitter.emitPackageProgress('a', payload);
+      emitter.emitAllComplete({});
+      emitter.emitOSProgress(osProgress);
+      emitter.emitOSResolveDependenciesProgress({ message: '', current: 0, total: 0 });
+      emitter.clearPackageProgress('unknown');
+      emitter.clearAllPackageProgress();
+    }).not.toThrow();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/os-download-orchestrator.test.ts
+++ b/electron/services/os-download-orchestrator.test.ts
@@ -1,0 +1,520 @@
+import * as path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DependencyResolutionResult,
+  OSDistribution,
+  OSPackageInfo,
+  Repository,
+} from '../../src/core/downloaders/os-shared/types';
+import { createOSDownloadOrchestrator } from './os-download-orchestrator';
+import type { OSDownloadStartOptions } from './os-package-router';
+
+const mocks = vi.hoisted(() => ({
+  ensureDir: vi.fn(),
+  mkdtemp: vi.fn(),
+  remove: vi.fn(),
+  writeFile: vi.fn(),
+  resolverFactory: vi.fn(),
+  downloaderFactory: vi.fn(),
+  resolve: vi.fn(),
+  download: vi.fn(),
+  archive: vi.fn(),
+  repository: vi.fn(),
+  generateScripts: vi.fn(),
+  osProgress: vi.fn(),
+  resolveProgress: vi.fn(),
+}));
+vi.mock('fs-extra', () => ({
+  ensureDir: mocks.ensureDir,
+  mkdtemp: mocks.mkdtemp,
+  remove: mocks.remove,
+  writeFile: mocks.writeFile,
+}));
+vi.mock('electron', () => ({ dialog: { showMessageBox: vi.fn() } }));
+vi.mock('../utils/logger', () => ({ createScopedLogger: () => ({ info: vi.fn() }) }));
+vi.mock('../../src/core', () => ({
+  getYumResolver: mocks.resolverFactory,
+  getAptResolver: mocks.resolverFactory,
+  getApkResolver: mocks.resolverFactory,
+  getYumDownloader: mocks.downloaderFactory,
+  getAptDownloader: mocks.downloaderFactory,
+  getApkDownloader: mocks.downloaderFactory,
+}));
+vi.mock('../../src/core/downloaders/os-shared/archive-packager', () => ({
+  OSArchivePackager: class {
+    createArchive = mocks.archive;
+  },
+}));
+vi.mock('../../src/core/downloaders/os-shared/repo-packager', () => ({
+  OSRepoPackager: class {
+    createLocalRepo = mocks.repository;
+  },
+}));
+vi.mock('../../src/core/downloaders/os-shared/script-generator', () => ({
+  OSScriptGenerator: class {
+    generateDependencyOrderScript = mocks.generateScripts;
+  },
+}));
+vi.mock('./download-progress', () => ({
+  createDownloadProgressEmitter: () => ({
+    emitOSProgress: mocks.osProgress,
+    emitOSResolveDependenciesProgress: mocks.resolveProgress,
+  }),
+}));
+
+const repo: Repository = {
+  id: 'main',
+  name: 'Main',
+  baseUrl: 'https://packages.invalid',
+  enabled: true,
+  gpgCheck: true,
+  isOfficial: true,
+};
+const distribution: OSDistribution = {
+  id: 'test-apt',
+  name: 'Test Linux',
+  version: '1',
+  packageManager: 'apt',
+  architectures: ['amd64'],
+  defaultRepos: [repo],
+  extendedRepos: [],
+};
+function makePackage(name: string): OSPackageInfo {
+  return {
+    name,
+    version: '1.0',
+    architecture: 'amd64',
+    size: 123,
+    dependencies: [],
+    checksum: { type: 'sha256', value: 'abc' },
+    location: `${name}.deb`,
+    repository: repo,
+  };
+}
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('OS download orchestration', () => {
+  const outputDir = path.resolve('test-output');
+  const stagingDir = path.join(outputDir, '.depssmuggler-os-test');
+  const archivePath = path.join(outputDir, 'os-packages.zip');
+  const repositoryPath = path.join(outputDir, 'repository');
+  const first = makePackage('curl');
+  const second = makePackage('libcurl');
+  const third = makePackage('openssl');
+  const options = (overrides: Partial<OSDownloadStartOptions> = {}): OSDownloadStartOptions => ({
+    packages: [first],
+    distribution,
+    architecture: 'amd64',
+    outputDir,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.ensureDir.mockResolvedValue(undefined);
+    mocks.mkdtemp.mockResolvedValue(stagingDir);
+    mocks.remove.mockResolvedValue(undefined);
+    mocks.writeFile.mockResolvedValue(undefined);
+    mocks.resolverFactory.mockReturnValue({ resolveDependencies: mocks.resolve });
+    mocks.downloaderFactory.mockReturnValue({ downloadPackage: mocks.download });
+    mocks.resolve.mockResolvedValue({
+      packages: [first],
+      warnings: [],
+      unresolved: [],
+      conflicts: [],
+    });
+    mocks.download.mockImplementation(async (pkg: OSPackageInfo) => ({
+      success: true,
+      filePath: path.join(stagingDir, `${pkg.name}.deb`),
+    }));
+    mocks.archive.mockResolvedValue(archivePath);
+    mocks.repository.mockResolvedValue(repositoryPath);
+    mocks.generateScripts.mockReturnValue({ bash: 'install curl', powershell: 'Install-Curl' });
+  });
+
+  it('resolves dependencies with optional flags defaulted off and returns unresolved/conflict details', async () => {
+    const unresolved = [{ name: 'missing' }];
+    const conflicts = [{ package: 'curl', versions: [first, { ...first, version: '2' }] }];
+    mocks.resolve.mockResolvedValue({
+      packages: [first],
+      unresolved,
+      conflicts,
+      warnings: ['warning'],
+    });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(
+      service.resolveDependencies({ packages: [first], distribution, architecture: 'amd64' })
+    ).resolves.toEqual({
+      packages: [first],
+      unresolved,
+      conflicts,
+    });
+    expect(mocks.resolverFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeOptional: false,
+        includeRecommends: false,
+        distribution,
+        architecture: 'amd64',
+      })
+    );
+    expect(mocks.resolve).toHaveBeenCalledWith([first]);
+    expect(mocks.downloaderFactory).not.toHaveBeenCalled();
+  });
+
+  it('accepts an empty package list without downloading or producing final artifacts', async () => {
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(service.startDownload(options({ packages: [] }))).resolves.toMatchObject({
+      success: [],
+      failed: [],
+      skipped: [],
+      generatedOutputs: [],
+      cancelled: false,
+    });
+    expect(mocks.download).not.toHaveBeenCalled();
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.repository).not.toHaveBeenCalled();
+    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(stagingDir);
+  });
+
+  it.each(['ensureDir', 'mkdtemp'] as const)(
+    'stops before downloading when %s fails with a permission error',
+    async (operation) => {
+      const error = new Error('EACCES: output directory');
+      mocks[operation].mockRejectedValue(error);
+      const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+      await expect(service.startDownload(options())).rejects.toBe(error);
+      expect(mocks.downloaderFactory).not.toHaveBeenCalled();
+      expect(mocks.download).not.toHaveBeenCalled();
+      expect(mocks.archive).not.toHaveBeenCalled();
+      expect(mocks.repository).not.toHaveBeenCalled();
+      if (operation === 'ensureDir') expect(mocks.mkdtemp).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not download when resolution leaves unresolved dependencies, while exposing conflicts and warnings', async () => {
+    const unresolved = [{ name: 'missing-lib' }];
+    const conflicts = [{ package: 'curl', versions: [first, { ...first, version: '2' }] }];
+    mocks.resolve.mockResolvedValue({
+      packages: [first, second],
+      warnings: ['repository warning'],
+      unresolved,
+      conflicts,
+    });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(
+      service.startDownload(options({ resolveDependencies: true, includeOptionalDeps: true }))
+    ).resolves.toMatchObject({
+      success: [],
+      generatedOutputs: [],
+      unresolved,
+      conflicts,
+      warnings: ['repository warning'],
+      cancelled: false,
+    });
+    expect(mocks.resolverFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeOptional: true,
+        includeRecommends: true,
+        abortSignal: expect.any(AbortSignal),
+      })
+    );
+    expect(mocks.osProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ currentPackage: '버전 충돌 1건 감지' })
+    );
+    expect(mocks.osProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ currentPackage: '해결되지 않은 의존성 1건' })
+    );
+    expect(mocks.mkdtemp).not.toHaveBeenCalled();
+    expect(mocks.downloaderFactory).not.toHaveBeenCalled();
+    expect(mocks.archive).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolution failures before creating staging files or a downloader', async () => {
+    const error = new Error('corrupt repository metadata');
+    mocks.resolve.mockRejectedValue(error);
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(service.startDownload(options({ resolveDependencies: true }))).rejects.toBe(error);
+    expect(mocks.mkdtemp).not.toHaveBeenCalled();
+    expect(mocks.downloaderFactory).not.toHaveBeenCalled();
+    expect(mocks.archive).not.toHaveBeenCalled();
+  });
+
+  it.each(['resolve', 'reject'] as const)(
+    'cancels during resolution even when the resolver later %ss',
+    async (settlement) => {
+      const started = deferred<void>();
+      const resolution = deferred<DependencyResolutionResult>();
+      mocks.resolve.mockImplementation(() => {
+        started.resolve();
+        return resolution.promise;
+      });
+      const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+      const pending = service.startDownload(options({ resolveDependencies: true }));
+      await started.promise;
+      await expect(service.cancelDownload()).resolves.toEqual({ success: true });
+      expect(mocks.resolverFactory.mock.calls[0][0].abortSignal.aborted).toBe(true);
+      if (settlement === 'resolve')
+        resolution.resolve({ packages: [first], warnings: [], unresolved: [], conflicts: [] });
+      else resolution.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      await expect(pending).resolves.toMatchObject({
+        cancelled: true,
+        success: [],
+        generatedOutputs: [],
+        warnings: ['의존성 해결 단계에서 취소되어 다운로드를 시작하지 않았습니다.'],
+      });
+      expect(mocks.mkdtemp).not.toHaveBeenCalled();
+      expect(mocks.downloaderFactory).not.toHaveBeenCalled();
+      expect(mocks.archive).not.toHaveBeenCalled();
+    }
+  );
+
+  it('downloads resolved packages in order and creates both tar.gz and repository outputs with scripts', async () => {
+    mocks.resolve.mockResolvedValue({
+      packages: [second, first],
+      warnings: ['warning'],
+      unresolved: [],
+      conflicts: [],
+    });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    const outputOptions = {
+      type: 'both' as const,
+      archiveFormat: 'tar.gz' as const,
+      generateScripts: true,
+      scriptTypes: ['dependency-order', 'local-repo'] as const,
+    };
+    const result = await service.startDownload(
+      options({
+        resolveDependencies: true,
+        concurrency: 7,
+        outputOptions: { ...outputOptions, scriptTypes: [...outputOptions.scriptTypes] },
+      })
+    );
+    expect(mocks.download.mock.calls).toEqual([[second], [first]]);
+    expect(mocks.downloaderFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ outputDir: stagingDir, concurrency: 7 })
+    );
+    const downloadedFiles = new Map([
+      ['libcurl-1.0', path.join(stagingDir, 'libcurl.deb')],
+      ['curl-1.0', path.join(stagingDir, 'curl.deb')],
+    ]);
+    expect(mocks.archive).toHaveBeenCalledWith([second, first], downloadedFiles, {
+      format: 'tar.gz',
+      outputPath: path.join(outputDir, 'os-packages'),
+      includeScripts: true,
+      scriptTypes: ['dependency-order', 'local-repo'],
+      packageManager: 'apt',
+      repoName: 'depssmuggler-local',
+    });
+    expect(mocks.repository).toHaveBeenCalledWith([second, first], downloadedFiles, {
+      packageManager: 'apt',
+      outputPath: repositoryPath,
+      repoName: 'depssmuggler-local',
+      includeSetupScript: true,
+    });
+    expect(mocks.writeFile.mock.calls).toEqual([
+      [path.join(repositoryPath, 'install.sh'), 'install curl'],
+      [path.join(repositoryPath, 'install.ps1'), 'Install-Curl'],
+    ]);
+    expect(result).toMatchObject({
+      success: [second, first],
+      failed: [],
+      cancelled: false,
+      warnings: ['warning'],
+      generatedOutputs: [
+        {
+          type: 'archive',
+          path: path.join(outputDir, 'os-packages.tar.gz'),
+          label: '압축 파일 (tar.gz)',
+        },
+        { type: 'repository', path: repositoryPath, label: '로컬 저장소' },
+      ],
+    });
+    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(stagingDir);
+  });
+
+  it('packages only successful downloads and retains failure and skipped details', async () => {
+    mocks.download
+      .mockResolvedValueOnce({ success: true, filePath: path.join(stagingDir, 'curl.deb') })
+      .mockResolvedValueOnce({ success: false, error: new Error('checksum mismatch') })
+      .mockResolvedValueOnce({ success: false, skipped: true });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    const result = await service.startDownload(options({ packages: [first, second, third] }));
+    expect(result).toMatchObject({
+      success: [first],
+      failed: [{ package: second, error: 'checksum mismatch' }],
+      skipped: [third],
+      generatedOutputs: [{ type: 'archive', path: archivePath, label: '압축 파일 (zip)' }],
+      cancelled: false,
+    });
+    expect(mocks.archive).toHaveBeenCalledWith(
+      [first],
+      new Map([['curl-1.0', path.join(stagingDir, 'curl.deb')]]),
+      expect.objectContaining({
+        format: 'zip',
+        includeScripts: true,
+        scriptTypes: ['dependency-order'],
+      })
+    );
+    expect(mocks.downloaderFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ concurrency: 3 })
+    );
+    expect(mocks.repository).not.toHaveBeenCalled();
+    expect(mocks.remove).toHaveBeenCalledWith(stagingDir);
+  });
+
+  it('does not package when all downloads failed, skipped, or returned no file', async () => {
+    mocks.download
+      .mockResolvedValueOnce({ success: false })
+      .mockResolvedValueOnce({ success: false, skipped: true })
+      .mockResolvedValueOnce({ success: true });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(
+      service.startDownload(options({ packages: [first, second, third] }))
+    ).resolves.toMatchObject({
+      success: [],
+      skipped: [second],
+      generatedOutputs: [],
+      failed: [
+        { package: first, error: '다운로드 실패' },
+        { package: third, error: '다운로드 실패' },
+      ],
+    });
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.repository).not.toHaveBeenCalled();
+    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(stagingDir);
+  });
+
+  it('cleans staging files if the downloader rejects unexpectedly', async () => {
+    const error = new Error('disk read failed');
+    mocks.download.mockRejectedValue(error);
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(service.startDownload(options({ packages: [first, second] }))).rejects.toBe(error);
+    expect(mocks.download).toHaveBeenCalledOnce();
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(stagingDir);
+  });
+
+  it('cancels during download, discards prior successes and skips remaining packages without packaging', async () => {
+    const startedSecond = deferred<void>();
+    const secondResult = deferred<{ success: boolean; filePath: string }>();
+    mocks.download
+      .mockResolvedValueOnce({ success: true, filePath: path.join(stagingDir, 'curl.deb') })
+      .mockImplementationOnce(() => {
+        startedSecond.resolve();
+        return secondResult.promise;
+      });
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    const pending = service.startDownload(options({ packages: [first, second, third] }));
+    await startedSecond.promise;
+    await service.cancelDownload();
+    expect(mocks.downloaderFactory.mock.calls[0][0].abortSignal.aborted).toBe(true);
+    secondResult.resolve({ success: true, filePath: path.join(stagingDir, 'libcurl.deb') });
+    await expect(pending).resolves.toMatchObject({
+      success: [],
+      skipped: [second, third],
+      cancelled: true,
+      generatedOutputs: [],
+      warnings: [expect.stringContaining('임시 파일 1개')],
+    });
+    expect(mocks.download).toHaveBeenCalledTimes(2);
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.repository).not.toHaveBeenCalled();
+    expect(mocks.remove).toHaveBeenCalledExactlyOnceWith(stagingDir);
+    // A completed cancellation must not poison the next request.
+    await expect(service.startDownload(options())).resolves.toMatchObject({
+      success: [first],
+      cancelled: false,
+    });
+  });
+
+  it.each(['archive', 'repository', 'script'] as const)(
+    'cleans generated outputs and staging when %s creation fails',
+    async (stage) => {
+      const error = new Error(`EACCES: ${stage}`);
+      if (stage === 'archive') mocks.archive.mockRejectedValue(error);
+      if (stage === 'repository') mocks.repository.mockRejectedValue(error);
+      if (stage === 'script') mocks.writeFile.mockRejectedValue(error);
+      const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+      await expect(
+        service.startDownload(
+          options({
+            outputOptions: {
+              type: 'both',
+              archiveFormat: 'zip',
+              generateScripts: true,
+              scriptTypes: ['dependency-order'],
+            },
+          })
+        )
+      ).rejects.toBe(error);
+      expect(mocks.remove.mock.calls).toEqual(
+        stage === 'archive'
+          ? [[archivePath], [stagingDir]]
+          : [[archivePath], [repositoryPath], [stagingDir]]
+      );
+      if (stage === 'archive') expect(mocks.repository).not.toHaveBeenCalled();
+      if (stage !== 'script') expect(mocks.writeFile).not.toHaveBeenCalled();
+      else expect(mocks.writeFile).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('cleans a cancelled archive and suppresses subsequent repository generation', async () => {
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    mocks.archive.mockImplementation(async () => {
+      await service.cancelDownload();
+      return archivePath;
+    });
+    await expect(
+      service.startDownload(
+        options({
+          outputOptions: {
+            type: 'both',
+            generateScripts: false,
+            scriptTypes: [],
+          },
+        })
+      )
+    ).resolves.toMatchObject({
+      success: [],
+      generatedOutputs: [],
+      cancelled: true,
+      warnings: ['패키징 단계에서 취소되어 생성 중이던 출력물을 정리했습니다.'],
+    });
+    expect(mocks.remove.mock.calls).toEqual([[archivePath], [stagingDir]]);
+    expect(mocks.repository).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('creates repository-only output without setup or install scripts when disabled', async () => {
+    const service = createOSDownloadOrchestrator({ getMainWindow: () => null });
+    await expect(
+      service.startDownload(
+        options({
+          outputOptions: {
+            type: 'repository',
+            generateScripts: false,
+            scriptTypes: ['local-repo', 'dependency-order'],
+          },
+        })
+      )
+    ).resolves.toMatchObject({
+      generatedOutputs: [{ type: 'repository', path: repositoryPath, label: '로컬 저장소' }],
+    });
+    expect(mocks.repository).toHaveBeenCalledWith(
+      [first],
+      expect.any(Map),
+      expect.objectContaining({ includeSetupScript: false })
+    );
+    expect(mocks.archive).not.toHaveBeenCalled();
+    expect(mocks.generateScripts).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/os-package-router.test.ts
+++ b/electron/services/os-package-router.test.ts
@@ -1,0 +1,302 @@
+import * as path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OSDistribution, OSPackageInfo } from '../../src/core/downloaders/os-shared/types';
+import {
+  buildOSDownloadStartResult,
+  cleanupGeneratedOutputs,
+  createOSDownloadErrorHandler,
+  createOSDownloaderForDistribution,
+  createOSResolverForDistribution,
+  DEFAULT_OS_OUTPUT_OPTIONS,
+  writeRepositoryScripts,
+} from './os-package-router';
+
+const mocks = vi.hoisted(() => ({
+  yumDownloader: vi.fn(),
+  aptDownloader: vi.fn(),
+  apkDownloader: vi.fn(),
+  yumResolver: vi.fn(),
+  aptResolver: vi.fn(),
+  apkResolver: vi.fn(),
+  dialog: vi.fn(),
+  writeFile: vi.fn(),
+  remove: vi.fn(),
+  generate: vi.fn(),
+}));
+vi.mock('electron', () => ({ dialog: { showMessageBox: mocks.dialog } }));
+vi.mock('fs-extra', () => ({ writeFile: mocks.writeFile, remove: mocks.remove }));
+vi.mock('../../src/core', () => ({
+  getYumDownloader: mocks.yumDownloader,
+  getAptDownloader: mocks.aptDownloader,
+  getApkDownloader: mocks.apkDownloader,
+  getYumResolver: mocks.yumResolver,
+  getAptResolver: mocks.aptResolver,
+  getApkResolver: mocks.apkResolver,
+}));
+vi.mock('../../src/core/downloaders/os-shared/script-generator', () => ({
+  OSScriptGenerator: class {
+    generateDependencyOrderScript = mocks.generate;
+  },
+}));
+
+const distribution: OSDistribution = {
+  id: 'test',
+  name: 'Test Linux',
+  version: '1',
+  packageManager: 'apt',
+  architectures: ['amd64'],
+  defaultRepos: [],
+  extendedRepos: [],
+};
+const pkg = { name: 'curl', version: '8' } as OSPackageInfo;
+function progressEmitter() {
+  return {
+    emitDownloadStatus: vi.fn(),
+    emitPackageProgress: vi.fn(),
+    clearPackageProgress: vi.fn(),
+    clearAllPackageProgress: vi.fn(),
+    emitAllComplete: vi.fn(),
+    emitOSProgress: vi.fn(),
+    emitOSResolveDependenciesProgress: vi.fn(),
+  };
+}
+
+describe('OS package router boundaries', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.writeFile.mockResolvedValue(undefined);
+    mocks.remove.mockResolvedValue(undefined);
+    mocks.generate.mockReturnValue({ bash: '#!/bin/bash\ninstall', powershell: 'Install-Package' });
+  });
+
+  it.each([
+    { response: 0, action: 'retry', cancelled: false },
+    { response: 1, action: 'skip', cancelled: false },
+    { response: 2, action: 'skip', cancelled: true },
+    { response: -1, action: 'skip', cancelled: true },
+  ])(
+    'maps dialog response $response to $action and cancellation=$cancelled',
+    async ({ response, action, cancelled }) => {
+      mocks.dialog.mockResolvedValue({ response });
+      const onCancel = vi.fn();
+      await expect(
+        createOSDownloadErrorHandler(null, onCancel)({ package: pkg, message: 'checksum mismatch' })
+      ).resolves.toBe(action);
+      expect(mocks.dialog).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          message: expect.stringContaining('curl: checksum mismatch'),
+          buttons: ['재시도', '건너뛰기', '취소'],
+          defaultId: 0,
+          cancelId: 2,
+        })
+      );
+      expect(onCancel).toHaveBeenCalledTimes(cancelled ? 1 : 0);
+    }
+  );
+
+  it('uses a fallback package label and propagates dialog rejection without cancellation', async () => {
+    const error = new Error('window closed');
+    mocks.dialog.mockRejectedValue(error);
+    const onCancel = vi.fn();
+    await expect(
+      createOSDownloadErrorHandler(null, onCancel)({ message: 'network error' })
+    ).rejects.toBe(error);
+    expect(mocks.dialog).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        message: expect.stringContaining('알 수 없는 패키지: network error'),
+      })
+    );
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it.each(['yum', 'apt', 'apk'] as const)(
+    'routes %s resolution with cancellation, dependency options and both progress channels',
+    (manager) => {
+      const resolver = { resolveDependencies: vi.fn() };
+      const factory = mocks[`${manager}Resolver`];
+      factory.mockReturnValue(resolver);
+      const emitter = progressEmitter();
+      const abortSignal = new AbortController().signal;
+      const selectedDistribution = { ...distribution, packageManager: manager };
+      expect(
+        createOSResolverForDistribution({
+          distribution: selectedDistribution,
+          architecture: 'arm64',
+          includeOptional: true,
+          includeRecommends: false,
+          progressEmitter: emitter,
+          abortSignal,
+        })
+      ).toBe(resolver);
+      expect(factory).toHaveBeenCalledWith({
+        distribution: selectedDistribution,
+        repositories: selectedDistribution.defaultRepos,
+        architecture: 'arm64',
+        includeOptional: true,
+        includeRecommends: false,
+        abortSignal,
+        onProgress: expect.any(Function),
+      });
+      factory.mock.calls[0][0].onProgress('resolving curl', 2, 5);
+      expect(emitter.emitOSProgress).toHaveBeenCalledWith({
+        currentPackage: 'resolving curl',
+        currentIndex: 2,
+        totalPackages: 5,
+        bytesDownloaded: 0,
+        totalBytes: 0,
+        speed: 0,
+        phase: 'resolving',
+      });
+      expect(emitter.emitOSResolveDependenciesProgress).toHaveBeenCalledWith({
+        message: 'resolving curl',
+        current: 2,
+        total: 5,
+      });
+      for (const other of ['yum', 'apt', 'apk'] as const) {
+        if (other !== manager) expect(mocks[`${other}Resolver`]).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it.each(['yum', 'apt', 'apk'] as const)(
+    'routes %s downloads with repository and progress/error callbacks',
+    async (manager) => {
+      const downloader = { downloadPackage: vi.fn() };
+      const factory = mocks[`${manager}Downloader`];
+      factory.mockReturnValue(downloader);
+      const emitter = progressEmitter();
+      const abortSignal = new AbortController().signal;
+      const onCancel = vi.fn();
+      const selectedDistribution = { ...distribution, packageManager: manager };
+      expect(
+        createOSDownloaderForDistribution({
+          distribution: selectedDistribution,
+          architecture: 'arm64',
+          outputDir: 'output',
+          concurrency: 5,
+          progressEmitter: emitter,
+          abortSignal,
+          onCancel,
+          mainWindow: null,
+        })
+      ).toBe(downloader);
+      expect(factory).toHaveBeenCalledWith({
+        distribution: selectedDistribution,
+        repositories: selectedDistribution.defaultRepos,
+        architecture: 'arm64',
+        outputDir: 'output',
+        concurrency: 5,
+        abortSignal,
+        onProgress: expect.any(Function),
+        onError: expect.any(Function),
+      });
+      const progress = { currentPackage: 'curl', phase: 'verifying' };
+      factory.mock.calls[0][0].onProgress(progress);
+      expect(emitter.emitOSProgress).toHaveBeenCalledWith(progress);
+      mocks.dialog.mockResolvedValue({ response: 2 });
+      await expect(factory.mock.calls[0][0].onError({ message: 'failure' })).resolves.toBe('skip');
+      expect(onCancel).toHaveBeenCalledOnce();
+      for (const other of ['yum', 'apt', 'apk'] as const) {
+        if (other !== manager) expect(mocks[`${other}Downloader`]).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it('rejects unsupported managers before calling any concrete factory', () => {
+    const options = {
+      distribution: { ...distribution, packageManager: 'pacman' } as unknown as OSDistribution,
+      architecture: 'amd64' as const,
+      includeOptional: false,
+      includeRecommends: false,
+      progressEmitter: progressEmitter(),
+      outputDir: 'out',
+      concurrency: 1,
+      onCancel: vi.fn(),
+      mainWindow: null,
+    };
+    expect(() => createOSResolverForDistribution(options)).toThrow(
+      'Unsupported package manager: pacman'
+    );
+    expect(() => createOSDownloaderForDistribution(options)).toThrow(
+      'Unsupported package manager: pacman'
+    );
+    for (const manager of ['yum', 'apt', 'apk'] as const) {
+      expect(mocks[`${manager}Resolver`]).not.toHaveBeenCalled();
+      expect(mocks[`${manager}Downloader`]).not.toHaveBeenCalled();
+    }
+    expect(mocks.dialog).not.toHaveBeenCalled();
+  });
+
+  it('builds an empty download result with explicit defaults', () => {
+    expect(
+      buildOSDownloadStartResult({
+        outputDir: 'out',
+        distribution,
+        outputOptions: DEFAULT_OS_OUTPUT_OPTIONS,
+      })
+    ).toEqual({
+      success: [],
+      failed: [],
+      skipped: [],
+      outputPath: 'out',
+      packageManager: 'apt',
+      outputOptions: DEFAULT_OS_OUTPUT_OPTIONS,
+      generatedOutputs: [],
+      warnings: [],
+      unresolved: [],
+      conflicts: [],
+      cancelled: false,
+    });
+  });
+
+  it.each(['yum', 'apt', 'apk'] as const)(
+    'writes Bash and PowerShell dependency scripts for %s using its package directory',
+    async (manager) => {
+      await writeRepositoryScripts('repository', [pkg], manager, [
+        'dependency-order',
+        'local-repo',
+      ]);
+      expect(mocks.generate).toHaveBeenCalledWith([pkg], manager, {
+        packageDir: manager === 'yum' ? './Packages' : '.',
+      });
+      expect(mocks.writeFile.mock.calls).toEqual([
+        [path.join('repository', 'install.sh'), '#!/bin/bash\ninstall'],
+        [path.join('repository', 'install.ps1'), 'Install-Package'],
+      ]);
+    }
+  );
+
+  it('does not generate dependency scripts when only local-repo scripts are requested', async () => {
+    await writeRepositoryScripts('repository', [], 'apt', ['local-repo']);
+    expect(mocks.generate).not.toHaveBeenCalled();
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('propagates script permission errors without starting the second script write', async () => {
+    const error = new Error('EACCES');
+    mocks.writeFile.mockRejectedValueOnce(error);
+    await expect(
+      writeRepositoryScripts('repository', [pkg], 'apt', ['dependency-order'])
+    ).rejects.toBe(error);
+    expect(mocks.writeFile).toHaveBeenCalledOnce();
+  });
+
+  it('cleans each generated output and propagates removal errors', async () => {
+    const error = new Error('EACCES');
+    mocks.remove.mockRejectedValueOnce(error);
+    await expect(
+      cleanupGeneratedOutputs([
+        { type: 'archive', path: 'archive.zip', label: 'archive' },
+        { type: 'repository', path: 'repository', label: 'repo' },
+      ])
+    ).rejects.toBe(error);
+    expect(mocks.remove.mock.calls).toEqual([['archive.zip'], ['repository']]);
+  });
+
+  it('accepts cleanup with no generated output', async () => {
+    await expect(cleanupGeneratedOutputs([])).resolves.toBeUndefined();
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/os-search-service.test.ts
+++ b/electron/services/os-search-service.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OSDistribution } from '../../src/core/downloaders/os-shared/types';
+import { createOSSearchService } from './os-search-service';
+
+const mocks = vi.hoisted(() => ({
+  yum: vi.fn(),
+  apt: vi.fn(),
+  apk: vi.fn(),
+  search: vi.fn(),
+  distribution: vi.fn(),
+  byManager: vi.fn(),
+  internet: vi.fn(),
+  invalidate: vi.fn(),
+  distributions: [
+    {
+      id: 'test-apt',
+      name: 'Test Linux',
+      version: '1',
+      packageManager: 'apt',
+      architectures: ['amd64', 'arm64'],
+      defaultRepos: [],
+      extendedRepos: [],
+    },
+  ],
+}));
+vi.mock('../../src/core', () => ({
+  getYumResolver: mocks.yum,
+  getAptResolver: mocks.apt,
+  getApkResolver: mocks.apk,
+}));
+vi.mock('../utils/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../src/core/downloaders/os-shared/repositories', () => ({
+  OS_DISTRIBUTIONS: mocks.distributions,
+  getDistributionById: mocks.distribution,
+  getDistributionsByPackageManager: mocks.byManager,
+}));
+vi.mock('../../src/core/downloaders/os-shared/distribution-fetcher', () => ({
+  getSimplifiedDistributions: mocks.internet,
+  invalidateDistributionCache: mocks.invalidate,
+}));
+
+describe('OS search service', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    for (const resolver of [mocks.yum, mocks.apt, mocks.apk])
+      resolver.mockReturnValue({ searchPackages: mocks.search });
+    mocks.distribution.mockReturnValue(mocks.distributions[0]);
+    mocks.search.mockResolvedValue([]);
+  });
+
+  it('uses internet distributions by default and invalidates the cache only on explicit refresh', async () => {
+    const remote = [{ id: 'remote', name: 'Remote Linux' }];
+    mocks.internet.mockResolvedValue(remote);
+    const service = createOSSearchService();
+    await expect(service.getAllDistributions()).resolves.toBe(remote);
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+    await expect(service.getAllDistributions({ refresh: true })).resolves.toBe(remote);
+    expect(mocks.invalidate).toHaveBeenCalledOnce();
+    expect(mocks.invalidate.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.internet.mock.invocationCallOrder[1]
+    );
+  });
+
+  it.each(['local', 'internet'] as const)(
+    'maps local distributions when source is %s or fetching fails',
+    async (source) => {
+      mocks.internet.mockRejectedValue(new Error('offline'));
+      await expect(
+        createOSSearchService().getAllDistributions({ source, refresh: true })
+      ).resolves.toEqual([
+        {
+          id: 'test-apt',
+          name: 'Test Linux',
+          version: '1',
+          osType: 'linux',
+          packageManager: 'apt',
+          architectures: ['amd64', 'arm64'],
+        },
+      ]);
+      expect(mocks.internet).toHaveBeenCalledTimes(source === 'internet' ? 1 : 0);
+      expect(mocks.invalidate).toHaveBeenCalledTimes(source === 'internet' ? 1 : 0);
+    }
+  );
+
+  it('preserves an empty internet result rather than replacing it with local entries', async () => {
+    mocks.internet.mockResolvedValue([]);
+    await expect(createOSSearchService().getAllDistributions()).resolves.toEqual([]);
+  });
+
+  it('looks up distributions by package manager or ID and preserves unknown lookup results', async () => {
+    mocks.byManager.mockReturnValue(mocks.distributions);
+    const service = createOSSearchService();
+    await expect(service.getDistributions('apt')).resolves.toBe(mocks.distributions);
+    expect(mocks.byManager).toHaveBeenCalledWith('apt');
+    mocks.distribution.mockReturnValue(undefined);
+    await expect(service.getDistribution('missing')).resolves.toBeUndefined();
+    expect(mocks.distribution).toHaveBeenCalledWith('missing');
+  });
+
+  it.each(['yum', 'apt', 'apk'] as const)(
+    'routes %s using canonical distribution metadata and the requested architecture',
+    async (packageManager) => {
+      const distribution = { ...mocks.distributions[0], packageManager } as OSDistribution;
+      mocks.distribution.mockReturnValue(distribution);
+      const latest = {
+        name: 'curl',
+        version: '8.0',
+        architecture: 'arm64',
+        checksum: { value: 'sha' },
+      };
+      mocks.search.mockResolvedValue([{ latest, versions: [latest] }]);
+      await expect(
+        createOSSearchService().searchPackages({
+          query: 'curl',
+          distribution: { id: 'test-apt', packageManager: 'untrusted-input' },
+          architecture: 'arm64',
+          matchType: 'exact',
+        })
+      ).resolves.toEqual({ packages: [latest], totalCount: 1 });
+      expect(mocks[packageManager]).toHaveBeenCalledWith({
+        repositories: distribution.defaultRepos,
+        architecture: 'arm64',
+        distribution,
+        includeOptional: false,
+        includeRecommends: false,
+      });
+      expect(mocks.search).toHaveBeenCalledWith('curl', 'exact');
+      for (const other of ['yum', 'apt', 'apk'] as const) {
+        if (other !== packageManager) expect(mocks[other]).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it.each([undefined, 'partial', 'wildcard'] as const)(
+    'normalizes %s matching to partial and returns empty results',
+    async (matchType) => {
+      await expect(
+        createOSSearchService().searchPackages({
+          query: '',
+          distribution: mocks.distributions[0] as OSDistribution,
+          architecture: 'amd64',
+          matchType,
+        })
+      ).resolves.toEqual({ packages: [], totalCount: 0 });
+      expect(mocks.search).toHaveBeenCalledWith('', 'partial');
+    }
+  );
+
+  it.each([
+    { limit: 1, expectedCount: 1 },
+    { limit: 0, expectedCount: 3 },
+    { limit: 10, expectedCount: 3 },
+  ])('limits to $limit without reducing totalCount', async ({ limit, expectedCount }) => {
+    const packages = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+    mocks.search.mockResolvedValue(packages.map((latest) => ({ latest })));
+    await expect(
+      createOSSearchService().searchPackages({
+        query: 'a',
+        distribution: mocks.distributions[0] as OSDistribution,
+        architecture: 'amd64',
+        limit,
+      })
+    ).resolves.toEqual({ packages: packages.slice(0, expectedCount), totalCount: 3 });
+  });
+
+  it('rejects unknown distribution IDs before creating a resolver', async () => {
+    mocks.distribution.mockReturnValue(undefined);
+    await expect(
+      createOSSearchService().searchPackages({
+        query: 'curl',
+        distribution: { id: 'missing', packageManager: 'apt' },
+        architecture: 'amd64',
+      })
+    ).rejects.toThrow('Unknown distribution: missing');
+    expect(mocks.yum).not.toHaveBeenCalled();
+    expect(mocks.apt).not.toHaveBeenCalled();
+    expect(mocks.apk).not.toHaveBeenCalled();
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported canonical package managers without searching', async () => {
+    mocks.distribution.mockReturnValue({ ...mocks.distributions[0], packageManager: 'pacman' });
+    await expect(
+      createOSSearchService().searchPackages({
+        query: 'curl',
+        distribution: mocks.distributions[0] as OSDistribution,
+        architecture: 'amd64',
+      })
+    ).rejects.toThrow('Unsupported package manager: pacman');
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolver errors rather than reporting an empty successful search', async () => {
+    const error = new Error('repository metadata unavailable');
+    mocks.search.mockRejectedValue(error);
+    await expect(
+      createOSSearchService().searchPackages({
+        query: 'curl',
+        distribution: mocks.distributions[0] as OSDistribution,
+        architecture: 'amd64',
+      })
+    ).rejects.toBe(error);
+  });
+});

--- a/electron/version-handlers.test.ts
+++ b/electron/version-handlers.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  python: vi.fn(),
+  cuda: vi.fn(),
+  preload: vi.fn(),
+  refresh: vi.fn(),
+  isValid: vi.fn(),
+  age: vi.fn(),
+}));
+vi.mock('electron', () => ({ ipcMain: { handle: mocks.handle } }));
+vi.mock('./utils/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../src/core/shared/version-fetcher', () => ({
+  fetchPythonVersions: mocks.python,
+  fetchCudaVersions: mocks.cuda,
+}));
+vi.mock('../src/core/shared/version-preloader', () => ({
+  preloadAllVersions: mocks.preload,
+  refreshExpiredCaches: mocks.refresh,
+  isCacheValid: mocks.isValid,
+  getCacheAge: mocks.age,
+}));
+
+function invoke(channel: string) {
+  const handler = mocks.handle.mock.calls.find(([name]) => name === channel)?.[1];
+  expect(handler).toBeTypeOf('function');
+  return handler({});
+}
+
+async function register() {
+  const { registerVersionHandlers } = await import('./version-handlers');
+  registerVersionHandlers();
+  // Settle the two background preloads before testing explicit IPC requests.
+  await Promise.allSettled([mocks.python.mock.results[0].value, mocks.cuda.mock.results[0].value]);
+}
+
+describe('version IPC caches', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    mocks.python.mockResolvedValue([]);
+    mocks.cuda.mockResolvedValue([]);
+  });
+
+  it('preloads Python and CUDA and serves repeated requests from memory', async () => {
+    mocks.python.mockResolvedValue(['3.14', '3.13']);
+    mocks.cuda.mockResolvedValue(['13.0', '12.6']);
+    await register();
+    for (let index = 0; index < 2; index++) {
+      await expect(invoke('versions:python')).resolves.toEqual(['3.14', '3.13']);
+      await expect(invoke('versions:cuda')).resolves.toEqual(['13.0', '12.6']);
+    }
+    expect(mocks.python).toHaveBeenCalledOnce();
+    expect(mocks.cuda).toHaveBeenCalledOnce();
+  });
+
+  it.each(['python', 'cuda'] as const)(
+    'retries empty %s preload results and caches the first nonempty response',
+    async (kind) => {
+      await register();
+      await expect(invoke(`versions:${kind}`)).resolves.toEqual([]);
+      mocks[kind].mockResolvedValue(['next-version']);
+      await expect(invoke(`versions:${kind}`)).resolves.toEqual(['next-version']);
+      await expect(invoke(`versions:${kind}`)).resolves.toEqual(['next-version']);
+      expect(mocks[kind]).toHaveBeenCalledTimes(3);
+    }
+  );
+
+  it.each([
+    ['python', ['3.13', '3.12', '3.11', '3.10', '3.9']],
+    ['cuda', ['12.6', '12.5', '12.4', '12.1', '12.0', '11.8']],
+  ] as const)(
+    'returns the %s fallback after preload/request failures and retries later',
+    async (kind, fallback) => {
+      mocks[kind].mockRejectedValue('offline');
+      await register();
+      await expect(invoke(`versions:${kind}`)).resolves.toEqual(fallback);
+      mocks[kind].mockResolvedValue(['recovered']);
+      await expect(invoke(`versions:${kind}`)).resolves.toEqual(['recovered']);
+      expect(mocks[kind]).toHaveBeenCalledTimes(3);
+    }
+  );
+
+  it('reports validity and age independently for both version caches', async () => {
+    mocks.isValid.mockImplementation((kind) => kind === 'python');
+    mocks.age.mockImplementation((kind) => (kind === 'python' ? 0 : undefined));
+    await register();
+    expect(invoke('versions:cache-status')).toEqual({
+      python: { valid: true, age: 0 },
+      cuda: { valid: false, age: undefined },
+    });
+    expect(mocks.isValid.mock.calls).toEqual([['python'], ['cuda']]);
+    expect(mocks.age.mock.calls).toEqual([['python'], ['cuda']]);
+  });
+
+  it('returns manual preload results and awaits expired-cache refresh', async () => {
+    const preloadResult = { python: true, cuda: false, errors: ['CUDA unavailable'] };
+    mocks.preload.mockResolvedValue(preloadResult);
+    mocks.refresh.mockResolvedValue(undefined);
+    await register();
+    await expect(invoke('versions:preload')).resolves.toBe(preloadResult);
+    await expect(invoke('versions:refresh-expired')).resolves.toBeUndefined();
+    expect(mocks.preload).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['versions:preload', 'preload'],
+    ['versions:refresh-expired', 'refresh'],
+  ] as const)('%s propagates service failures to its caller', async (channel, mockName) => {
+    const error = new Error('cache permission denied');
+    mocks[mockName].mockRejectedValue(error);
+    await register();
+    await expect(invoke(channel)).rejects.toBe(error);
+  });
+});

--- a/src/cli/commands/cache.test.ts
+++ b/src/cli/commands/cache.test.ts
@@ -1,0 +1,170 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cacheClear, cacheList, cacheSize } from './cache';
+
+const prompt = vi.hoisted(() => ({ createInterface: vi.fn(), question: vi.fn(), close: vi.fn() }));
+const pathExists = vi.hoisted(() => vi.fn<(target: string) => Promise<boolean>>());
+vi.mock('readline', () => ({ createInterface: prompt.createInterface }));
+vi.mock('fs-extra', () => ({
+  pathExists,
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  readJson: vi.fn(),
+  remove: vi.fn(),
+}));
+vi.mock('../../core/config', () => ({
+  getConfigManager: () => ({ getConfig: () => ({ cachePath: 'test-cache', maxCacheSize: 4096 }) }),
+}));
+
+const failure = (code: string) => Object.assign(new Error(`${code}: cache denied`), { code });
+const fileStat = (size: number, directory = false) => ({
+  size,
+  isDirectory: () => directory,
+  mtime: new Date('2026-01-01T00:00:00Z'),
+});
+const output = () => vi.mocked(console.log).mock.calls.flat().join('\n');
+const errors = () => vi.mocked(console.error).mock.calls.flat().join('\n');
+
+describe('CLI 캐시 명령', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    pathExists.mockResolvedValue(true);
+    vi.mocked(fs.readdir).mockResolvedValue([] as never);
+    prompt.createInterface.mockReturnValue(prompt);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('하위 디렉토리까지 합산하여 크기와 사용률을 출력한다', async () => {
+    vi.mocked(fs.readdir).mockImplementation(
+      async (dir) =>
+        (String(dir) === 'test-cache' ? ['direct.whl', 'nested'] : ['dependency.whl']) as never
+    );
+    vi.mocked(fs.stat).mockImplementation(
+      async (target) =>
+        fileStat(
+          String(target).endsWith('direct.whl') ? 1024 : 1024,
+          String(target).endsWith('nested')
+        ) as never
+    );
+    await cacheSize();
+    expect(output()).toContain('크기: 2 KB');
+    expect(output()).toContain('최대 크기: 4 KB');
+    expect(output()).toContain('사용률: 50.0%');
+    expect(fs.stat).toHaveBeenCalledWith(path.join('test-cache', 'nested', 'dependency.whl'));
+  });
+
+  it('캐시가 없으면 0바이트를 출력한다', async () => {
+    pathExists.mockResolvedValue(false);
+    await cacheSize();
+    expect(output()).toContain('크기: 0 B');
+    expect(output()).toContain('사용률: 0.0%');
+    expect(fs.readdir).not.toHaveBeenCalled();
+  });
+
+  it.each(['EACCES', 'EPERM'])('크기 조회 권한 오류를 출력한다: %s', async (code) => {
+    vi.mocked(fs.readdir).mockRejectedValue(failure(code));
+    await cacheSize();
+    expect(errors()).toContain(`캐시 크기 확인 실패: ${code}`);
+    expect(output()).not.toContain('사용률');
+  });
+
+  it('조회 중 디렉토리가 사라지면 없음 안내를 표시한다', async () => {
+    vi.mocked(fs.readdir).mockRejectedValue(failure('ENOENT'));
+    await cacheSize();
+    expect(output()).toContain('캐시 디렉토리가 존재하지 않습니다');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it.each(['', 'n', 'no', 'unexpected'])(
+    '삭제 확인에서 %j를 입력하면 파일을 조회하거나 삭제하지 않는다',
+    async (answer) => {
+      prompt.question.mockImplementation((_question, respond) => respond(answer));
+      await cacheClear({});
+      expect(prompt.close).toHaveBeenCalledOnce();
+      expect(fs.pathExists).not.toHaveBeenCalled();
+      expect(fs.remove).not.toHaveBeenCalled();
+      expect(output()).toContain('캐시 삭제가 취소되었습니다');
+    }
+  );
+
+  it.each(['y', 'Y', 'yes', 'YES'])('삭제 확인 %j를 받으면 캐시만 삭제한다', async (answer) => {
+    prompt.question.mockImplementation((_question, respond) => respond(answer));
+    await cacheClear({});
+    expect(prompt.close).toHaveBeenCalledOnce();
+    expect(fs.remove).toHaveBeenCalledExactlyOnceWith('test-cache');
+    expect(output()).toContain('캐시가 삭제되었습니다');
+  });
+
+  it('강제 삭제는 입력을 기다리지 않는다', async () => {
+    await cacheClear({ force: true });
+    expect(prompt.createInterface).not.toHaveBeenCalled();
+    expect(fs.remove).toHaveBeenCalledExactlyOnceWith('test-cache');
+  });
+
+  it('캐시 크기 조회 실패 후 삭제를 진행하지 않는다', async () => {
+    vi.mocked(fs.readdir).mockRejectedValue(failure('EACCES'));
+    await cacheClear({ force: true });
+    expect(fs.remove).not.toHaveBeenCalled();
+    expect(errors()).toContain('캐시 삭제 실패: EACCES');
+  });
+
+  it('삭제 권한 거부를 실패로 출력한다', async () => {
+    vi.mocked(fs.remove).mockRejectedValue(failure('EPERM'));
+    await cacheClear({ force: true });
+    expect(errors()).toContain('캐시 삭제 실패: EPERM');
+    expect(output()).not.toContain('삭제되었습니다');
+  });
+
+  it('삭제 직전 디렉토리가 사라지면 삭제할 캐시가 없음을 알린다', async () => {
+    vi.mocked(fs.remove).mockRejectedValue(failure('ENOENT'));
+    await cacheClear({ force: true });
+    expect(output()).toContain('삭제할 캐시가 없습니다');
+  });
+
+  it.each([true, false])('비어 있거나 없는 캐시 목록을 안내한다 (존재=%s)', async (exists) => {
+    pathExists.mockResolvedValue(exists);
+    await cacheList();
+    expect(output()).toContain('캐시된 패키지가 없습니다');
+    expect(fs.readJson).not.toHaveBeenCalled();
+  });
+
+  it('매니페스트가 있는 항목과 손상된 항목을 함께 표시한다', async () => {
+    vi.mocked(fs.readdir).mockImplementation(
+      async (dir) => (String(dir) === 'test-cache' ? ['valid', 'broken'] : []) as never
+    );
+    vi.mocked(fs.stat).mockResolvedValue(fileStat(0, true) as never);
+    vi.mocked(fs.readJson).mockImplementation(async (target) => {
+      if (String(target).includes('broken')) throw new SyntaxError('invalid JSON');
+      return { name: 'requests', version: '2.32.0', type: 'pip' };
+    });
+    await cacheList();
+    expect(output()).toContain('requests');
+    expect(output()).toContain('2.32.0');
+    expect(output()).toContain('broken');
+    expect(output()).toContain('총 2개 패키지');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('빈 매니페스트의 이름과 버전은 대체값을 표시한다', async () => {
+    vi.mocked(fs.readdir).mockImplementation(
+      async (dir) => (String(dir) === 'test-cache' ? ['unnamed-cache'] : []) as never
+    );
+    vi.mocked(fs.readJson).mockResolvedValue({});
+    vi.mocked(fs.stat).mockResolvedValue(fileStat(0, true) as never);
+    await cacheList();
+    expect(output()).toContain('unnamed-cache');
+    expect(output()).toContain('0 B');
+    expect(output()).toContain('총 1개 패키지');
+  });
+
+  it('목록 읽기 권한이 없으면 오류만 표시한다', async () => {
+    vi.mocked(fs.readdir).mockRejectedValue(failure('EACCES'));
+    await cacheList();
+    expect(errors()).toContain('캐시 목록 조회 실패: EACCES');
+    expect(fs.readJson).not.toHaveBeenCalled();
+    expect(output()).not.toContain('총');
+  });
+});

--- a/src/cli/commands/config.test.ts
+++ b/src/cli/commands/config.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { configGet, configList, configReset, configSet } from './config';
+
+const manager = vi.hoisted(() => ({ getConfig: vi.fn(), set: vi.fn(), reset: vi.fn() }));
+vi.mock('../../core/config', () => ({ getConfigManager: () => manager }));
+
+describe('CLI 설정 명령', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    manager.getConfig.mockReturnValue({ concurrentDownloads: 5, cacheEnabled: false });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('키를 생략하면 전체 설정 JSON을 출력한다', async () => {
+    await configGet();
+    expect(console.log).toHaveBeenCalledWith(JSON.stringify(manager.getConfig(), null, 2));
+  });
+
+  it('false와 0인 설정도 존재하는 값으로 출력한다', async () => {
+    manager.getConfig.mockReturnValue({ cacheEnabled: false, maxCacheSize: 0 });
+    await configGet('cacheEnabled');
+    await configGet('maxCacheSize');
+    const output = vi.mocked(console.log).mock.calls.flat().join('\n');
+    expect(output).toContain('false');
+    expect(output).toContain('0');
+    expect(output).not.toContain('찾을 수 없습니다');
+  });
+
+  it('알 수 없는 키는 조회 실패 안내를 출력하고 설정을 바꾸지 않는다', async () => {
+    await configGet('unknown');
+    expect(vi.mocked(console.log).mock.calls.flat().join('\n')).toContain(
+      "설정 'unknown'를 찾을 수 없습니다"
+    );
+    expect(manager.set).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['cacheEnabled', 'true', true],
+    ['cacheEnabled', 'false', false],
+    ['concurrentDownloads', '5', 5],
+    ['maxCacheSize', '0', 0],
+    ['cachePath', '/tmp/package-cache', '/tmp/package-cache'],
+    ['logLevel', 'debug', 'debug'],
+  ])('%s=%s를 기존 CLI 변환 규칙으로 저장한다', async (key, input, expected) => {
+    await configSet(key, input as string);
+    expect(manager.set).toHaveBeenCalledExactlyOnceWith(key, expected);
+    expect(vi.mocked(console.log).mock.calls.flat().join('\n')).toContain('설정이 저장되었습니다');
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it.each(['EACCES: permission denied', '유효하지 않은 설정 키'])(
+    '저장 오류를 출력하고 실패 코드로 종료한다: %s',
+    async (message) => {
+      manager.set.mockImplementation(() => {
+        throw new Error(message);
+      });
+      await expect(configSet('cachePath', '/restricted')).rejects.toThrow('process.exit');
+      expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toContain(
+        `설정 저장 실패: ${message}`
+      );
+      expect(process.exit).toHaveBeenCalledExactlyOnceWith(1);
+      expect(console.log).not.toHaveBeenCalled();
+    }
+  );
+
+  it('설정 목록에서 기본 설명과 확장 설정을 표시한다', async () => {
+    manager.getConfig.mockReturnValue({
+      concurrentDownloads: 5,
+      custom: 'value',
+      nested: { enabled: true },
+    });
+    await configList();
+    const output = vi.mocked(console.log).mock.calls.flat().join('\n');
+    expect(output).toContain('동시 다운로드 수');
+    expect(output).toContain('custom');
+    expect(output).toContain('value');
+    expect(output).toContain('{"enabled":true}');
+  });
+
+  it('빈 설정 목록도 헤더와 함께 출력한다', async () => {
+    manager.getConfig.mockReturnValue({});
+    await expect(configList()).resolves.toBeUndefined();
+    expect(vi.mocked(console.log).mock.calls.flat().join('\n')).toContain('설정 목록');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('기본값 초기화가 성공하면 성공 안내를 표시한다', async () => {
+    await configReset();
+    expect(manager.reset).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.log).mock.calls.flat().join('\n')).toContain(
+      '설정이 초기화되었습니다'
+    );
+  });
+
+  it('초기화 권한 오류는 성공으로 표시하지 않는다', async () => {
+    manager.reset.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    await expect(configReset()).rejects.toThrow('process.exit');
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toContain(
+      '설정 초기화 실패: EACCES'
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/downloaders/docker-auth.test.ts
+++ b/src/core/downloaders/docker-auth.test.ts
@@ -1,0 +1,278 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DockerAuthClient } from './docker-auth-client';
+import {
+  AuthStrategyRegistry,
+  CustomRegistryAuthStrategy,
+  DockerHubAuthStrategy,
+  ECRAuthStrategy,
+  GHCRAuthStrategy,
+  QuayAuthStrategy,
+  defaultAuthStrategyRegistry,
+  type RegistryAuthStrategy,
+} from './docker-auth-strategies';
+import { REGISTRY_CONFIGS, createCustomRegistryConfig, type RegistryType } from './docker-utils';
+
+vi.mock('axios', () => ({ default: { get: vi.fn() } }));
+vi.mock('../../utils/logger', () => ({ default: { error: vi.fn(), debug: vi.fn() } }));
+
+const get = vi.mocked(axios.get);
+
+beforeEach(() => vi.resetAllMocks());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('Docker registry authentication strategies', () => {
+  const providers = [
+    {
+      type: 'docker.io',
+      strategy: new DockerHubAuthStrategy(),
+      config: REGISTRY_CONFIGS['docker.io'],
+      url: 'https://auth.docker.io/token',
+    },
+    {
+      type: 'ghcr.io',
+      strategy: new GHCRAuthStrategy(),
+      config: REGISTRY_CONFIGS['ghcr.io'],
+      url: 'https://ghcr.io/token',
+    },
+    {
+      type: 'ecr',
+      strategy: new ECRAuthStrategy(),
+      config: REGISTRY_CONFIGS.ecr,
+      url: 'https://public.ecr.aws/token',
+    },
+    {
+      type: 'custom',
+      strategy: new CustomRegistryAuthStrategy(),
+      config: createCustomRegistryConfig('registry.example.test'),
+      url: 'https://registry.example.test/v2/auth',
+    },
+  ] as const;
+
+  it.each(providers)(
+    '$type requests a pull-scoped token using its provider endpoint',
+    async ({ strategy, config, url, type }) => {
+      get.mockResolvedValue({ data: { token: 'pull-token', expires_in: 900 } });
+
+      await expect(strategy.getToken(config, 'team/image')).resolves.toEqual({
+        token: 'pull-token',
+        expiresIn: 900,
+      });
+      expect(get).toHaveBeenCalledExactlyOnceWith(url, {
+        params: { service: config.service, scope: 'repository:team/image:pull' },
+      });
+      expect(strategy.isApplicable(type)).toBe(true);
+      expect(strategy.isApplicable('quay.io')).toBe(false);
+    }
+  );
+
+  it.each(providers)(
+    '$type uses an unscoped catalog request and default token lifetime',
+    async ({ strategy, config }) => {
+      get.mockResolvedValue({ data: { token: 'catalog-token' } });
+
+      await expect(strategy.getToken(config, '')).resolves.toEqual({
+        token: 'catalog-token',
+        expiresIn: 300,
+      });
+      expect(get).toHaveBeenCalledWith(expect.any(String), {
+        params: { service: config.service, scope: '' },
+      });
+    }
+  );
+
+  it.each(providers.slice(0, 3))(
+    '$type propagates authentication rejection',
+    async ({ strategy, config }) => {
+      const denied = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+      get.mockRejectedValue(denied);
+
+      await expect(strategy.getToken(config, 'team/private')).rejects.toBe(denied);
+      expect(get).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('custom registries allow an anonymous fallback when token retrieval fails', async () => {
+    get.mockRejectedValue(new Error('token endpoint unavailable'));
+
+    await expect(
+      new CustomRegistryAuthStrategy().getToken(
+        createCustomRegistryConfig('registry.example.test'),
+        'public/image'
+      )
+    ).resolves.toEqual({ token: '', expiresIn: 300 });
+  });
+
+  it('Quay discovers the token realm and service from a 401 challenge', async () => {
+    get
+      .mockResolvedValueOnce({
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://auth.example.test/token",service="challenge-service"',
+        },
+      })
+      .mockResolvedValueOnce({ data: { token: 'quay-token', expires_in: 600 } });
+    const strategy = new QuayAuthStrategy();
+
+    await expect(strategy.getToken(REGISTRY_CONFIGS['quay.io'], 'org/image')).resolves.toEqual({
+      token: 'quay-token',
+      expiresIn: 600,
+    });
+    const challengeOptions = get.mock.calls[0][1]!;
+    expect(get.mock.calls[0][0]).toBe('https://quay.io/v2/');
+    expect(challengeOptions.validateStatus!(401)).toBe(true);
+    expect(challengeOptions.validateStatus!(200)).toBe(false);
+    expect(get).toHaveBeenLastCalledWith('https://auth.example.test/token', {
+      params: { service: 'challenge-service', scope: 'repository:org/image:pull' },
+    });
+    expect(strategy.isApplicable('quay.io')).toBe(true);
+    expect(strategy.isApplicable('custom')).toBe(false);
+  });
+
+  it('Quay uses its configured service and default lifetime when the challenge omits them', async () => {
+    get
+      .mockResolvedValueOnce({
+        headers: { 'www-authenticate': 'Bearer realm="https://auth.example.test/token"' },
+      })
+      .mockResolvedValueOnce({ data: { token: 'catalog-token' } });
+
+    await expect(new QuayAuthStrategy().getToken(REGISTRY_CONFIGS['quay.io'], '')).resolves.toEqual(
+      { token: 'catalog-token', expiresIn: 300 }
+    );
+    expect(get).toHaveBeenLastCalledWith('https://auth.example.test/token', {
+      params: { service: 'quay.io', scope: '' },
+    });
+  });
+
+  it.each([{}, { 'www-authenticate': 'Basic service="quay.io"' }])(
+    'Quay falls back to anonymous access without a bearer realm: %j',
+    async (headers) => {
+      get.mockResolvedValue({ headers });
+      await expect(
+        new QuayAuthStrategy().getToken(REGISTRY_CONFIGS['quay.io'], 'public/image')
+      ).resolves.toEqual({ token: '', expiresIn: 300 });
+      expect(get).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it.each(['challenge', 'token'])(
+    'Quay falls back to anonymous access after a failed %s request',
+    async (stage) => {
+      if (stage === 'token') {
+        get.mockResolvedValueOnce({
+          headers: { 'www-authenticate': 'Bearer realm="https://auth.example.test/token"' },
+        });
+      }
+      get.mockRejectedValue(new Error('Access denied'));
+
+      await expect(
+        new QuayAuthStrategy().getToken(REGISTRY_CONFIGS['quay.io'], 'public/image')
+      ).resolves.toEqual({ token: '', expiresIn: 300 });
+      expect(get).toHaveBeenCalledTimes(stage === 'token' ? 2 : 1);
+    }
+  );
+
+  it('selects each built-in strategy and gives newly registered strategies priority', () => {
+    const registry = new AuthStrategyRegistry();
+    for (const type of ['docker.io', 'ghcr.io', 'ecr', 'quay.io', 'custom'] as RegistryType[]) {
+      expect(registry.getStrategy(type).isApplicable(type)).toBe(true);
+    }
+    const override: RegistryAuthStrategy = {
+      isApplicable: (type) => type === 'docker.io',
+      getToken: vi.fn(),
+    };
+    registry.registerStrategy(override);
+
+    expect(registry.getStrategy('docker.io')).toBe(override);
+    expect(registry.getStrategies()[0]).toBe(override);
+    expect(defaultAuthStrategyRegistry.getStrategies()).not.toContain(override);
+    expect(() => new AuthStrategyRegistry([]).getStrategy('custom')).toThrow(
+      'No auth strategy found for registry type: custom'
+    );
+  });
+});
+
+describe('DockerAuthClient token lifecycle', () => {
+  function setup() {
+    const getToken = vi
+      .fn<RegistryAuthStrategy['getToken']>()
+      .mockResolvedValue({ token: 'cached-token', expiresIn: 300 });
+    const registry = new AuthStrategyRegistry([{ isApplicable: () => true, getToken }]);
+    return { client: new DockerAuthClient(registry), registry, getToken };
+  }
+
+  it('reuses tokens until the refresh-buffer boundary, then obtains a fresh token', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const { client, getToken } = setup();
+    await expect(client.getToken('library/nginx')).resolves.toBe('cached-token');
+    vi.advanceTimersByTime(239_999);
+    await expect(client.getToken('library/nginx')).resolves.toBe('cached-token');
+    expect(getToken).toHaveBeenCalledTimes(1);
+
+    getToken.mockResolvedValueOnce({ token: 'refreshed-token', expiresIn: 300 });
+    vi.advanceTimersByTime(1);
+    await expect(client.getToken('library/nginx')).resolves.toBe('refreshed-token');
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(getToken).toHaveBeenLastCalledWith(REGISTRY_CONFIGS['docker.io'], 'library/nginx');
+  });
+
+  it('separates repositories and registries and invalidates only the requested registry', async () => {
+    const { client, getToken } = setup();
+    await client.getTokenForRegistry('docker.io', 'team/one');
+    await client.getTokenForRegistry('docker.io', 'team/two');
+    await client.getTokenForRegistry('ghcr.io', 'team/one');
+    client.clearTokenCacheForRegistry('docker.io');
+    await client.getTokenForRegistry('ghcr.io', 'team/one');
+    expect(getToken).toHaveBeenCalledTimes(3);
+
+    await client.getTokenForRegistry('docker.io', 'team/one');
+    await client.getTokenForRegistry('docker.io', 'team/two');
+    expect(getToken).toHaveBeenCalledTimes(5);
+    client.clearTokenCache();
+    await client.getTokenForRegistry('ghcr.io', 'team/one');
+    expect(getToken).toHaveBeenCalledTimes(6);
+  });
+
+  it('caches anonymous tokens and immediately refreshes tokens shorter than the buffer', async () => {
+    const { client, getToken } = setup();
+    getToken.mockResolvedValue({ token: '', expiresIn: 300 });
+    await client.getToken('library/nginx');
+    await expect(client.getToken('library/nginx')).resolves.toBe('');
+    expect(getToken).toHaveBeenCalledTimes(1);
+
+    client.clearTokenCache();
+    getToken.mockResolvedValue({ token: 'short-lived', expiresIn: 30 });
+    await client.getToken('library/nginx');
+    await client.getToken('library/nginx');
+    expect(getToken).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves the original auth failure and retries a later call without caching it', async () => {
+    const { client, getToken } = setup();
+    const denied = new Error('forbidden');
+    getToken.mockRejectedValueOnce(denied);
+    await expect(client.getToken('library/nginx')).rejects.toBe(denied);
+    await expect(client.getToken('library/nginx')).resolves.toBe('cached-token');
+    expect(getToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes custom registry URLs, reuses configurations, and rejects malformed URLs', async () => {
+    const { client, registry, getToken } = setup();
+    const config = client.getRegistryConfig('http://localhost:5000/v2/');
+    expect(config).toEqual({
+      authUrl: 'http://localhost:5000/v2/auth',
+      registryUrl: 'http://localhost:5000/v2',
+      service: 'localhost',
+    });
+    expect(client.getRegistryConfig('http://localhost:5000/v2/')).toBe(config);
+    expect(client.getRegistryConfig('registry-1.docker.io')).toBe(REGISTRY_CONFIGS['docker.io']);
+    expect(client.getStrategyRegistry()).toBe(registry);
+    expect(new DockerAuthClient().getStrategyRegistry()).toBe(defaultAuthStrategyRegistry);
+    await expect(client.getTokenForRegistry('http://[invalid', 'image')).rejects.toThrow();
+    expect(getToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/downloaders/docker-blob-downloader.test.ts
+++ b/src/core/downloaders/docker-blob-downloader.test.ts
@@ -1,0 +1,268 @@
+import axios from 'axios';
+import { PassThrough, Readable, Writable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DockerAuthClient } from './docker-auth-client';
+import { DockerBlobDownloader } from './docker-blob-downloader';
+
+const io = vi.hoisted(() => ({
+  createWriteStream: vi.fn(),
+  remove: vi.fn(),
+  readdir: vi.fn(),
+  createTar: vi.fn(),
+  checksum: vi.fn(),
+}));
+vi.mock('axios', () => ({ default: vi.fn() }));
+vi.mock('fs', () => ({ createWriteStream: io.createWriteStream }));
+vi.mock('fs-extra', () => ({ remove: io.remove, readdir: io.readdir }));
+vi.mock('tar', () => ({ create: io.createTar }));
+vi.mock('./docker-utils', async () => ({
+  ...(await vi.importActual<typeof import('./docker-utils')>('./docker-utils')),
+  calculateSha256: io.checksum,
+}));
+vi.mock('../../utils/logger', () => ({ default: { error: vi.fn(), debug: vi.fn() } }));
+
+describe('DockerBlobDownloader', () => {
+  let downloader: DockerBlobDownloader;
+  const streams: Array<Readable | Writable> = [];
+  const request = vi.mocked(axios);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    downloader = new DockerBlobDownloader(new DockerAuthClient());
+    io.checksum.mockResolvedValue('abc123');
+    io.remove.mockResolvedValue(undefined);
+    io.createTar.mockResolvedValue(undefined);
+    io.createWriteStream.mockImplementation(() => {
+      const writer = new PassThrough();
+      streams.push(writer);
+      return writer;
+    });
+  });
+  afterEach(() => {
+    for (const stream of streams.splice(0)) stream.destroy();
+    vi.restoreAllMocks();
+  });
+
+  function response(chunks = [Buffer.from('abc'), Buffer.from('12345')]) {
+    const source = Readable.from(chunks);
+    streams.push(source);
+    request.mockResolvedValue({ data: source });
+    return source;
+  }
+
+  it('streams an authenticated blob, reports byte deltas, and verifies the completed file', async () => {
+    response();
+    const progress = vi.fn();
+    await downloader.downloadBlob(
+      'team/image',
+      'sha256:abc123',
+      '/download/layer.tar',
+      'pull-token',
+      'ghcr.io',
+      progress
+    );
+
+    expect(request).toHaveBeenCalledExactlyOnceWith({
+      method: 'GET',
+      url: 'https://ghcr.io/v2/team/image/blobs/sha256:abc123',
+      responseType: 'stream',
+      headers: { Authorization: 'Bearer pull-token' },
+    });
+    expect(io.createWriteStream).toHaveBeenCalledExactlyOnceWith('/download/layer.tar');
+    expect(progress.mock.calls).toEqual([[3], [5]]);
+    expect(io.checksum).toHaveBeenCalledExactlyOnceWith('/download/layer.tar');
+    expect(io.remove).not.toHaveBeenCalled();
+  });
+
+  it('allows anonymous downloads without a progress callback', async () => {
+    response([Buffer.from('layer')]);
+    await downloader.downloadBlob('library/nginx', 'sha256:abc123', '/download/layer.tar', '');
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://registry-1.docker.io/v2/library/nginx/blobs/sha256:abc123',
+        headers: {},
+      })
+    );
+  });
+
+  it('completes and verifies an empty blob without reporting nonexistent bytes', async () => {
+    response([]);
+    const progress = vi.fn();
+    await downloader.downloadBlob(
+      'team/image',
+      'sha256:abc123',
+      '/download/empty',
+      '',
+      'ghcr.io',
+      progress
+    );
+    expect(progress).not.toHaveBeenCalled();
+    expect(io.checksum).toHaveBeenCalledWith('/download/empty');
+  });
+
+  it('removes a corrupt blob before rejecting its checksum', async () => {
+    response();
+    io.checksum.mockResolvedValue('different-hash');
+    await expect(
+      downloader.downloadBlob('team/image', 'sha256:abc123', '/download/corrupt', '', 'ghcr.io')
+    ).rejects.toThrow('Blob 체크섬 검증 실패: sha256:abc123');
+    expect(io.remove).toHaveBeenCalledExactlyOnceWith('/download/corrupt');
+  });
+
+  it('propagates network/auth failure before opening a destination file', async () => {
+    const denied = Object.assign(new Error('Forbidden'), { response: { status: 403 } });
+    request.mockRejectedValue(denied);
+    await expect(
+      downloader.downloadBlob('team/private', 'sha256:abc123', '/download/file', 'bad-token')
+    ).rejects.toBe(denied);
+    expect(io.createWriteStream).not.toHaveBeenCalled();
+    expect(io.checksum).not.toHaveBeenCalled();
+  });
+
+  it('propagates destination permission failure without attempting checksum verification', async () => {
+    response();
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const writer = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback(denied);
+      },
+    });
+    streams.push(writer);
+    io.createWriteStream.mockReturnValue(writer);
+
+    await expect(
+      downloader.downloadBlob('team/image', 'sha256:abc123', '/restricted/file', '')
+    ).rejects.toBe(denied);
+    expect(io.checksum).not.toHaveBeenCalled();
+    expect(io.remove).not.toHaveBeenCalled();
+  });
+
+  it('propagates checksum file-reading errors', async () => {
+    response();
+    const failure = Object.assign(new Error('file disappeared'), { code: 'ENOENT' });
+    io.checksum.mockRejectedValue(failure);
+    await expect(
+      downloader.downloadBlob('team/image', 'sha256:abc123', '/download/file', '')
+    ).rejects.toBe(failure);
+    expect(io.remove).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { actual: 'ABC123', expected: 'abc123', valid: true },
+    { actual: 'abc123', expected: 'ABC123', valid: true },
+    { actual: 'abc123', expected: 'def456', valid: false },
+  ])(
+    'compares checksum strings case-insensitively: $actual / $expected',
+    async ({ actual, expected, valid }) => {
+      io.checksum.mockResolvedValue(actual);
+      await expect(downloader.verifyChecksum('/download/file', expected)).resolves.toBe(valid);
+    }
+  );
+
+  it('archives all image entries relative to the source directory', async () => {
+    io.readdir.mockResolvedValue(['manifest.json', 'config.json', 'layer']);
+    await downloader.createImageTar('/download/image', '/download/image.tar');
+    expect(io.readdir).toHaveBeenCalledExactlyOnceWith('/download/image');
+    expect(io.createTar).toHaveBeenCalledExactlyOnceWith(
+      { file: '/download/image.tar', cwd: '/download/image' },
+      ['manifest.json', 'config.json', 'layer']
+    );
+  });
+
+  it('propagates archive directory access errors without creating a tar', async () => {
+    const denied = Object.assign(new Error('directory forbidden'), { code: 'EACCES' });
+    io.readdir.mockRejectedValue(denied);
+    await expect(
+      downloader.createImageTar('/restricted/image', '/download/image.tar')
+    ).rejects.toBe(denied);
+    expect(io.createTar).not.toHaveBeenCalled();
+  });
+
+  it('propagates archive writing errors', async () => {
+    io.readdir.mockResolvedValue([]);
+    const failure = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+    io.createTar.mockRejectedValue(failure);
+    await expect(downloader.createImageTar('/download/image', '/download/image.tar')).rejects.toBe(
+      failure
+    );
+  });
+
+  it('downloads blobs sequentially and forwards progress for each blob', async () => {
+    let completeFirst!: () => void;
+    const firstDone = new Promise<void>((resolve) => {
+      completeFirst = resolve;
+    });
+    const download = vi
+      .spyOn(downloader, 'downloadBlob')
+      .mockImplementationOnce(async (_repo, _digest, _dest, _token, _registry, onChunk) => {
+        onChunk?.(4);
+        await firstDone;
+      })
+      .mockImplementationOnce(async (_repo, _digest, _dest, _token, _registry, onChunk) => {
+        onChunk?.(6);
+      });
+    const progress = vi.fn();
+    const result = downloader.downloadBlobs(
+      'team/image',
+      [
+        { digest: 'sha256:first', fileName: 'first.tar' },
+        { digest: 'sha256:second', fileName: 'second.tar' },
+      ],
+      '/download',
+      'token',
+      'quay.io',
+      progress
+    );
+
+    expect(download).toHaveBeenCalledTimes(1);
+    completeFirst();
+    await expect(result).resolves.toEqual(['/download/first.tar', '/download/second.tar']);
+    expect(download.mock.calls.map((args) => args.slice(0, 5))).toEqual([
+      ['team/image', 'sha256:first', '/download/first.tar', 'token', 'quay.io'],
+      ['team/image', 'sha256:second', '/download/second.tar', 'token', 'quay.io'],
+    ]);
+    expect(progress.mock.calls).toEqual([
+      [4, 0],
+      [6, 0],
+    ]);
+  });
+
+  it('returns no paths for empty input and stops remaining downloads after a failure', async () => {
+    const failure = new Error('first layer unavailable');
+    const download = vi.spyOn(downloader, 'downloadBlob').mockRejectedValue(failure);
+    await expect(
+      downloader.downloadBlobs('team/image', [], '/download', '', 'ghcr.io')
+    ).resolves.toEqual([]);
+    expect(download).not.toHaveBeenCalled();
+    await expect(
+      downloader.downloadBlobs(
+        'team/image',
+        [
+          { digest: 'sha256:first', fileName: 'first.tar' },
+          { digest: 'sha256:second', fileName: 'second.tar' },
+        ],
+        '/download',
+        '',
+        'ghcr.io'
+      )
+    ).rejects.toBe(failure);
+    expect(download).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads a blob list without requiring a progress observer', async () => {
+    vi.spyOn(downloader, 'downloadBlob').mockImplementation(
+      async (_repo, _digest, _dest, _token, _registry, onChunk) => {
+        onChunk?.(5);
+      }
+    );
+    await expect(
+      downloader.downloadBlobs(
+        'team/image',
+        [{ digest: 'sha256:abc123', fileName: 'layer.tar' }],
+        '/download',
+        '',
+        'ghcr.io'
+      )
+    ).resolves.toEqual(['/download/layer.tar']);
+  });
+});

--- a/src/core/downloaders/docker-catalog-cache.test.ts
+++ b/src/core/downloaders/docker-catalog-cache.test.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { DockerAuthClient } from './docker-auth-client';
+import { DockerCatalogCache, DEFAULT_CATALOG_CACHE_TTL } from './docker-catalog-cache';
+
+vi.mock('axios', () => ({ default: { get: vi.fn() } }));
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('DockerCatalogCache', () => {
+  let cache: DockerCatalogCache;
+  let token: MockInstance<DockerAuthClient['getTokenForRegistry']>;
+  const get = vi.mocked(axios.get);
+  const now = new Date('2026-01-01T00:00:00Z').getTime();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const auth = new DockerAuthClient();
+    token = vi.spyOn(auth, 'getTokenForRegistry').mockResolvedValue('catalog-token');
+    cache = new DockerCatalogCache(auth);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('requests an unscoped catalog token and caches repositories with observable expiry', async () => {
+    get.mockResolvedValue({ data: { repositories: ['team/a', 'team/b'] } });
+    expect(cache.getCatalogCacheStatus()).toEqual([]);
+    expect(cache.getCatalogCacheTTL()).toBe(DEFAULT_CATALOG_CACHE_TTL);
+
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['team/a', 'team/b']);
+    await cache.getCachedCatalog('ghcr.io');
+    expect(token).toHaveBeenCalledExactlyOnceWith('ghcr.io', '');
+    expect(get).toHaveBeenCalledExactlyOnceWith('https://ghcr.io/v2/_catalog', {
+      headers: { Authorization: 'Bearer catalog-token' },
+      params: { n: 1000 },
+      timeout: 30000,
+    });
+    expect(cache.getCatalogCacheStatus()).toEqual([
+      {
+        registry: 'ghcr.io',
+        repositoryCount: 2,
+        fetchedAt: now,
+        expiresAt: now + DEFAULT_CATALOG_CACHE_TTL,
+        isExpired: false,
+      },
+    ]);
+  });
+
+  it('refreshes exactly at expiry and applies a configured TTL to new entries', async () => {
+    cache.setCatalogCacheTTL(1000);
+    expect(cache.getCatalogCacheTTL()).toBe(1000);
+    get
+      .mockResolvedValueOnce({ data: { repositories: ['old/image'] } })
+      .mockResolvedValueOnce({ data: { repositories: ['new/image'] } });
+    await cache.getCachedCatalog('ghcr.io');
+    vi.advanceTimersByTime(999);
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['old/image']);
+    vi.advanceTimersByTime(1);
+    expect(cache.getCatalogCacheStatus()[0].isExpired).toBe(true);
+
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['new/image']);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(cache.getCatalogCacheStatus()[0]).toMatchObject({
+      fetchedAt: now + 1000,
+      expiresAt: now + 2000,
+      isExpired: false,
+    });
+  });
+
+  it('uses stale data on network failure, leaving it expired so later requests retry', async () => {
+    cache.setCatalogCacheTTL(1);
+    get.mockResolvedValueOnce({ data: { repositories: ['cached/image'] } });
+    await cache.getCachedCatalog('ghcr.io');
+    vi.advanceTimersByTime(1);
+    get.mockRejectedValueOnce(new Error('network unavailable'));
+
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['cached/image']);
+    expect(cache.getCatalogCacheStatus()[0]).toMatchObject({ fetchedAt: now, isExpired: true });
+    get.mockResolvedValueOnce({ data: { repositories: ['recovered/image'] } });
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['recovered/image']);
+    expect(get).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns an empty list after denied authentication and retries without a poisoned cache', async () => {
+    token.mockRejectedValueOnce(new Error('forbidden'));
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual([]);
+    expect(get).not.toHaveBeenCalled();
+    expect(cache.getCatalogCacheStatus()).toEqual([]);
+
+    get.mockResolvedValue({ data: { repositories: ['public/image'] } });
+    await expect(cache.getCachedCatalog('ghcr.io')).resolves.toEqual(['public/image']);
+    expect(token).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an empty list on a first catalog request failure without caching the failure', async () => {
+    get.mockRejectedValue(new Error('catalog disabled'));
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual([]);
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual([]);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(cache.getCatalogCacheStatus()).toEqual([]);
+  });
+
+  it.each([{ repositories: [] }, {}])('caches a successful empty catalog: %j', async (data) => {
+    get.mockResolvedValue({ data });
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual([]);
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual([]);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(cache.getCatalogCacheStatus()[0].repositoryCount).toBe(0);
+  });
+
+  it('isolates registries, force refreshes one, and clears all cached catalogs', async () => {
+    get
+      .mockResolvedValueOnce({ data: { repositories: ['ghcr/old'] } })
+      .mockResolvedValueOnce({ data: { repositories: ['quay/image'] } })
+      .mockResolvedValueOnce({ data: { repositories: ['ghcr/new'] } });
+    await cache.getCachedCatalog('ghcr.io');
+    await cache.getCachedCatalog('quay.io');
+    await expect(cache.refreshCatalogCache('ghcr.io')).resolves.toEqual(['ghcr/new']);
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual(['quay/image']);
+    expect(get).toHaveBeenCalledTimes(3);
+
+    cache.clearCatalogCache();
+    expect(cache.getCatalogCacheStatus()).toEqual([]);
+    get.mockResolvedValue({ data: { repositories: ['fresh/image'] } });
+    await expect(cache.getCachedCatalog('quay.io')).resolves.toEqual(['fresh/image']);
+    expect(get).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/core/downloaders/docker-manifest-service.test.ts
+++ b/src/core/downloaders/docker-manifest-service.test.ts
@@ -1,0 +1,141 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DockerAuthClient } from './docker-auth-client';
+import { DockerManifestService } from './docker-manifest-service';
+import type { DockerManifest, DockerManifestEntry } from './docker-types';
+
+vi.mock('axios', () => ({ default: { get: vi.fn() } }));
+vi.mock('../../utils/logger', () => ({ default: { error: vi.fn(), debug: vi.fn() } }));
+
+const get = vi.mocked(axios.get);
+const single: DockerManifest = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.manifest.v1+json',
+  layers: [],
+};
+function entry(arch: string, os = 'linux', variant?: string): DockerManifestEntry {
+  return {
+    mediaType: single.mediaType,
+    size: 123,
+    digest: `sha256:${os}-${arch}-${variant || 'default'}`,
+    platform: { architecture: arch, os, ...(variant ? { variant } : {}) },
+  };
+}
+function index(manifests: DockerManifestEntry[]): DockerManifest {
+  return { schemaVersion: 2, mediaType: 'application/vnd.oci.image.index.v1+json', manifests };
+}
+
+describe('DockerManifestService', () => {
+  let service: DockerManifestService;
+  beforeEach(() => {
+    vi.resetAllMocks();
+    service = new DockerManifestService(new DockerAuthClient());
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(['token', ''])(
+    'requests all Docker/OCI media types and adds authorization only for a nonempty token (%j)',
+    async (token) => {
+      get.mockResolvedValue({ data: single });
+      await expect(service.getManifest('library/nginx', 'latest', token)).resolves.toBe(single);
+      expect(get).toHaveBeenCalledExactlyOnceWith(
+        'https://registry-1.docker.io/v2/library/nginx/manifests/latest',
+        {
+          headers: {
+            Accept: [
+              'application/vnd.docker.distribution.manifest.v2+json',
+              'application/vnd.docker.distribution.manifest.list.v2+json',
+              'application/vnd.oci.image.manifest.v1+json',
+              'application/vnd.oci.image.index.v1+json',
+            ].join(', '),
+            ...(token ? { Authorization: 'Bearer token' } : {}),
+          },
+        }
+      );
+    }
+  );
+
+  it('selects the requested Linux architecture and variant, skipping Windows and other variants', async () => {
+    const selected = entry('arm', 'linux', 'v7');
+    get
+      .mockResolvedValueOnce({
+        data: index([entry('arm', 'windows', 'v7'), entry('arm', 'linux', 'v6'), selected]),
+      })
+      .mockResolvedValueOnce({ data: single });
+
+    await expect(
+      service.getManifestForArchitecture('team/image', 'v1', 'token', 'ghcr.io', 'arm', 'v7')
+    ).resolves.toBe(single);
+    expect(get.mock.calls.map(([url]) => url)).toEqual([
+      'https://ghcr.io/v2/team/image/manifests/v1',
+      `https://ghcr.io/v2/team/image/manifests/${selected.digest}`,
+    ]);
+    expect(get.mock.calls[1][1]?.headers).toMatchObject({ Authorization: 'Bearer token' });
+  });
+
+  it('accepts any Linux variant when none is specified and returns undefined for a single manifest', () => {
+    const selected = entry('arm', 'linux', 'v6');
+    expect(
+      service.findArchitectureManifest(
+        index([entry('arm', 'windows'), selected, entry('arm', 'linux', 'v7')]),
+        'arm'
+      )
+    ).toBe(selected);
+    expect(service.findArchitectureManifest(single, 'amd64')).toBeUndefined();
+    expect(service.findArchitectureManifest(index([]), 'amd64')).toBeUndefined();
+  });
+
+  it('returns a single-platform manifest without a second request', async () => {
+    get.mockResolvedValue({ data: single });
+    await expect(
+      service.getManifestForArchitecture(
+        'team/image',
+        'sha256:config',
+        '',
+        'registry.example.test',
+        'amd64'
+      )
+    ).resolves.toBe(single);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports available platforms when the requested variant is unavailable', async () => {
+    get.mockResolvedValue({
+      data: index([entry('amd64'), entry('arm', 'linux', 'v6'), entry('arm64', 'windows')]),
+    });
+    await expect(
+      service.getManifestForArchitecture('team/image', 'v1', '', 'quay.io', 'arm', 'v7')
+    ).rejects.toThrow(
+      '아키텍처 arm/v7를 지원하지 않습니다. 지원 아키텍처: linux/amd64, linux/arm/v6, windows/arm64'
+    );
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an empty multi-platform index without attempting a digest request', async () => {
+    get.mockResolvedValue({ data: index([]) });
+    await expect(
+      service.getManifestForArchitecture('team/image', 'v1', '', 'quay.io', 'amd64')
+    ).rejects.toThrow('아키텍처 amd64를 지원하지 않습니다.');
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([401, 404])('preserves a registry HTTP %i error', async (status) => {
+    const failure = Object.assign(new Error('registry rejected manifest'), {
+      response: { status },
+    });
+    get.mockRejectedValue(failure);
+    await expect(
+      service.getManifestForArchitecture('team/image', 'v1', 'bad-token', 'ghcr.io', 'amd64')
+    ).rejects.toBe(failure);
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves failure when fetching the selected platform digest', async () => {
+    const failure = new Error('digest missing');
+    get.mockResolvedValueOnce({ data: index([entry('amd64')]) }).mockRejectedValueOnce(failure);
+    await expect(
+      service.getManifestForArchitecture('team/image', 'v1', '', 'ghcr.io', 'amd64')
+    ).rejects.toBe(failure);
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/downloaders/docker-search-service.test.ts
+++ b/src/core/downloaders/docker-search-service.test.ts
@@ -1,0 +1,248 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DockerAuthClient } from './docker-auth-client';
+import { DockerCatalogCache } from './docker-catalog-cache';
+import { DockerManifestService } from './docker-manifest-service';
+import { DockerSearchService } from './docker-search-service';
+import type { DockerManifest } from './docker-types';
+
+const requests = vi.hoisted(() => ({ get: vi.fn(), hubGet: vi.fn(), create: vi.fn() }));
+vi.mock('axios', () => ({ default: { get: requests.get, create: requests.create } }));
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('DockerSearchService', () => {
+  let service: DockerSearchService;
+  let auth: DockerAuthClient;
+  let catalog: DockerCatalogCache;
+  let manifest: DockerManifestService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    requests.create.mockReturnValue({ get: requests.hubGet });
+    auth = new DockerAuthClient();
+    catalog = new DockerCatalogCache(auth);
+    manifest = new DockerManifestService(auth);
+    service = new DockerSearchService(auth, catalog, manifest);
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('queries Docker Hub and maps repository names and descriptions', async () => {
+    requests.hubGet.mockResolvedValue({
+      data: {
+        results: [
+          { repo_name: 'library/nginx', short_description: 'Web server' },
+          { repo_name: 'team/nginx', short_description: '' },
+        ],
+      },
+    });
+    await expect(service.searchPackages('nginx')).resolves.toEqual([
+      {
+        type: 'docker',
+        name: 'docker.io/library/nginx',
+        version: 'latest',
+        metadata: { description: 'Web server', registry: 'docker.io' },
+      },
+      {
+        type: 'docker',
+        name: 'docker.io/team/nginx',
+        version: 'latest',
+        metadata: { description: '', registry: 'docker.io' },
+      },
+    ]);
+    expect(axios.create).toHaveBeenCalledExactlyOnceWith({
+      baseURL: 'https://hub.docker.com/v2',
+      timeout: 30000,
+    });
+    expect(requests.hubGet).toHaveBeenCalledExactlyOnceWith('/search/repositories/', {
+      params: { query: 'nginx', page_size: 50 },
+    });
+    expect(requests.get).not.toHaveBeenCalled();
+  });
+
+  it('filters Quay private repositories before limiting public results and handles absent descriptions', async () => {
+    requests.get.mockResolvedValue({
+      data: {
+        results: [
+          {
+            namespace: { name: 'secret' },
+            name: 'private',
+            description: 'secret',
+            is_public: false,
+          },
+          ...Array.from({ length: 51 }, (_, i) => ({
+            namespace: { name: 'public' },
+            name: `image-${i}`,
+            description: i === 0 ? null : 'Image',
+            is_public: true,
+          })),
+        ],
+      },
+    });
+    const result = await service.searchPackages('image', 'quay.io');
+    expect(result).toHaveLength(50);
+    expect(result[0]).toEqual({
+      type: 'docker',
+      name: 'quay.io/public/image-0',
+      version: 'latest',
+      metadata: { description: '', registry: 'quay.io' },
+    });
+    expect(result[49].name).toBe('quay.io/public/image-49');
+    expect(requests.get).toHaveBeenCalledExactlyOnceWith(
+      'https://quay.io/api/v1/find/repositories',
+      { params: { query: 'image' }, timeout: 30000 }
+    );
+  });
+
+  it.each(['ghcr.io', 'public.ecr.aws'])(
+    'provides a direct image entry for %s without invoking an unsupported search API',
+    async (registry) => {
+      const cached = vi.spyOn(catalog, 'getCachedCatalog');
+      const result = await service.searchPackages('org/image', registry);
+      expect(result).toEqual([
+        {
+          type: 'docker',
+          name: `${registry}/org/image`,
+          version: 'latest',
+          metadata: { registry, description: expect.stringContaining('정확한 이미지명 입력 필요') },
+        },
+      ]);
+      expect(requests.get).not.toHaveBeenCalled();
+      expect(requests.hubGet).not.toHaveBeenCalled();
+      expect(cached).not.toHaveBeenCalled();
+    }
+  );
+
+  it('searches custom catalogs case-insensitively and limits matching repositories', async () => {
+    const cached = vi
+      .spyOn(catalog, 'getCachedCatalog')
+      .mockResolvedValue([
+        'unrelated/image',
+        ...Array.from({ length: 51 }, (_, i) => `Team/APP-${i}`),
+      ]);
+    const result = await service.searchPackages('app', 'registry.example.test');
+    expect(cached).toHaveBeenCalledExactlyOnceWith('registry.example.test');
+    expect(result).toHaveLength(50);
+    expect(result[0]).toEqual({
+      type: 'docker',
+      name: 'registry.example.test/Team/APP-0',
+      version: 'latest',
+      metadata: { registry: 'registry.example.test' },
+    });
+    expect(result[49].name).toBe('registry.example.test/Team/APP-49');
+    expect(requests.get).not.toHaveBeenCalled();
+  });
+
+  it.each(['docker.io', 'quay.io', 'registry.example.test'])(
+    'returns no invented search results for an empty %s catalog',
+    async (registry) => {
+      requests.hubGet.mockResolvedValue({ data: { results: [] } });
+      requests.get.mockResolvedValue({ data: { results: [] } });
+      vi.spyOn(catalog, 'getCachedCatalog').mockResolvedValue([]);
+      await expect(service.searchPackages('missing', registry)).resolves.toEqual([]);
+    }
+  );
+
+  it('propagates search transport failure', async () => {
+    const failure = new Error('search timed out');
+    requests.hubGet.mockRejectedValue(failure);
+    await expect(service.searchPackages('nginx')).rejects.toBe(failure);
+  });
+
+  it('uses Docker Hub tags for unqualified official images', async () => {
+    requests.hubGet.mockResolvedValue({ data: { results: [{ name: 'latest' }, { name: '1.0' }] } });
+    await expect(service.getVersions('nginx')).resolves.toEqual(['latest', '1.0']);
+    expect(requests.hubGet).toHaveBeenCalledExactlyOnceWith('/repositories/library/nginx/tags', {
+      params: { page_size: 100 },
+    });
+  });
+
+  it('uses an explicit image registry instead of the default and preserves nested namespaces', async () => {
+    const token = vi.spyOn(auth, 'getTokenForRegistry').mockResolvedValue('tags-token');
+    requests.get.mockResolvedValue({ data: { tags: ['v2', 'v1'] } });
+    await expect(service.getVersions('ghcr.io/org/nested/image', 'quay.io')).resolves.toEqual([
+      'v2',
+      'v1',
+    ]);
+    expect(token).toHaveBeenCalledExactlyOnceWith('ghcr.io', 'org/nested/image');
+    expect(requests.get).toHaveBeenCalledExactlyOnceWith(
+      'https://ghcr.io/v2/org/nested/image/tags/list',
+      { headers: { Authorization: 'Bearer tags-token' } }
+    );
+    expect(requests.hubGet).not.toHaveBeenCalled();
+  });
+
+  it.each([{ tags: [] }, { tags: null }, {}])('handles empty non-Hub tags: %j', async (data) => {
+    vi.spyOn(auth, 'getTokenForRegistry').mockResolvedValue('token');
+    requests.get.mockResolvedValue({ data });
+    await expect(service.getVersions('org/image', 'quay.io')).resolves.toEqual([]);
+  });
+
+  it('propagates denied tag authentication before requesting registry tags', async () => {
+    const failure = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+    vi.spyOn(auth, 'getTokenForRegistry').mockRejectedValue(failure);
+    await expect(service.getVersions('ghcr.io/team/private')).rejects.toBe(failure);
+    expect(requests.get).not.toHaveBeenCalled();
+  });
+
+  it('propagates a missing Docker Hub repository error', async () => {
+    const failure = Object.assign(new Error('Not found'), { response: { status: 404 } });
+    requests.hubGet.mockRejectedValue(failure);
+    await expect(service.getVersions('missing')).rejects.toBe(failure);
+  });
+
+  it('builds Docker Hub metadata with a default tag, config digest, and summed layer size', async () => {
+    const token = vi.spyOn(auth, 'getToken').mockResolvedValue('metadata-token');
+    const readManifest = vi.spyOn(manifest, 'getManifest').mockResolvedValue({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      config: {
+        digest: 'sha256:config',
+        size: 10,
+        mediaType: 'application/vnd.oci.image.config.v1+json',
+      },
+      layers: [
+        { digest: 'sha256:a', size: 100, mediaType: 'layer' },
+        { digest: 'sha256:b', size: 200, mediaType: 'layer' },
+      ],
+    });
+    await expect(service.getPackageMetadata('nginx', '')).resolves.toEqual({
+      type: 'docker',
+      name: 'library/nginx',
+      version: 'latest',
+      metadata: { registry: 'docker.io', tag: 'latest', digest: 'sha256:config', size: 300 },
+    });
+    expect(token).toHaveBeenCalledExactlyOnceWith('library/nginx');
+    expect(readManifest).toHaveBeenCalledExactlyOnceWith(
+      'library/nginx',
+      'latest',
+      'metadata-token'
+    );
+  });
+
+  it.each([
+    { extra: { layers: [] }, size: 0 },
+    { extra: { manifests: [] }, size: undefined },
+  ])('supports metadata without config data: %j', async ({ extra, size }) => {
+    vi.spyOn(auth, 'getToken').mockResolvedValue('token');
+    vi.spyOn(manifest, 'getManifest').mockResolvedValue({
+      schemaVersion: 2,
+      mediaType: 'manifest',
+      ...extra,
+    } as DockerManifest);
+    const result = await service.getPackageMetadata('org/image', 'v1');
+    expect(result).toMatchObject({ name: 'org/image', version: 'v1', metadata: { tag: 'v1' } });
+    expect(result.metadata?.size).toBe(size);
+    expect(result.metadata?.digest).toBeUndefined();
+  });
+
+  it.each(['authentication', 'manifest'])('propagates metadata %s failure', async (stage) => {
+    const failure = new Error('metadata unavailable');
+    const token = vi.spyOn(auth, 'getToken').mockResolvedValue('token');
+    const readManifest = vi.spyOn(manifest, 'getManifest').mockRejectedValue(failure);
+    if (stage === 'authentication') token.mockRejectedValue(failure);
+    await expect(service.getPackageMetadata('nginx', 'v1')).rejects.toBe(failure);
+    expect(readManifest).toHaveBeenCalledTimes(stage === 'manifest' ? 1 : 0);
+  });
+});

--- a/src/core/downloaders/os-shared/archive-packager.test.ts
+++ b/src/core/downloaders/os-shared/archive-packager.test.ts
@@ -1,0 +1,290 @@
+import { EventEmitter } from 'node:events';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OSArchivePackager, type ArchiveOptions } from './archive-packager';
+import { getDownloadedFileKey } from './package-file-utils';
+import type { OSPackageInfo } from './types';
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(),
+  archiver: vi.fn(),
+  dependencyScript: vi.fn(),
+  repoScript: vi.fn(),
+}));
+vi.mock('fs', () => ({
+  existsSync: mocks.existsSync,
+  mkdirSync: mocks.mkdirSync,
+  createWriteStream: mocks.createWriteStream,
+}));
+vi.mock('archiver', () => ({ default: mocks.archiver }));
+vi.mock('./script-generator', () => ({
+  OSScriptGenerator: class {
+    generateDependencyOrderScript = mocks.dependencyScript;
+    generateLocalRepoScript = mocks.repoScript;
+  },
+}));
+
+function pkg(overrides: Partial<OSPackageInfo> = {}): OSPackageInfo {
+  return {
+    name: 'httpd',
+    version: '2.4.57',
+    release: '3.el9',
+    architecture: 'x86_64',
+    size: 2048,
+    location: 'Packages/httpd-2.4.57-3.el9.x86_64.rpm',
+    checksum: { type: 'sha256', value: 'hash' },
+    repository: {
+      id: 'baseos',
+      name: 'BaseOS',
+      baseUrl: 'https://example.test',
+      enabled: true,
+      gpgCheck: false,
+      isOfficial: true,
+    },
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+describe('OSArchivePackager', () => {
+  let packager: OSArchivePackager;
+  let output: EventEmitter;
+  let archive: EventEmitter & {
+    pipe: ReturnType<typeof vi.fn>;
+    file: ReturnType<typeof vi.fn>;
+    append: ReturnType<typeof vi.fn>;
+    finalize: ReturnType<typeof vi.fn>;
+  };
+  let options: ArchiveOptions;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    output = new EventEmitter();
+    archive = Object.assign(new EventEmitter(), {
+      pipe: vi.fn(),
+      file: vi.fn(),
+      append: vi.fn(),
+      finalize: vi.fn(() => {
+        queueMicrotask(() => output.emit('close'));
+      }),
+    });
+    mocks.existsSync.mockReturnValue(true);
+    mocks.createWriteStream.mockReturnValue(output);
+    mocks.archiver.mockReturnValue(archive);
+    mocks.dependencyScript.mockReturnValue({
+      bash: '# dependency bash',
+      powershell: '# dependency powershell',
+    });
+    mocks.repoScript.mockReturnValue({
+      bash: '# repository bash',
+      powershell: '# repository powershell',
+    });
+    packager = new OSArchivePackager();
+    options = {
+      format: 'zip',
+      outputPath: path.join('output', 'bundle'),
+      includeScripts: false,
+      scriptTypes: [],
+      packageManager: 'yum',
+    };
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function appended(name: string): string {
+    const call = archive.append.mock.calls.find(([, opts]) => opts.name === name);
+    expect(call, `expected ${name} in the archive`).toBeDefined();
+    return call![0] as string;
+  }
+
+  it('creates a ZIP with real RPM filenames, deterministic metadata, and Korean installation instructions', async () => {
+    const packageInfo = pkg();
+    const downloadedPath = path.join('downloads', 'httpd-2.4.57-3.el9.x86_64.rpm');
+    await expect(
+      packager.createArchive(
+        [packageInfo],
+        new Map([[getDownloadedFileKey(packageInfo), downloadedPath]]),
+        options
+      )
+    ).resolves.toBe(path.join('output', 'bundle.zip'));
+
+    expect(mocks.archiver).toHaveBeenCalledExactlyOnceWith('zip', { zlib: { level: 9 } });
+    expect(archive.pipe).toHaveBeenCalledExactlyOnceWith(output);
+    expect(archive.file).toHaveBeenCalledExactlyOnceWith(downloadedPath, {
+      name: 'packages/httpd-2.4.57-3.el9.x86_64.rpm',
+    });
+    expect(JSON.parse(appended('metadata.json'))).toEqual({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      packageManager: 'yum',
+      totalPackages: 1,
+      totalSize: 2048,
+      packages: [
+        {
+          name: 'httpd',
+          version: '2.4.57',
+          architecture: 'x86_64',
+          size: 2048,
+          filename: 'httpd-2.4.57-3.el9.x86_64.rpm',
+        },
+      ],
+    });
+    expect(appended('README.txt')).toContain('YUM/RPM');
+    expect(appended('README.txt')).toContain('총 크기: 2.00 KB');
+    expect(appended('README.txt')).toContain('yum install <패키지명>');
+    expect(appended('README.txt')).toContain('- httpd 2.4.57 (x86_64)');
+    expect(mocks.mkdirSync).not.toHaveBeenCalled();
+    expect(mocks.dependencyScript).not.toHaveBeenCalled();
+  });
+
+  it.each(['zip', 'tar.gz'] as const)(
+    'preserves the supplied .%s extension and creates missing output directories',
+    async (format) => {
+      options = { ...options, format, outputPath: path.join('output', `bundle.${format}`) };
+      mocks.existsSync.mockReturnValue(false);
+      await expect(packager.createArchive([], new Map(), options)).resolves.toBe(
+        options.outputPath
+      );
+      expect(mocks.mkdirSync).toHaveBeenCalledExactlyOnceWith(path.dirname(options.outputPath), {
+        recursive: true,
+      });
+      expect(mocks.createWriteStream).toHaveBeenCalledExactlyOnceWith(options.outputPath);
+      expect(mocks.archiver).toHaveBeenCalledWith(
+        format === 'zip' ? 'zip' : 'tar',
+        format === 'zip' ? { zlib: { level: 9 } } : { gzip: true, gzipOptions: { level: 9 } }
+      );
+      expect(JSON.parse(appended('metadata.json'))).toMatchObject({
+        totalPackages: 0,
+        totalSize: 0,
+        packages: [],
+      });
+      expect(appended('README.txt')).toContain('총 크기: 0.00 B');
+    }
+  );
+
+  it('appends .tar.gz and omits all optional entries when disabled', async () => {
+    await expect(
+      packager.createArchive([], new Map(), {
+        ...options,
+        format: 'tar.gz',
+        includeMetadata: false,
+        includeReadme: false,
+      })
+    ).resolves.toBe(path.join('output', 'bundle.tar.gz'));
+    expect(archive.append).not.toHaveBeenCalled();
+    expect(archive.file).not.toHaveBeenCalled();
+    expect(archive.finalize).toHaveBeenCalledOnce();
+  });
+
+  it('skips packages without a download mapping or whose file no longer exists', async () => {
+    const packages = [pkg(), pkg({ name: 'missing-file' }), pkg({ name: 'unmapped' })];
+    const present = path.join('downloads', 'actual.rpm');
+    const missing = path.join('downloads', 'deleted.rpm');
+    mocks.existsSync.mockImplementation((filePath) => filePath !== missing);
+    await packager.createArchive(
+      packages,
+      new Map([
+        [getDownloadedFileKey(packages[0]), present],
+        [getDownloadedFileKey(packages[1]), missing],
+      ]),
+      options
+    );
+
+    expect(archive.file).toHaveBeenCalledExactlyOnceWith(present, { name: 'packages/actual.rpm' });
+  });
+
+  it('includes both selected script types with executable Bash modes and a custom repository name', async () => {
+    const packages = [pkg()];
+    await packager.createArchive(packages, new Map(), {
+      ...options,
+      includeScripts: true,
+      scriptTypes: ['dependency-order', 'local-repo'],
+      repoName: 'offline-repo',
+    });
+    expect(mocks.dependencyScript).toHaveBeenCalledExactlyOnceWith(packages, 'yum', {
+      repoName: 'offline-repo',
+      packageDir: './packages',
+    });
+    expect(mocks.repoScript).toHaveBeenCalledExactlyOnceWith(packages, 'yum', {
+      repoName: 'offline-repo',
+      packageDir: './packages',
+    });
+    expect(archive.append.mock.calls.slice(0, 4)).toEqual([
+      ['# dependency bash', { name: 'install.sh', mode: 0o755 }],
+      ['# dependency powershell', { name: 'install.ps1' }],
+      ['# repository bash', { name: 'setup-repo.sh', mode: 0o755 }],
+      ['# repository powershell', { name: 'setup-repo.ps1' }],
+    ]);
+  });
+
+  it.each(['dependency-order', 'local-repo'] as const)(
+    'generates only the selected %s script with the default repository name',
+    async (scriptType) => {
+      await packager.createArchive([], new Map(), {
+        ...options,
+        includeScripts: true,
+        scriptTypes: [scriptType],
+      });
+      const selected =
+        scriptType === 'dependency-order' ? mocks.dependencyScript : mocks.repoScript;
+      const other = scriptType === 'dependency-order' ? mocks.repoScript : mocks.dependencyScript;
+      expect(selected).toHaveBeenCalledExactlyOnceWith([], 'yum', {
+        repoName: 'depssmuggler-local',
+        packageDir: './packages',
+      });
+      expect(other).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    {
+      manager: 'apt',
+      label: 'APT/DEB',
+      command: 'apt-get install',
+      size: 1024 ** 2,
+      sizeLabel: '1.00 MB',
+    },
+    {
+      manager: 'apk',
+      label: 'APK (Alpine Linux)',
+      command: 'apk add',
+      size: 1024 ** 3,
+      sizeLabel: '1.00 GB',
+    },
+  ] as const)(
+    'creates the $manager README and size units',
+    async ({ manager, label, command, size, sizeLabel }) => {
+      await packager.createArchive([pkg({ size })], new Map(), {
+        ...options,
+        packageManager: manager,
+      });
+      expect(appended('README.txt')).toContain(label);
+      expect(appended('README.txt')).toContain(command);
+      expect(appended('README.txt')).toContain(sizeLabel);
+    }
+  );
+
+  it('propagates output directory permission failure before starting compression', async () => {
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    mocks.existsSync.mockReturnValue(false);
+    mocks.mkdirSync.mockImplementation(() => {
+      throw denied;
+    });
+    await expect(packager.createArchive([], new Map(), options)).rejects.toBe(denied);
+    expect(mocks.createWriteStream).not.toHaveBeenCalled();
+    expect(mocks.archiver).not.toHaveBeenCalled();
+  });
+
+  it('rejects an archiver error without waiting for an output close event', async () => {
+    const failure = new Error('compression failed');
+    archive.finalize.mockImplementation(() => {
+      queueMicrotask(() => archive.emit('error', failure));
+    });
+    await expect(packager.createArchive([], new Map(), options)).rejects.toBe(failure);
+  });
+});

--- a/src/core/downloaders/os-shared/dependency-tree.test.ts
+++ b/src/core/downloaders/os-shared/dependency-tree.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OSDependencyTree } from './dependency-tree';
+import type { OSPackageInfo } from './types';
+
+function pkg(name: string, overrides: Partial<OSPackageInfo> = {}): OSPackageInfo {
+  return {
+    name,
+    version: '1.0',
+    architecture: 'amd64',
+    size: 100,
+    location: `${name}.deb`,
+    checksum: { type: 'sha256', value: 'checksum' },
+    dependencies: [],
+    repository: {
+      id: 'main',
+      name: 'Main',
+      baseUrl: 'https://example.test',
+      enabled: true,
+      gpgCheck: false,
+      isOfficial: true,
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('OSDependencyTree', () => {
+  it('reports a completely empty graph without errors', () => {
+    const tree = new OSDependencyTree();
+    expect(tree.getInstallOrder()).toEqual([]);
+    expect(tree.getRootPackages()).toEqual([]);
+    expect(tree.getLeafPackages()).toEqual([]);
+    expect(tree.toVisualizationData()).toEqual({ nodes: [], edges: [] });
+    expect(tree.getStats()).toEqual({
+      totalPackages: 0,
+      totalSize: 0,
+      missingCount: 0,
+      conflictCount: 0,
+      maxDepth: 0,
+    });
+  });
+
+  it('deduplicates identical nodes while preserving different versions and architectures', () => {
+    const tree = new OSDependencyTree();
+    const first = pkg('lib');
+    tree.addNode(first);
+    tree.addNode({ ...first });
+    tree.addNode(pkg('lib', { version: '2.0', size: 200 }));
+    tree.addNode(pkg('lib', { architecture: 'arm64', size: 300 }));
+    expect(tree.hasNode({ ...first })).toBe(true);
+    expect(tree.hasNode(pkg('absent'))).toBe(false);
+    expect(tree.getPackageCount()).toBe(3);
+    expect(tree.getTotalSize()).toBe(600);
+    expect(tree.getAllPackages()[0]).toBe(first);
+  });
+
+  it('orders a diamond graph from shared dependency to roots and computes its longest depth', () => {
+    const tree = new OSDependencyTree();
+    const app = pkg('app');
+    const left = pkg('left');
+    const right = pkg('right');
+    const shared = pkg('shared');
+    const base = pkg('base');
+    tree.addEdge(app, left, { name: 'left' });
+    tree.addEdge(app, right, { name: 'right', isOptional: true });
+    tree.addEdge(left, shared, { name: 'shared' });
+    tree.addEdge(right, shared, { name: 'shared' });
+    tree.addEdge(shared, base, { name: 'base' });
+
+    const order = tree.getInstallOrder();
+    for (const [parent, child] of [
+      [app, left],
+      [app, right],
+      [left, shared],
+      [right, shared],
+      [shared, base],
+    ]) {
+      expect(order.indexOf(child)).toBeLessThan(order.indexOf(parent));
+    }
+    expect(order).toHaveLength(5);
+    expect(tree.getInstallOrder()).toEqual(order);
+    expect(tree.getRootPackages()).toEqual([app]);
+    expect(tree.getLeafPackages()).toEqual([base]);
+    expect(tree.getStats()).toMatchObject({ maxDepth: 3, totalPackages: 5, totalSize: 500 });
+    expect(tree.toVisualizationData()).toEqual({
+      nodes: [app, left, right, shared, base].map((node) => ({
+        id: `${node.name}-1.0-amd64`,
+        label: node.name,
+        version: '1.0',
+        size: 100,
+      })),
+      edges: [
+        { source: 'app-1.0-amd64', target: 'left-1.0-amd64', optional: false },
+        { source: 'app-1.0-amd64', target: 'right-1.0-amd64', optional: true },
+        { source: 'left-1.0-amd64', target: 'shared-1.0-amd64', optional: false },
+        { source: 'right-1.0-amd64', target: 'shared-1.0-amd64', optional: false },
+        { source: 'shared-1.0-amd64', target: 'base-1.0-amd64', optional: false },
+      ],
+    });
+  });
+
+  it('keeps disconnected packages and cycles in the installation result without hanging or duplicates', () => {
+    const tree = new OSDependencyTree();
+    const a = pkg('a');
+    const b = pkg('b');
+    const independent = pkg('independent');
+    tree.addEdge(a, b, { name: 'b' });
+    tree.addEdge(b, a, { name: 'a' });
+    tree.addNode(independent);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const order = tree.getInstallOrder();
+    expect(order[0]).toBe(independent);
+    expect(new Set(order)).toEqual(new Set([a, b, independent]));
+    expect(order).toHaveLength(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Circular dependency detected'));
+    expect(Number.isFinite(tree.getStats().maxDepth)).toBe(true);
+  });
+
+  it('does not lose nodes when a package depends on itself or an edge is repeated', () => {
+    const self = pkg('self');
+    const app = pkg('app');
+    const leaf = pkg('leaf');
+    const tree = new OSDependencyTree();
+    tree.addEdge(self, self, { name: 'self' });
+    tree.addEdge(app, leaf, { name: 'leaf' });
+    tree.addEdge(app, leaf, { name: 'leaf' });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const order = tree.getInstallOrder();
+    expect(order).toHaveLength(3);
+    expect(order.indexOf(leaf)).toBeLessThan(order.indexOf(app));
+    expect(order).toContain(self);
+    expect(tree.getStats().maxDepth).toBe(1);
+  });
+
+  it('retains missing dependency reasons and returns an independent result array', () => {
+    const tree = new OSDependencyTree();
+    const app = pkg('app');
+    tree.addMissingDependency(app, { name: 'absent' });
+    tree.addMissingDependency(
+      app,
+      { name: 'old', version: '2', operator: '>=' },
+      'version_mismatch'
+    );
+    tree.addMissingDependency(app, { name: 'wrong-arch' }, 'architecture_mismatch');
+    expect(tree.getMissingDependencies().map((missing) => missing.reason)).toEqual([
+      'not_found',
+      'version_mismatch',
+      'architecture_mismatch',
+    ]);
+    expect(tree.getMissingDependencies()[1]).toEqual({
+      requestedBy: app,
+      dependency: { name: 'old', version: '2', operator: '>=' },
+      reason: 'version_mismatch',
+    });
+    tree.getMissingDependencies().pop();
+    expect(tree.getStats().missingCount).toBe(3);
+  });
+
+  it('merges repeated version conflicts without duplicating existing versions', () => {
+    const tree = new OSDependencyTree();
+    const old = pkg('lib');
+    const current = pkg('lib', { version: '2.0' });
+    const next = pkg('lib', { version: '3.0' });
+    const firstRequester = { package: pkg('app'), requiredVersion: '1.0' };
+    const nextRequester = { package: pkg('tool'), requiredVersion: '3.0' };
+    tree.addConflict('lib', [old, current], [firstRequester]);
+    tree.addConflict('lib', [current, next], [nextRequester]);
+    expect(tree.getConflicts()).toEqual([
+      {
+        packageName: 'lib',
+        versions: [old, current, next],
+        requestedBy: [firstRequester, nextRequester],
+      },
+    ]);
+    expect(tree.getStats().conflictCount).toBe(1);
+  });
+});

--- a/src/core/mailer/email-sender-errors.test.ts
+++ b/src/core/mailer/email-sender-errors.test.ts
@@ -1,0 +1,137 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as nodemailer from 'nodemailer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmailSender } from './email-sender';
+
+const transport = vi.hoisted(() => ({ sendMail: vi.fn(), verify: vi.fn(), close: vi.fn() }));
+const pathExists = vi.hoisted(() => vi.fn<(path: string) => Promise<boolean>>());
+vi.mock('nodemailer', () => ({ createTransport: vi.fn() }));
+vi.mock('fs-extra', () => ({ pathExists, stat: vi.fn() }));
+vi.mock('../../utils/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('메일 전달 오류 및 첨부 크기 경계', () => {
+  let sender: EmailSender;
+  const options = { to: 'recipient@example.test', subject: '패키지 전달' };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(nodemailer.createTransport).mockReturnValue(transport as never);
+    transport.sendMail.mockResolvedValue({ messageId: 'sent' });
+    pathExists.mockResolvedValue(true);
+    sender = new EmailSender(
+      { host: 'smtp.example.test', port: 587, secure: false, from: 'sender@example.test' },
+      10
+    );
+  });
+  afterEach(() => sender.close());
+
+  it.each(['pathExists', 'stat'] as const)(
+    '첨부파일 %s 권한 오류가 나면 발송하지 않는다',
+    async (operation) => {
+      vi.mocked(fs[operation]).mockRejectedValue(
+        Object.assign(new Error('EACCES: attachment'), { code: 'EACCES' })
+      );
+      await expect(
+        sender.sendEmail({ ...options, attachments: [path.join('restricted', 'package.zip')] })
+      ).resolves.toEqual({ success: false, error: 'EACCES: attachment' });
+      expect(transport.sendMail).not.toHaveBeenCalled();
+    }
+  );
+
+  it('첨부 크기가 제한과 정확히 같으면 단일 메일로 발송한다', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ size: 5 } as never);
+    const attachments = [path.join('packages', 'one.zip'), path.join('packages', 'two.zip')];
+    await expect(sender.sendEmail({ ...options, attachments })).resolves.toMatchObject({
+      success: true,
+      emailsSent: 1,
+      attachmentsSent: 2,
+    });
+    expect(transport.sendMail).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        subject: options.subject,
+        attachments: attachments.map((file) => ({ filename: path.basename(file), path: file })),
+      })
+    );
+  });
+
+  it('합계가 제한을 넘으면 순서를 유지하면서 그룹별 첨부와 제목을 발송한다', async () => {
+    const sizes = new Map([
+      ['one.zip', 5],
+      ['two.zip', 5],
+      ['three.zip', 1],
+    ]);
+    vi.mocked(fs.stat).mockImplementation(
+      async (file) => ({ size: sizes.get(String(file)) }) as never
+    );
+    transport.sendMail
+      .mockResolvedValueOnce({ messageId: 'first' })
+      .mockResolvedValueOnce({ messageId: 'second' });
+    await expect(
+      sender.sendEmail({ ...options, attachments: [...sizes.keys()] })
+    ).resolves.toMatchObject({
+      success: true,
+      messageId: 'first, second',
+      emailsSent: 2,
+      attachmentsSent: 3,
+    });
+    expect(
+      transport.sendMail.mock.calls.map(([mail]) => ({
+        subject: mail.subject,
+        files: mail.attachments.map((entry: { path: string }) => entry.path),
+      }))
+    ).toEqual([
+      { subject: '패키지 전달 (1/2)', files: ['one.zip', 'two.zip'] },
+      { subject: '패키지 전달 (2/2)', files: ['three.zip'] },
+    ]);
+  });
+
+  it('첫 그룹에서 인증이 거부되면 나머지 그룹을 보내지 않는다', async () => {
+    vi.mocked(fs.stat).mockResolvedValue({ size: 6 } as never);
+    transport.sendMail.mockRejectedValue(
+      Object.assign(new Error('535 Authentication failed'), { code: 'EAUTH' })
+    );
+    await expect(
+      sender.sendEmail({ ...options, attachments: ['one.zip', 'two.zip'] })
+    ).resolves.toMatchObject({
+      success: false,
+      error: '535 Authentication failed',
+      emailsSent: 0,
+      attachmentsSent: 0,
+    });
+    expect(transport.sendMail).toHaveBeenCalledOnce();
+  });
+
+  it('수신자 입력을 SMTP가 거부하면 실패 결과를 반환한다', async () => {
+    transport.sendMail.mockRejectedValue(
+      Object.assign(new Error('No recipients defined'), { code: 'EENVELOPE' })
+    );
+    await expect(sender.sendEmail({ ...options, to: '' })).resolves.toEqual({
+      success: false,
+      error: 'No recipients defined',
+    });
+  });
+
+  it('전송기 생성 실패는 첨부를 읽거나 발송하기 전에 반환한다', async () => {
+    vi.mocked(nodemailer.createTransport).mockImplementation(() => {
+      throw new Error('invalid SMTP configuration');
+    });
+    await expect(sender.sendEmail({ ...options, attachments: ['one.zip'] })).resolves.toEqual({
+      success: false,
+      error: 'invalid SMTP configuration',
+    });
+    expect(fs.pathExists).not.toHaveBeenCalled();
+    expect(transport.sendMail).not.toHaveBeenCalled();
+  });
+
+  it('SMTP 검증 실패 뒤 재시도할 수 있으며 메일은 발송하지 않는다', async () => {
+    const failure = Object.assign(new Error('535 Authentication failed'), { code: 'EAUTH' });
+    transport.verify.mockRejectedValueOnce(failure).mockResolvedValueOnce(true);
+    await expect(sender.testConnection()).rejects.toBe(failure);
+    await expect(sender.testConnection()).resolves.toBe(true);
+    expect(nodemailer.createTransport).toHaveBeenCalledOnce();
+    expect(transport.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/resolver/os-resolver-utils.test.ts
+++ b/src/core/resolver/os-resolver-utils.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  convertToSearchResults,
+  createResolverFactory,
+  groupPackagesByName,
+  matchPackagesByQuery,
+  searchPackagesCommon,
+  sortVersionsDescending,
+  type DependencyResolverOptions,
+} from './os-resolver-utils';
+import type { OSPackageInfo } from '../downloaders/os-shared/types';
+import * as versionUtils from '../shared/version-utils';
+
+function pkg(name: string, version = '1.0'): OSPackageInfo {
+  return {
+    name,
+    version,
+    architecture: 'amd64',
+    size: 100,
+    location: `${name}.deb`,
+    dependencies: [],
+    checksum: { type: 'sha256', value: 'checksum' },
+    repository: {
+      id: 'main',
+      name: 'Main',
+      baseUrl: 'https://example.test',
+      enabled: true,
+      gpgCheck: false,
+      isOfficial: true,
+    },
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('OS resolver search helpers', () => {
+  const packages = [
+    pkg('libfoo'),
+    pkg('libfoo-dev'),
+    pkg('libbar'),
+    pkg('other-libfoo'),
+    pkg('foo'),
+  ];
+
+  it('distinguishes exact names from the default partial search', () => {
+    expect(matchPackagesByQuery(packages, 'libfoo', 'exact')).toEqual([packages[0]]);
+    expect(matchPackagesByQuery(packages, 'libfoo')).toEqual([
+      packages[0],
+      packages[1],
+      packages[3],
+    ]);
+    expect(matchPackagesByQuery(packages, 'LIBFOO')).toEqual([]);
+  });
+
+  it.each([
+    { query: 'lib*', expected: ['libfoo', 'libfoo-dev', 'libbar'] },
+    { query: '*foo', expected: ['libfoo', 'other-libfoo', 'foo'] },
+    { query: 'lib???', expected: ['libfoo', 'libbar'] },
+    { query: 'lib??', expected: [] },
+  ])('supports anchored glob search for $query', ({ query, expected }) => {
+    expect(matchPackagesByQuery(packages, query, 'wildcard').map((result) => result.name)).toEqual(
+      expected
+    );
+  });
+
+  it('returns empty results for absent packages and handles an empty catalog', () => {
+    expect(searchPackagesCommon(packages, 'missing')).toEqual([]);
+    expect(searchPackagesCommon([], '')).toEqual([]);
+    expect(groupPackagesByName([])).toEqual(new Map());
+    expect(convertToSearchResults(new Map())).toEqual([]);
+    expect(sortVersionsDescending([])).toEqual([]);
+  });
+
+  it('groups versions by package name, sorts names and versions, and preserves the input arrays', () => {
+    const input = [
+      pkg('zlib', '1.9'),
+      pkg('alpha', '2.0'),
+      pkg('zlib', '1.10'),
+      pkg('zlib', '2.0'),
+    ];
+    const original = [...input];
+    const grouped = groupPackagesByName(input);
+    expect(grouped.get('zlib')).toEqual([input[0], input[2], input[3]]);
+
+    const results = convertToSearchResults(grouped);
+    expect(results.map((result) => result.name)).toEqual(['alpha', 'zlib']);
+    expect(results[1]).toEqual({
+      name: 'zlib',
+      versions: [input[3], input[2], input[0]],
+      latest: input[3],
+    });
+    expect(input).toEqual(original);
+    expect(grouped.get('zlib')).toEqual([input[0], input[2], input[3]]);
+    expect(searchPackagesCommon(input, 'zlib', 'exact')).toEqual([results[1]]);
+  });
+
+  it('falls back to lexical version ordering when the shared comparator cannot compare a pair', () => {
+    vi.spyOn(versionUtils, 'compareVersions').mockImplementation(() => {
+      throw new Error('unrecognized version format');
+    });
+    const older = pkg('pkg', 'a-custom');
+    const newer = pkg('pkg', 'z-custom');
+    expect(sortVersionsDescending([older, newer])).toEqual([newer, older]);
+  });
+
+  it('normalizes an empty version before invoking the shared comparator', () => {
+    const compare = vi.spyOn(versionUtils, 'compareVersions');
+    const empty = pkg('pkg', '');
+    const versioned = pkg('pkg', '1.0');
+    expect(sortVersionsDescending([empty, versioned])).toEqual([versioned, empty]);
+    expect(compare).toHaveBeenCalledWith('', '1.0');
+  });
+});
+
+describe('createResolverFactory', () => {
+  class Resolver {
+    constructor(readonly options: DependencyResolverOptions) {}
+  }
+
+  function options(): DependencyResolverOptions {
+    const repository = pkg('example').repository;
+    return {
+      distribution: {
+        id: 'ubuntu-22.04',
+        name: 'Ubuntu',
+        version: '22.04',
+        packageManager: 'apt',
+        architectures: ['amd64', 'arm64'],
+        defaultRepos: [repository],
+        extendedRepos: [],
+      },
+      architecture: 'amd64',
+      repositories: [repository],
+      includeOptional: false,
+      includeRecommends: false,
+    };
+  }
+
+  it('requires options and recovers on the next valid request', () => {
+    const create = createResolverFactory(Resolver, 'APT resolver');
+    expect(() => create()).toThrow('APT resolver requires DependencyResolverOptions');
+    const opts = options();
+    expect(create(opts).options).toBe(opts);
+  });
+
+  it('reuses an instance for equivalent options and keeps distinct factories isolated', () => {
+    const firstFactory = createResolverFactory(Resolver, 'APT');
+    const secondFactory = createResolverFactory(Resolver, 'APT');
+    const opts = options();
+    const first = firstFactory(opts);
+    expect(
+      firstFactory({
+        ...opts,
+        distribution: { ...opts.distribution },
+        repositories: [...opts.repositories],
+      })
+    ).toBe(first);
+    expect(secondFactory(opts)).not.toBe(first);
+  });
+
+  it.each([
+    {
+      field: 'distribution',
+      change: (opts: DependencyResolverOptions) => ({
+        ...opts,
+        distribution: { ...opts.distribution, id: 'ubuntu-24.04' },
+      }),
+    },
+    {
+      field: 'architecture',
+      change: (opts: DependencyResolverOptions) => ({ ...opts, architecture: 'arm64' as const }),
+    },
+    {
+      field: 'includeOptional',
+      change: (opts: DependencyResolverOptions) => ({ ...opts, includeOptional: true }),
+    },
+    {
+      field: 'includeRecommends',
+      change: (opts: DependencyResolverOptions) => ({ ...opts, includeRecommends: true }),
+    },
+    {
+      field: 'repositories',
+      change: (opts: DependencyResolverOptions) => ({
+        ...opts,
+        repositories: [{ ...opts.repositories[0], id: 'universe' }],
+      }),
+    },
+  ])('creates and caches a fresh resolver when $field changes', ({ change }) => {
+    const create = createResolverFactory(Resolver, 'APT');
+    const opts = options();
+    const first = create(opts);
+    const changed = change(opts);
+    const second = create(changed);
+    expect(second).not.toBe(first);
+    expect(second.options).toBe(changed);
+    expect(create(changed)).toBe(second);
+  });
+
+  it.each(['abortSignal', 'onProgress'] as const)(
+    'isolates request-specific %s without replacing the reusable instance',
+    (field) => {
+      const create = createResolverFactory(Resolver, 'APT');
+      const opts = options();
+      const cached = create(opts);
+      const requestOptions = {
+        ...opts,
+        [field]: field === 'abortSignal' ? new AbortController().signal : vi.fn(),
+      };
+      const firstRequest = create(requestOptions);
+      const secondRequest = create(requestOptions);
+      expect(firstRequest).not.toBe(cached);
+      expect(secondRequest).not.toBe(firstRequest);
+      expect(firstRequest.options).toBe(requestOptions);
+      expect(create(opts)).toBe(cached);
+    }
+  );
+
+  it('does not cache a failed constructor', () => {
+    const construct = vi.fn().mockImplementationOnce(() => {
+      throw new Error('metadata initialization failed');
+    });
+    class FallibleResolver {
+      constructor(_options: DependencyResolverOptions) {
+        construct();
+      }
+    }
+    const create = createResolverFactory(FallibleResolver, 'APT');
+    const opts = options();
+    expect(() => create(opts)).toThrow('metadata initialization failed');
+    const resolved = create(opts);
+    expect(create(opts)).toBe(resolved);
+    expect(construct).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/shared/axios-http-client.test.ts
+++ b/src/core/shared/axios-http-client.test.ts
@@ -1,0 +1,183 @@
+import { PassThrough } from 'stream';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AxiosHttpClient,
+  getDefaultHttpClient,
+  resetDefaultHttpClient,
+  setDefaultHttpClient,
+} from './axios-http-client';
+import { HttpError } from './http-client';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+}));
+vi.mock('axios', () => ({ default: { create: vi.fn(), isAxiosError: vi.fn() } }));
+
+describe('Axios HTTP 어댑터', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resetDefaultHttpClient();
+    vi.mocked(axios.create).mockReturnValue(transport as never);
+    vi.mocked(axios.isAxiosError).mockImplementation((error) => Boolean(error?.isAxiosError));
+  });
+  afterEach(() => resetDefaultHttpClient());
+
+  it('기본 timeout, redirect 제한 및 사용자 에이전트를 설정한다', () => {
+    new AxiosHttpClient();
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: undefined,
+      timeout: 30000,
+      headers: { 'User-Agent': 'DepsSmuggler/1.0' },
+      maxRedirects: 5,
+    });
+  });
+
+  it('명시한 0 옵션과 사용자 헤더를 덮어쓰지 않는다', () => {
+    new AxiosHttpClient({
+      baseURL: 'https://registry.example',
+      timeout: 0,
+      maxRedirects: 0,
+      headers: { 'User-Agent': 'custom', Accept: 'application/json' },
+    });
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: 'https://registry.example',
+      timeout: 0,
+      maxRedirects: 0,
+      headers: { 'User-Agent': 'custom', Accept: 'application/json' },
+    });
+  });
+
+  it.each(['get', 'post', 'put', 'delete', 'head'] as const)(
+    '%s 응답의 데이터, 상태 및 헤더를 보존한다',
+    async (method) => {
+      transport[method].mockResolvedValue({
+        data: null,
+        status: 204,
+        statusText: 'No Content',
+        headers: { 'X-Token': 'abc', 'Set-Cookie': ['a=1', 'b=2'], ignored: undefined },
+      });
+      const client = new AxiosHttpClient();
+      const result = await client[method]('/packages');
+      expect(result).toEqual({
+        data: null,
+        status: 204,
+        statusText: 'No Content',
+        headers: { 'x-token': 'abc', 'set-cookie': 'a=1, b=2' },
+      });
+      if (method === 'post' || method === 'put') {
+        expect(transport[method]).toHaveBeenCalledExactlyOnceWith('/packages', undefined, {});
+      } else {
+        expect(transport[method]).toHaveBeenCalledExactlyOnceWith('/packages', {});
+      }
+    }
+  );
+
+  it.each(['post', 'put'] as const)('%s 요청의 빈 본문을 그대로 전달한다', async (method) => {
+    transport[method].mockResolvedValue({ data: {}, status: 200, statusText: 'OK' });
+    await new AxiosHttpClient()[method]('/packages', '', { headers: { Accept: 'text/plain' } });
+    expect(transport[method]).toHaveBeenCalledWith('/packages', '', {
+      headers: { Accept: 'text/plain' },
+    });
+  });
+
+  it('요청 옵션과 진행률 및 취소 signal을 전달한다', async () => {
+    transport.get.mockResolvedValue({ data: 'ok', status: 200, statusText: 'OK' });
+    const signal = new AbortController().signal;
+    const onDownloadProgress = vi.fn();
+    const validateStatus = (status: number) => status < 400;
+    await new AxiosHttpClient().get('/packages', {
+      params: { q: '', limit: 0, all: false },
+      headers: { Accept: 'text/plain' },
+      timeout: 0,
+      maxRedirects: 0,
+      responseType: 'text',
+      onDownloadProgress,
+      signal,
+      validateStatus,
+    });
+    const config = transport.get.mock.calls[0][1];
+    expect(config).toEqual({
+      params: { q: '', limit: 0, all: false },
+      headers: { Accept: 'text/plain' },
+      timeout: 0,
+      maxRedirects: 0,
+      responseType: 'text',
+      onDownloadProgress: expect.any(Function),
+      signal,
+      validateStatus,
+    });
+    config.onDownloadProgress({ loaded: 3, total: 6, progress: 0.5, bytes: 3 });
+    expect(onDownloadProgress).toHaveBeenCalledExactlyOnceWith({
+      loaded: 3,
+      total: 6,
+      progress: 0.5,
+    });
+  });
+
+  it('스트림 요청은 responseType을 stream으로 설정한다', async () => {
+    const stream = new PassThrough();
+    transport.get.mockResolvedValue({ data: stream, status: 200, statusText: 'OK', headers: {} });
+    const result = await new AxiosHttpClient().getStream('/large-package', {
+      responseType: 'json',
+    });
+    expect(transport.get).toHaveBeenCalledWith('/large-package', { responseType: 'stream' });
+    expect(result.data).toBe(stream);
+    stream.destroy();
+  });
+
+  it.each(['get', 'post', 'put', 'delete', 'head', 'getStream'] as const)(
+    '%s의 인증 거부 상태와 응답을 HttpError로 전달한다',
+    async (method) => {
+      const denied = {
+        isAxiosError: true,
+        message: 'Forbidden',
+        response: {
+          status: 403,
+          statusText: 'Forbidden',
+          data: { error: 'access denied' },
+          headers: { 'X-Request-ID': 'trace-123' },
+        },
+      };
+      transport[method === 'getStream' ? 'get' : method].mockRejectedValue(denied);
+      const result = new AxiosHttpClient()[method]('/private');
+      await expect(result).rejects.toBeInstanceOf(HttpError);
+      await expect(result).rejects.toMatchObject({
+        message: 'Forbidden',
+        status: 403,
+        statusText: 'Forbidden',
+        response: { data: { error: 'access denied' }, headers: { 'x-request-id': 'trace-123' } },
+      });
+    }
+  );
+
+  it.each([
+    [{ isAxiosError: true, message: 'timeout' }, 'timeout'],
+    [new TypeError('invalid URL'), 'invalid URL'],
+    ['network offline', 'network offline'],
+    [null, 'null'],
+  ])('응답 없는 오류를 HttpError로 정규화한다: %s', async (failure, message) => {
+    transport.get.mockRejectedValue(failure);
+    await expect(new AxiosHttpClient().get('')).rejects.toMatchObject({
+      name: 'HttpError',
+      message,
+      status: undefined,
+      response: undefined,
+    });
+  });
+
+  it('기본 클라이언트 주입과 리셋을 독립적으로 수행한다', () => {
+    const initial = getDefaultHttpClient();
+    expect(getDefaultHttpClient()).toBe(initial);
+    const custom = new AxiosHttpClient({ baseURL: 'https://custom.example' });
+    setDefaultHttpClient(custom);
+    expect(getDefaultHttpClient()).toBe(custom);
+    resetDefaultHttpClient();
+    expect(getDefaultHttpClient()).not.toBe(custom);
+    expect(axios.create).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/core/shared/cache/cache-store.test.ts
+++ b/src/core/shared/cache/cache-store.test.ts
@@ -1,0 +1,214 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheStore } from './cache-store';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  rmSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+vi.mock('../../../utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const createStore = () =>
+  new CacheStore<unknown>({
+    name: 'test',
+    ttlMs: 1000,
+    diskTtlMs: 2000,
+    diskCachePath: 'test-cache',
+  });
+const denied = () => {
+  throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+};
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('공유 캐시 경계와 오류 복구', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(10000);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it.each([false, 0, '', []])('빈 키와 falsy 값 %j도 캐시 히트로 처리한다', async (value) => {
+    const cache = createStore();
+    cache.set('', value);
+    const fetcher = vi.fn();
+    await expect(cache.getOrFetch('', fetcher)).resolves.toEqual({
+      data: value,
+      fromCache: true,
+      cacheType: 'memory',
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('TTL 경계 바로 전에는 유효하고 경계에서는 만료된다', () => {
+    const cache = createStore();
+    cache.set('key', 'value');
+    vi.setSystemTime(10999);
+    expect(cache.has('key')).toBe(true);
+    vi.setSystemTime(11000);
+    expect(cache.get('key')).toBeUndefined();
+    expect(cache.size).toBe(0);
+    expect(cache.getStats()).toMatchObject({ evictions: 1, misses: 1 });
+  });
+
+  it('동시 요청이 함께 실패해도 대기 상태를 해제하고 재시도할 수 있다', async () => {
+    const cache = createStore();
+    const first = deferred<string>();
+    const fetcher = vi.fn().mockReturnValueOnce(first.promise).mockResolvedValueOnce('recovered');
+    const original = cache.getOrFetch('key', fetcher);
+    const joined = cache.getOrFetch('key', fetcher);
+    const results = Promise.allSettled([original, joined]);
+    const failure = new Error('registry unavailable');
+    first.reject(failure);
+    const settled = await results;
+    expect(settled[0]).toEqual({ status: 'rejected', reason: failure });
+    expect(settled[1]).toMatchObject({ status: 'rejected' });
+    expect(cache.getStats().pendingRequests).toBe(0);
+    expect(cache.has('key')).toBe(false);
+    await expect(cache.getOrFetch('key', fetcher)).resolves.toEqual({
+      data: 'recovered',
+      fromCache: false,
+      cacheType: 'network',
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupeFetch의 null 결과는 저장하지 않고 다음 요청에서 다시 조회한다', async () => {
+    const cache = createStore();
+    const fetcher = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce('found');
+    await expect(cache.dedupeFetch('key', fetcher)).resolves.toBeNull();
+    expect(cache.has('key')).toBe(false);
+    expect(cache.getStats().pendingRequests).toBe(0);
+    await expect(cache.dedupeFetch('key', fetcher)).resolves.toBe('found');
+    expect(cache.get('key')).toBe('found');
+  });
+
+  it('dedupeFetch는 진행 중인 실패를 모든 호출자에게 전달하고 대기를 해제한다', async () => {
+    const cache = createStore();
+    const deferredRequest = deferred<string>();
+    const fetcher = vi.fn(() => deferredRequest.promise);
+    const first = cache.dedupeFetch('key', fetcher);
+    const second = cache.dedupeFetch('key', fetcher);
+    const results = Promise.allSettled([first, second]);
+    const failure = new Error('timeout');
+    deferredRequest.reject(failure);
+    expect(await results).toEqual([
+      { status: 'rejected', reason: failure },
+      { status: 'rejected', reason: failure },
+    ]);
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(cache.getStats().pendingRequests).toBe(0);
+  });
+
+  it('디스크 읽기 권한 오류는 네트워크 조회로 복구한다', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockImplementation(denied);
+    const cache = createStore();
+    const fetcher = vi.fn().mockResolvedValue({ name: 'requests' });
+    await expect(cache.getOrFetch('requests', fetcher)).resolves.toEqual({
+      data: { name: 'requests' },
+      fromCache: false,
+      cacheType: 'network',
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it.each(['mkdirSync', 'writeFileSync'] as const)(
+    '디스크 %s 권한 오류가 메모리 캐시를 손상시키지 않는다',
+    (operation) => {
+      vi.mocked(fs[operation]).mockImplementation(denied);
+      const cache = createStore();
+      expect(() => cache.set('key', 'value')).not.toThrow();
+      expect(cache.get('key')).toBe('value');
+    }
+  );
+
+  it.each(['', '{invalid'])('손상된 디스크 JSON %j는 메모리에 저장하지 않는다', (content) => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(content);
+    const cache = createStore();
+    expect(cache.getFromDisk('key')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('디스크 TTL이 끝나면 파일을 제거하고 네트워크에서 다시 조회한다', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ data: JSON.stringify('stale'), cachedAt: 8000 })
+    );
+    const cache = createStore();
+    const fetcher = vi.fn().mockResolvedValue('fresh');
+    await expect(cache.getOrFetch('key', fetcher)).resolves.toMatchObject({
+      data: 'fresh',
+      fromCache: false,
+    });
+    expect(fs.unlinkSync).toHaveBeenCalledWith(path.join('test-cache', 'key.json'));
+  });
+
+  it('사용자 역직렬화 실패를 캐시 미스로 처리한다', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ data: 'bad', cachedAt: 10000 }));
+    const cache = new CacheStore({
+      name: 'custom',
+      ttlMs: 1000,
+      diskCachePath: 'test-cache',
+      deserialize: () => {
+        throw new Error('invalid format');
+      },
+    });
+    expect(cache.getFromDisk('key')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('파일 삭제 권한이 없어도 메모리 삭제와 초기화를 완료한다', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.unlinkSync).mockImplementation(denied);
+    vi.mocked(fs.rmSync).mockImplementation(denied);
+    const cache = createStore();
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.has('a')).toBe(false);
+    expect(() => cache.clear()).not.toThrow();
+    expect(cache.size).toBe(0);
+  });
+
+  it('prune은 손상되거나 만료된 JSON만 지우고 다른 파일은 보존한다', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'fresh.json',
+      'expired.json',
+      'broken.json',
+      'README.txt',
+    ] as never);
+    vi.mocked(fs.readFileSync).mockImplementation((target) => {
+      if (String(target).endsWith('broken.json')) return '{broken';
+      return JSON.stringify({
+        data: JSON.stringify('data'),
+        cachedAt: String(target).endsWith('expired.json') ? 8000 : 10000,
+      });
+    });
+    const cache = createStore();
+    expect(cache.prune()).toBe(2);
+    expect(
+      vi.mocked(fs.unlinkSync).mock.calls.map(([target]) => path.basename(String(target)))
+    ).toEqual(['expired.json', 'broken.json']);
+    expect(cache.getStats().evictions).toBe(2);
+  });
+});

--- a/src/core/shared/conda-utils.test.ts
+++ b/src/core/shared/conda-utils.test.ts
@@ -1,0 +1,420 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AnacondaFileInfo, RepoData, RepoDataPackage } from './conda-types';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  decompress: vi.fn(),
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('axios', () => ({ default: { get: mocks.get } }));
+vi.mock('fzstd', () => ({ decompress: mocks.decompress }));
+vi.mock('../../utils/logger', () => ({ default: mocks.logger }));
+
+let getCondaDownloadUrl: typeof import('./conda-utils').getCondaDownloadUrl;
+let getCondaSubdir: typeof import('./conda-utils').getCondaSubdir;
+const baseUrl = 'https://conda.anaconda.org';
+
+function pkg(overrides: Partial<RepoDataPackage> = {}): RepoDataPackage {
+  return {
+    name: 'numpy',
+    version: '2.0.0',
+    build: 'py312_0',
+    build_number: 0,
+    depends: ['python >=3.12'],
+    subdir: 'linux-64',
+    size: 4096,
+    ...overrides,
+  };
+}
+
+function apiFile(overrides: Partial<AnacondaFileInfo> = {}): AnacondaFileInfo {
+  return {
+    basename: 'linux-64/numpy-2.0.0-py312_0.conda',
+    version: '2.0.0',
+    size: 8192,
+    attrs: { subdir: 'linux-64', build: 'py312_0', build_number: 0 },
+    download_url:
+      '//api.anaconda.org/download/conda-forge/numpy/2.0.0/linux-64/numpy-2.0.0-py312_0.conda',
+    ...overrides,
+  };
+}
+
+function serveIndexes(indexes: Record<string, RepoData>, files: AnacondaFileInfo[] = []) {
+  mocks.get.mockImplementation(async (url: string) => {
+    if (url.endsWith('/files')) return { data: files };
+    if (url.endsWith('/current_repodata.json')) {
+      const subdir = url.split('/').at(-2)!;
+      return { data: indexes[subdir] ?? { packages: {} } };
+    }
+    throw new Error(`mock index unavailable: ${url}`);
+  });
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.resetAllMocks();
+  mocks.get.mockRejectedValue(new Error('mock network unavailable'));
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  ({ getCondaDownloadUrl, getCondaSubdir } = await import('./conda-utils'));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('getCondaSubdir', () => {
+  it.each([
+    [undefined, undefined, 'linux-64'],
+    ['linux', 'x86_64', 'linux-64'],
+    ['LINUX', 'ARM64', 'linux-aarch64'],
+    ['linux', 'aarch64', 'linux-aarch64'],
+    ['macos', 'x86_64', 'osx-64'],
+    ['darwin', 'arm64', 'osx-arm64'],
+    ['macos', 'aarch64', 'osx-arm64'],
+    ['windows', 'amd64', 'win-64'],
+    ['windows', 'arm64', 'win-arm64'],
+    ['windows', 'aarch64', 'win-arm64'],
+    ['unknown', 'arm64', 'linux-64'],
+    ['', '', 'linux-64'],
+  ])('maps OS %s and architecture %s to %s', (os, arch, subdir) => {
+    expect(getCondaSubdir(os, arch)).toBe(subdir);
+    expect(mocks.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('Conda repodata retrieval and caching', () => {
+  it('decodes a zstd index and returns the exact package URL, filename and size', async () => {
+    const compressed = Uint8Array.from([1, 2, 3, 4]);
+    const repodata: RepoData = {
+      packages: {},
+      'packages.conda': { 'numpy-2.0.0-py312_0.conda': pkg() },
+    };
+    mocks.get.mockResolvedValueOnce({ data: compressed.buffer });
+    mocks.decompress.mockReturnValueOnce(new TextEncoder().encode(JSON.stringify(repodata)));
+    await expect(
+      getCondaDownloadUrl('numpy', '2.0.0', 'x86_64', 'linux', 'conda-forge', '3.12')
+    ).resolves.toEqual({
+      url: `${baseUrl}/conda-forge/linux-64/numpy-2.0.0-py312_0.conda`,
+      filename: 'numpy-2.0.0-py312_0.conda',
+      size: 4096,
+    });
+    expect(mocks.get).toHaveBeenCalledExactlyOnceWith(
+      `${baseUrl}/conda-forge/linux-64/repodata.json.zst`,
+      {
+        responseType: 'arraybuffer',
+        headers: { 'User-Agent': 'DepsSmuggler/1.0' },
+        timeout: 120000,
+      }
+    );
+    expect(mocks.decompress).toHaveBeenCalledExactlyOnceWith(compressed);
+  });
+
+  it.each(['download', 'decompression', 'invalid-json'] as const)(
+    'falls back to current repodata after a compressed %s failure',
+    async (failure) => {
+      if (failure === 'download') mocks.get.mockRejectedValueOnce(new Error('404'));
+      else {
+        mocks.get.mockResolvedValueOnce({ data: new Uint8Array([0]).buffer });
+        if (failure === 'decompression')
+          mocks.decompress.mockImplementationOnce(() => {
+            throw new Error('invalid zstd frame');
+          });
+        else mocks.decompress.mockReturnValueOnce(new TextEncoder().encode('not json'));
+      }
+      mocks.get.mockResolvedValueOnce({ data: { packages: { 'numpy.tar.bz2': pkg() } } });
+      await expect(getCondaDownloadUrl('numpy', '2.0.0')).resolves.toEqual({
+        url: `${baseUrl}/conda-forge/linux-64/numpy.tar.bz2`,
+        filename: 'numpy.tar.bz2',
+        size: 4096,
+      });
+      expect(mocks.get.mock.calls.map(([url]) => url)).toEqual([
+        `${baseUrl}/conda-forge/linux-64/repodata.json.zst`,
+        `${baseUrl}/conda-forge/linux-64/current_repodata.json`,
+      ]);
+    }
+  );
+
+  it('tries full repodata when both compressed and current indexes fail', async () => {
+    mocks.get
+      .mockRejectedValueOnce(new Error('zstd unsupported'))
+      .mockRejectedValueOnce(new Error('current index unavailable'))
+      .mockResolvedValueOnce({ data: { packages: { 'numpy.tar.bz2': pkg() } } });
+    const result = await getCondaDownloadUrl('numpy', '2.0.0');
+    expect(result?.filename).toBe('numpy.tar.bz2');
+    expect(mocks.get.mock.calls.map(([url]) => url)).toEqual([
+      `${baseUrl}/conda-forge/linux-64/repodata.json.zst`,
+      `${baseUrl}/conda-forge/linux-64/current_repodata.json`,
+      `${baseUrl}/conda-forge/linux-64/repodata.json`,
+    ]);
+  });
+
+  it('reuses the index across package lookups but separates channel and platform caches', async () => {
+    serveIndexes({
+      'linux-64': {
+        packages: { 'numpy-linux.conda': pkg(), 'scipy-linux.conda': pkg({ name: 'scipy' }) },
+      },
+      'osx-arm64': { packages: { 'numpy-mac.conda': pkg({ subdir: 'osx-arm64' }) } },
+    });
+    expect((await getCondaDownloadUrl('numpy', '2.0.0'))?.filename).toBe('numpy-linux.conda');
+    expect((await getCondaDownloadUrl('scipy', '2.0.0'))?.filename).toBe('scipy-linux.conda');
+    expect(mocks.get).toHaveBeenCalledTimes(2);
+    expect((await getCondaDownloadUrl('numpy', '2.0.0', 'arm64', 'macos'))?.filename).toBe(
+      'numpy-mac.conda'
+    );
+    expect(
+      (await getCondaDownloadUrl('numpy', '2.0.0', 'x86_64', 'linux', 'custom-channel'))?.url
+    ).toContain('/custom-channel/linux-64/');
+    expect(mocks.get).toHaveBeenCalledTimes(6);
+    expect(mocks.get.mock.calls.map(([url]) => url)).toContain(
+      `${baseUrl}/custom-channel/linux-64/current_repodata.json`
+    );
+  });
+
+  it('does not cache failed index requests, allowing a later retry to recover', async () => {
+    await expect(getCondaDownloadUrl('numpy', '2.0.0')).resolves.toBeNull();
+    expect(mocks.get).toHaveBeenCalledTimes(7);
+    serveIndexes({ 'linux-64': { packages: { 'numpy.conda': pkg() } } });
+    expect((await getCondaDownloadUrl('numpy', '2.0.0'))?.filename).toBe('numpy.conda');
+    expect(mocks.get).toHaveBeenCalledTimes(9);
+  });
+});
+
+describe('Conda package and Python build selection', () => {
+  it('uses the highest compatible Python build before newer incompatible builds', async () => {
+    serveIndexes({
+      'linux-64': {
+        packages: {
+          'wrong-package.conda': pkg({ name: 'other', build_number: 99 }),
+          'wrong-version.conda': pkg({ version: '3.0.0', build_number: 99 }),
+          'numpy-py311.conda': pkg({ build: 'py311_50', build_number: 50 }),
+          'numpy-py312-older.conda': pkg({ build: 'py312_1', build_number: 1 }),
+          'numpy-cp312-newer.conda': pkg({ build: 'cp312_4', build_number: 4 }),
+        },
+      },
+    });
+    await expect(
+      getCondaDownloadUrl('numpy', '2.0.0', undefined, undefined, undefined, '3.12.4')
+    ).resolves.toEqual({
+      url: `${baseUrl}/conda-forge/linux-64/numpy-cp312-newer.conda`,
+      filename: 'numpy-cp312-newer.conda',
+      size: 4096,
+    });
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('accepts native libraries without a Python build tag for a specified Python version', async () => {
+    serveIndexes({
+      'linux-64': {
+        packages: {
+          'libblas.conda': pkg({
+            name: 'libblas',
+            build: 'openblas_h123_7',
+            build_number: 7,
+            depends: [],
+          }),
+        },
+      },
+    });
+    expect(
+      (await getCondaDownloadUrl('libblas', '2.0.0', undefined, undefined, undefined, '3.12'))
+        ?.filename
+    ).toBe('libblas.conda');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, '', 'not-a-version'])(
+    'chooses the highest build when Python version is %s',
+    async (pythonVersion) => {
+      serveIndexes({
+        'linux-64': {
+          packages: {
+            'numpy-older.conda': pkg({ build: 'py312_0', build_number: 0 }),
+            'numpy-newer.conda': pkg({ build: 'py311_8', build_number: 8 }),
+          },
+        },
+      });
+      expect(
+        (
+          await getCondaDownloadUrl(
+            'numpy',
+            '2.0.0',
+            undefined,
+            undefined,
+            undefined,
+            pythonVersion
+          )
+        )?.filename
+      ).toBe('numpy-newer.conda');
+    }
+  );
+
+  it('prefers a .conda artifact over a legacy archive with the same build number', async () => {
+    serveIndexes({
+      'linux-64': {
+        packages: { 'numpy.tar.bz2': pkg() },
+        'packages.conda': { 'numpy.conda': pkg() },
+      },
+    });
+    expect((await getCondaDownloadUrl('numpy', '2.0.0'))?.filename).toBe('numpy.conda');
+  });
+
+  it('checks noarch when target-platform repodata has no matching package and defaults missing size to zero', async () => {
+    serveIndexes({
+      'linux-64': { packages: { 'wrong-version.conda': pkg({ version: '1.0.0' }) } },
+      noarch: {
+        packages: {
+          'numpy-noarch.conda': pkg({ subdir: 'noarch', build: 'pyhd8ed1ab_0', size: undefined }),
+        },
+      },
+    });
+    await expect(
+      getCondaDownloadUrl('numpy', '2.0.0', undefined, undefined, undefined, '3.12')
+    ).resolves.toEqual({
+      url: `${baseUrl}/conda-forge/noarch/numpy-noarch.conda`,
+      filename: 'numpy-noarch.conda',
+      size: 0,
+    });
+    expect(mocks.get.mock.calls.some(([url]) => String(url).endsWith('/files'))).toBe(false);
+  });
+
+  it('still checks noarch when all target-platform index requests fail', async () => {
+    mocks.get.mockImplementation(async (url: string) => {
+      if (url === `${baseUrl}/conda-forge/noarch/current_repodata.json`) {
+        return { data: { packages: { 'numpy-noarch.conda': pkg({ subdir: 'noarch' }) } } };
+      }
+      throw new Error('mock 404');
+    });
+    expect((await getCondaDownloadUrl('numpy', '2.0.0'))?.url).toBe(
+      `${baseUrl}/conda-forge/noarch/numpy-noarch.conda`
+    );
+    expect(mocks.get).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('Conda Anaconda API fallback and errors', () => {
+  it('falls back to API files and selects the highest compatible Python build in the requested subdir', async () => {
+    serveIndexes({}, [
+      apiFile({ basename: 'linux-64/wrong-version.conda', version: '1.0.0' }),
+      apiFile({
+        basename: 'win-64/wrong-platform.conda',
+        attrs: { subdir: 'win-64', build: 'py312_20', build_number: 20 },
+      }),
+      apiFile({
+        basename: 'linux-64/wrong-python.conda',
+        attrs: { subdir: 'linux-64', build: 'py311_99', build_number: 99 },
+      }),
+      apiFile({
+        basename: 'linux-64/old-build.conda',
+        attrs: { subdir: 'linux-64', build: 'py312_1', build_number: 1 },
+      }),
+      apiFile({
+        basename: 'linux-64/selected.conda',
+        attrs: { subdir: 'linux-64', build: 'cp312_3', build_number: 3 },
+        size: 9000,
+      }),
+    ]);
+    await expect(
+      getCondaDownloadUrl('numpy', '2.0.0', undefined, undefined, 'custom', '3.12')
+    ).resolves.toEqual({
+      url: `${baseUrl}/custom/linux-64/selected.conda`,
+      filename: 'selected.conda',
+      size: 9000,
+    });
+    expect(mocks.get).toHaveBeenLastCalledWith(
+      'https://api.anaconda.org/package/custom/numpy/files',
+      {
+        headers: { 'User-Agent': 'DepsSmuggler/1.0' },
+        timeout: 30000,
+      }
+    );
+    expect(mocks.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('selects the highest API build when no Python version is requested', async () => {
+    serveIndexes({}, [
+      apiFile(),
+      apiFile({
+        basename: 'linux-64/newer.conda',
+        attrs: { subdir: 'linux-64', build: 'py311_7', build_number: 7 },
+      }),
+    ]);
+    expect((await getCondaDownloadUrl('numpy', '2.0.0'))?.filename).toBe('newer.conda');
+  });
+
+  it('uses a matching noarch API file when no requested-subdir file exists', async () => {
+    serveIndexes({}, [
+      apiFile({ version: '1.0.0' }),
+      apiFile({
+        basename: 'noarch/numpy-any.conda',
+        attrs: { subdir: 'noarch', build: 'pyhd8ed1ab_0', build_number: 0 },
+        size: 0,
+      }),
+    ]);
+    await expect(getCondaDownloadUrl('numpy', '2.0.0', 'arm64', 'macos')).resolves.toEqual({
+      url: `${baseUrl}/conda-forge/noarch/numpy-any.conda`,
+      filename: 'numpy-any.conda',
+      size: 0,
+    });
+  });
+
+  it.each<{ files: AnacondaFileInfo[] }>([
+    { files: [] },
+    { files: [apiFile({ version: '1.0.0' })] },
+    { files: [apiFile({ attrs: { subdir: 'win-64', build: 'py312_0', build_number: 0 } })] },
+  ])(
+    'returns null when all metadata lacks matching release/platform files: %j',
+    async ({ files }) => {
+      serveIndexes({}, files);
+      await expect(getCondaDownloadUrl('numpy', '2.0.0')).resolves.toBeNull();
+      expect(mocks.get).toHaveBeenCalledTimes(5);
+      expect(mocks.logger.error).not.toHaveBeenCalled();
+      expect(mocks.logger.warn).toHaveBeenCalledWith(
+        '[conda-utils] API에서도 패키지를 찾을 수 없음',
+        {
+          packageName: 'numpy',
+          version: '2.0.0',
+          subdir: 'linux-64',
+        }
+      );
+      expect(mocks.logger.warn).toHaveBeenCalledWith('[conda-utils] 패키지를 찾을 수 없음', {
+        packageName: 'numpy',
+        version: '2.0.0',
+        channel: 'conda-forge',
+        subdir: 'linux-64',
+      });
+    }
+  );
+
+  it.each(['ECONNRESET', 'ETIMEDOUT', 'HTTP 403'])(
+    'returns null after %s failures exhaust all index and API fallbacks',
+    async (reason) => {
+      const error = new Error(reason);
+      mocks.get.mockRejectedValue(error);
+      await expect(getCondaDownloadUrl('numpy', '2.0.0')).resolves.toBeNull();
+      expect(mocks.get.mock.calls.map(([url]) => url)).toEqual([
+        `${baseUrl}/conda-forge/linux-64/repodata.json.zst`,
+        `${baseUrl}/conda-forge/linux-64/current_repodata.json`,
+        `${baseUrl}/conda-forge/linux-64/repodata.json`,
+        `${baseUrl}/conda-forge/noarch/repodata.json.zst`,
+        `${baseUrl}/conda-forge/noarch/current_repodata.json`,
+        `${baseUrl}/conda-forge/noarch/repodata.json`,
+        'https://api.anaconda.org/package/conda-forge/numpy/files',
+      ]);
+      expect(mocks.logger.error).toHaveBeenCalledWith('[conda-utils] Anaconda API 조회 실패', {
+        packageName: 'numpy',
+        version: '2.0.0',
+        error,
+      });
+    }
+  );
+
+  it('reports a malformed API response as a failed lookup instead of throwing', async () => {
+    serveIndexes({});
+    const getIndexes = mocks.get.getMockImplementation()!;
+    mocks.get.mockImplementation(async (url: string) =>
+      url.endsWith('/files') ? { data: null } : getIndexes(url)
+    );
+    await expect(getCondaDownloadUrl('numpy', '2.0.0')).resolves.toBeNull();
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      '[conda-utils] Anaconda API 조회 실패',
+      expect.objectContaining({ packageName: 'numpy', error: expect.any(TypeError) })
+    );
+  });
+});

--- a/src/core/shared/conda-validator.test.ts
+++ b/src/core/shared/conda-validator.test.ts
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateCondaChannel, validateCondaChannelStrict } from './conda-validator';
+
+vi.mock('axios', () => ({ default: { head: vi.fn() } }));
+
+describe('Conda 채널 검증', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('채널의 noarch 인덱스가 200이면 유효하다', async () => {
+    vi.mocked(axios.head).mockResolvedValue({ status: 200 });
+    await expect(validateCondaChannel('conda-forge')).resolves.toBe(true);
+    expect(axios.head).toHaveBeenCalledWith(
+      'https://conda.anaconda.org/conda-forge/noarch/repodata.json',
+      expect.objectContaining({ timeout: 5000 })
+    );
+    const validate = vi.mocked(axios.head).mock.calls[0][1]!.validateStatus!;
+    expect(validate(200)).toBe(true);
+    expect(validate(403)).toBe(false);
+  });
+
+  it('200 이외의 응답은 유효하지 않다', async () => {
+    vi.mocked(axios.head).mockResolvedValue({ status: 204 });
+    await expect(validateCondaChannel('empty-channel')).resolves.toBe(false);
+  });
+
+  it.each([401, 403, 404, 500])('채널 HTTP %s 오류는 false로 반환한다', async (status) => {
+    vi.mocked(axios.head).mockRejectedValue(
+      Object.assign(new Error(`HTTP ${status}`), { response: { status } })
+    );
+    await expect(validateCondaChannel('private-or-missing')).resolves.toBe(false);
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it('타임아웃과 빈 채널의 접근 실패도 false로 반환한다', async () => {
+    vi.mocked(axios.head).mockRejectedValue(new Error('timeout'));
+    await expect(validateCondaChannel('')).resolves.toBe(false);
+  });
+
+  it('일부 플랫폼이 실패해도 하나의 인덱스가 접근 가능하면 유효하다', async () => {
+    vi.mocked(axios.head)
+      .mockRejectedValueOnce(new Error('404'))
+      .mockResolvedValueOnce({ status: 200 })
+      .mockRejectedValue(new Error('403'));
+    await expect(validateCondaChannelStrict('linux-only')).resolves.toBe(true);
+    expect(axios.head).toHaveBeenCalledTimes(4);
+  });
+
+  it('모든 플랫폼이 실패하면 유효하지 않다', async () => {
+    vi.mocked(axios.head).mockRejectedValue(new Error('network offline'));
+    await expect(validateCondaChannelStrict('offline', ['linux-64', 'noarch'])).resolves.toBe(
+      false
+    );
+    expect(axios.head).toHaveBeenCalledTimes(2);
+  });
+
+  it('빈 플랫폼 목록은 요청하지 않고 false를 반환한다', async () => {
+    await expect(validateCondaChannelStrict('conda-forge', [])).resolves.toBe(false);
+    expect(axios.head).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/shared/file-utils.test.ts
+++ b/src/core/shared/file-utils.test.ts
@@ -1,0 +1,256 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
+import { PassThrough } from 'stream';
+import archiver from 'archiver';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTarGzArchive, createZipArchive, downloadFile } from './file-utils';
+
+vi.mock('fs', () => ({ createWriteStream: vi.fn(), unlink: vi.fn(), unlinkSync: vi.fn() }));
+vi.mock('http', () => ({ get: vi.fn() }));
+vi.mock('https', () => ({ get: vi.fn() }));
+vi.mock('archiver', () => ({ default: vi.fn() }));
+vi.mock('../../utils/logger', () => ({ default: { debug: vi.fn() } }));
+
+function transfer(headers: Record<string, string> = { 'content-length': '6' }, statusCode = 200) {
+  const file = Object.assign(new PassThrough(), { close: vi.fn() });
+  const response = Object.assign(new PassThrough(), { headers, statusCode });
+  const request = Object.assign(new EventEmitter(), { destroy: vi.fn() });
+  const chunks: Buffer[] = [];
+  file.on('data', (chunk: Buffer) => chunks.push(chunk));
+  vi.mocked(fs.createWriteStream).mockReturnValueOnce(file as never);
+  return { file, response, request, chunks };
+}
+
+describe('공유 파일 전송', () => {
+  beforeEach(() => vi.resetAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each(['http', 'https'] as const)(
+    '%s 스트림의 모든 바이트와 누적 진행률을 전달한다',
+    async (protocol) => {
+      const { file, response, request, chunks } = transfer();
+      vi.mocked((protocol === 'http' ? http : https).get).mockImplementationOnce(((
+        _url: unknown,
+        _options: unknown,
+        callback: (response: unknown) => void
+      ) => {
+        callback(response);
+        return request;
+      }) as never);
+      const progress = vi.fn();
+      const pending = downloadFile(
+        `${protocol}://registry.example/package`,
+        'package.bin',
+        progress
+      );
+      response.write(Buffer.from('abc'));
+      response.end(Buffer.from('def'));
+      await pending;
+      expect(Buffer.concat(chunks).toString()).toBe('abcdef');
+      expect(progress.mock.calls).toEqual([
+        [3, 6],
+        [6, 6],
+      ]);
+      expect(file.close).toHaveBeenCalledOnce();
+      expect(fs.unlink).not.toHaveBeenCalled();
+    }
+  );
+
+  it('길이 헤더가 없는 빈 파일도 완료한다', async () => {
+    const { response, request, chunks } = transfer({});
+    vi.mocked(https.get).mockImplementationOnce(((
+      _url: unknown,
+      _options: unknown,
+      callback: (response: unknown) => void
+    ) => {
+      callback(response);
+      return request;
+    }) as never);
+    const progress = vi.fn();
+    const pending = downloadFile('https://registry.example/empty', 'empty.bin', progress);
+    response.end();
+    await pending;
+    expect(Buffer.concat(chunks)).toHaveLength(0);
+    expect(progress).not.toHaveBeenCalled();
+  });
+
+  it('전체 크기를 모르는 스트림은 진행률의 total을 0으로 전달한다', async () => {
+    const { response, request } = transfer({});
+    vi.mocked(http.get).mockImplementationOnce(((
+      _url: unknown,
+      _options: unknown,
+      callback: (response: unknown) => void
+    ) => {
+      callback(response);
+      return request;
+    }) as never);
+    const progress = vi.fn();
+    const pending = downloadFile('http://registry.example/package', 'package.bin', progress);
+    response.end(Buffer.from('abc'));
+    await pending;
+    expect(progress).toHaveBeenCalledExactlyOnceWith(3, 0);
+  });
+
+  it('네트워크 오류는 원본 오류로 거절하고 부분 파일을 정리한다', async () => {
+    const { file, request } = transfer();
+    vi.mocked(https.get).mockReturnValueOnce(request as never);
+    const failure = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    const pending = downloadFile('https://registry.example/package', 'partial.bin', vi.fn());
+    const rejected = expect(pending).rejects.toBe(failure);
+    request.emit('error', failure);
+    await rejected;
+    expect(file.close).toHaveBeenCalledOnce();
+    expect(fs.unlink).toHaveBeenCalledWith('partial.bin', expect.any(Function));
+  });
+
+  it('잘못된 URL을 transport가 거부하면 오류를 전달한다', async () => {
+    const failure = new TypeError('Invalid URL');
+    transfer();
+    vi.mocked(http.get).mockImplementationOnce(() => {
+      throw failure;
+    });
+    await expect(downloadFile('', 'invalid.bin', vi.fn())).rejects.toBe(failure);
+  });
+
+  it('일시정지 후 재개하고 완료 시 감시 타이머를 제거한다', async () => {
+    vi.useFakeTimers();
+    const { file, response, request } = transfer();
+    vi.mocked(https.get).mockImplementationOnce(((
+      _url: unknown,
+      _options: unknown,
+      callback: (response: unknown) => void
+    ) => {
+      callback(response);
+      return request;
+    }) as never);
+    let paused = true;
+    const progress = vi.fn();
+    const pending = downloadFile('https://registry.example/package', 'package.bin', progress, {
+      shouldPause: () => paused,
+    });
+    response.write(Buffer.from('abc'));
+    response.write(Buffer.from('def'));
+    expect(response.isPaused()).toBe(true);
+    expect(progress).toHaveBeenCalledTimes(1);
+    paused = false;
+    await vi.advanceTimersByTimeAsync(100);
+    response.end();
+    await pending;
+    expect(progress.mock.calls).toEqual([
+      [3, 6],
+      [6, 6],
+    ]);
+    expect(file.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('일시정지 중 취소하면 요청과 부분 파일 및 타이머를 정리한다', async () => {
+    vi.useFakeTimers();
+    const { file, response, request } = transfer();
+    vi.mocked(https.get).mockImplementationOnce(((
+      _url: unknown,
+      _options: unknown,
+      callback: (response: unknown) => void
+    ) => {
+      callback(response);
+      return request;
+    }) as never);
+    const controller = new AbortController();
+    const pending = downloadFile('https://registry.example/package', 'partial.bin', vi.fn(), {
+      signal: controller.signal,
+      shouldPause: () => true,
+    });
+    const rejected = expect(pending).rejects.toThrow('Download aborted');
+    response.write(Buffer.from('abc'));
+    controller.abort();
+    await rejected;
+    expect(request.destroy).toHaveBeenCalledOnce();
+    expect(file.close).toHaveBeenCalledOnce();
+    expect(fs.unlink).toHaveBeenCalledWith('partial.bin', expect.any(Function));
+    expect(vi.getTimerCount()).toBe(0);
+    response.destroy();
+    file.destroy();
+  });
+
+  it.each([301, 302])('%s 리다이렉트는 기존 파일을 정리하고 새 주소에서 받는다', async (status) => {
+    const first = transfer({ location: 'https://cdn.example/package' }, status);
+    const second = transfer();
+    const pendingResponses = [first, second];
+    vi.mocked(https.get).mockImplementation(((
+      _url: unknown,
+      _options: unknown,
+      callback: (response: unknown) => void
+    ) => {
+      const next = pendingResponses.shift()!;
+      callback(next.response);
+      return next.request;
+    }) as never);
+    const pending = downloadFile('https://registry.example/package', 'package.bin', vi.fn());
+    second.response.end(Buffer.from('abcdef'));
+    await pending;
+    expect(first.file.close).toHaveBeenCalledOnce();
+    expect(fs.unlinkSync).toHaveBeenCalledWith('package.bin');
+    expect(https.get).toHaveBeenNthCalledWith(
+      2,
+      'https://cdn.example/package',
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(Buffer.concat(second.chunks).toString()).toBe('abcdef');
+  });
+});
+
+describe('공유 압축 유틸리티', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it.each([
+    [createZipArchive, 'zip', { zlib: { level: 9 } }],
+    [createTarGzArchive, 'tar', { gzip: true, gzipOptions: { level: 9 } }],
+  ] as const)(
+    '압축 형식에 맞게 설정하고 출력 close까지 기다린다 (%s)',
+    async (create, format, options) => {
+      const output = new EventEmitter();
+      const archive = Object.assign(new EventEmitter(), {
+        pipe: vi.fn(),
+        directory: vi.fn(),
+        finalize: vi.fn(),
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(output as never);
+      vi.mocked(archiver).mockReturnValue(archive as never);
+      const pending = create('packages', 'archive');
+      const completed = vi.fn();
+      void pending.then(completed);
+      await Promise.resolve();
+      expect(completed).not.toHaveBeenCalled();
+      expect(archiver).toHaveBeenCalledWith(format, options);
+      expect(archive.directory).toHaveBeenCalledWith('packages', false);
+      expect(archive.pipe).toHaveBeenCalledWith(output);
+      expect(archive.finalize).toHaveBeenCalledOnce();
+      output.emit('close');
+      await pending;
+    }
+  );
+
+  it.each([createZipArchive, createTarGzArchive])(
+    '압축기의 권한 오류를 호출자에게 전달한다 (%s)',
+    async (create) => {
+      vi.mocked(fs.createWriteStream).mockReturnValue(new EventEmitter() as never);
+      const archive = Object.assign(new EventEmitter(), {
+        pipe: vi.fn(),
+        directory: vi.fn(),
+        finalize: vi.fn(),
+      });
+      vi.mocked(archiver).mockReturnValue(archive as never);
+      const failure = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      const pending = create('restricted', 'archive');
+      const rejected = expect(pending).rejects.toBe(failure);
+      archive.emit('error', failure);
+      await rejected;
+    }
+  );
+});

--- a/src/core/shared/maven-utils.test.ts
+++ b/src/core/shared/maven-utils.test.ts
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildMavenClassifier,
+  fetchClassifiersFromMavenCentral,
+  getAvailableClassifiers,
+  getAvailableClassifiersAsync,
+  isNativeArtifact,
+  isNativeArtifactFromApi,
+} from './maven-utils';
+
+vi.mock('axios', () => ({ default: { get: vi.fn() } }));
+
+describe('Maven 네이티브 아티팩트 classifier', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    ['Linux', 'AMD64', 'linux-x86_64'],
+    ['darwin', 'arm64', 'osx-aarch_64'],
+    ['macos', 'aarch64', 'osx-aarch_64'],
+    ['windows', 'x86_64', 'windows-x86_64'],
+    ['', 'x86_64', undefined],
+    ['linux', '', undefined],
+    ['unknown', 'x86_64', undefined],
+    ['linux', 'unsupported', undefined],
+  ])('%s/%s를 classifier로 변환하거나 미지원 입력을 제외한다', (os, arch, expected) => {
+    expect(buildMavenClassifier(os, arch)).toBe(expected);
+  });
+
+  it.each([
+    ['netty-transport-native-epoll', true],
+    ['lwjgl-opengl', true],
+    ['lwjgl', true],
+    ['javacpp-platform', true],
+    ['commons-lang3', false],
+    ['', false],
+  ])('%s 아티팩트의 native 여부를 판별한다', (name, expected) => {
+    expect(isNativeArtifact('org.example', name)).toBe(expected);
+  });
+
+  it('알려진 라이브러리와 일반 native 패키지에 classifier 후보를 제공한다', () => {
+    expect(getAvailableClassifiers('org.lwjgl', 'lwjgl-opengl')).toContain('natives-linux');
+    expect(getAvailableClassifiers('org.example', 'custom-native')).toContain('linux-x86_64');
+    expect(getAvailableClassifiers('org.example', 'plain-library')).toEqual([]);
+  });
+
+  it.each([undefined, '3.3.6'])(
+    '버전 %s의 classifier 조회에서 문서·소스·테스트 아티팩트를 제외한다',
+    async (version) => {
+      vi.mocked(axios.get).mockResolvedValue({
+        data: {
+          response: {
+            docs: [
+              {
+                ec: [
+                  '.jar',
+                  '.pom',
+                  '-sources.jar',
+                  '-javadoc.jar',
+                  '-tests.jar',
+                  '-test-sources.jar',
+                  '-natives-linux.jar',
+                  '-natives-macos-arm64.jar',
+                ],
+              },
+            ],
+          },
+        },
+      });
+      await expect(
+        fetchClassifiersFromMavenCentral('org.lwjgl', 'lwjgl', version)
+      ).resolves.toEqual(['natives-linux', 'natives-macos-arm64']);
+      const url = vi.mocked(axios.get).mock.calls[0][0];
+      expect(url).toContain('g:org.lwjgl+AND+a:lwjgl');
+      if (version) expect(url).toContain(`+AND+v:${version}`);
+      else expect(url).not.toContain('+AND+v:');
+      expect(axios.get).toHaveBeenCalledWith(url, { timeout: 10000 });
+    }
+  );
+
+  it.each([
+    undefined,
+    {},
+    { response: { docs: [] } },
+    { response: { docs: [{}] } },
+    { response: { docs: [{ ec: 'invalid' }] } },
+  ])('빈/잘못된 검색 응답은 classifier가 없다', async (data) => {
+    vi.mocked(axios.get).mockResolvedValue({ data });
+    await expect(fetchClassifiersFromMavenCentral('org.example', 'missing')).resolves.toEqual([]);
+  });
+
+  it.each(['403 Forbidden', 'timeout'])('접근 오류를 빈 목록으로 반환한다: %s', async (message) => {
+    vi.mocked(axios.get).mockRejectedValue(new Error(message));
+    await expect(getAvailableClassifiersAsync('org.example', 'private', '1.0')).resolves.toEqual(
+      []
+    );
+    expect(console.error).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [['-linux-x86_64.jar'], true],
+    [['-all.jar'], false],
+    [[], false],
+  ])('API의 플랫폼 classifier 여부로 native를 판별한다', async (ec, expected) => {
+    vi.mocked(axios.get).mockResolvedValue({ data: { response: { docs: [{ ec }] } } });
+    await expect(isNativeArtifactFromApi('org.example', 'library', '1.0')).resolves.toBe(expected);
+  });
+});

--- a/src/core/shared/pip-candidate.test.ts
+++ b/src/core/shared/pip-candidate.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CandidateEvaluator,
+  createCandidateFromRelease,
+  selectBestCandidateFromAllVersions,
+  selectBestCandidateFromReleases,
+} from './pip-candidate';
+import type { CandidateEvaluatorConfig, PyPIReleaseInfo } from './pip-candidate';
+
+const config: CandidateEvaluatorConfig = {
+  pythonVersion: '3.11',
+  platform: 'windows',
+  arch: 'x86_64',
+};
+function release(filename: string, extra: Partial<PyPIReleaseInfo> = {}): PyPIReleaseInfo {
+  return {
+    filename,
+    url: `https://files.example/${filename}`,
+    size: 100,
+    digests: { sha256: 'known-hash' },
+    packagetype: filename.endsWith('.whl') ? 'bdist_wheel' : 'sdist',
+    python_version: 'py3',
+    ...extra,
+  };
+}
+const candidate = (
+  version = '1.0',
+  filename = `demo-${version}-py3-none-any.whl`,
+  extra: Partial<PyPIReleaseInfo> = {}
+) => createCandidateFromRelease('Demo-Package', version, release(filename, extra));
+
+describe('pip 설치 후보 평가', () => {
+  it('릴리스의 배포 메타데이터와 정규화한 이름을 보존한다', () => {
+    const result = candidate('1.0', 'demo-1.0-py3-none-any.whl', {
+      requires_python: '>=3.8',
+      yanked: true,
+      yanked_reason: 'broken release',
+    });
+    expect(result).toMatchObject({
+      name: 'demo_package',
+      version: '1.0',
+      packageType: 'wheel',
+      size: 100,
+      hash: 'known-hash',
+      requiresPython: '>=3.8',
+      isYanked: true,
+      yankedReason: 'broken release',
+    });
+    expect(result.wheelInfo).toBeDefined();
+  });
+
+  it('소스 배포와 비어 있는 Python 요구사항을 처리한다', () => {
+    expect(candidate('1.0', 'demo-1.0.tar.gz', { requires_python: null })).toMatchObject({
+      packageType: 'sdist',
+      wheelInfo: undefined,
+      requiresPython: undefined,
+    });
+  });
+
+  it.each([
+    ['>=3.11', true],
+    ['>=3.12', false],
+    ['>3.10', true],
+    ['>3.11', false],
+    ['<=3.11', true],
+    ['<=3.10', false],
+    ['<3.12', true],
+    ['<3.11', false],
+    ['==3.11', true],
+    ['==3.10', false],
+    ['!=3.10', true],
+    ['!=3.11', false],
+    ['>=3.8,<3.12', true],
+    ['>=3.8,!=3.11', false],
+  ])('Python 3.11에 대한 %s 요구사항을 평가한다', (requires_python, applicable) => {
+    expect(
+      new CandidateEvaluator(config).isApplicable(candidate('1.0', undefined, { requires_python }))
+    ).toBe(applicable);
+  });
+
+  it('대상 플랫폼과 Python ABI가 다른 wheel을 제외한다', () => {
+    const evaluator = new CandidateEvaluator(config);
+    expect(
+      evaluator.isApplicable(candidate('1.0', 'demo-1.0-cp311-cp311-manylinux_2_17_x86_64.whl'))
+    ).toBe(false);
+    expect(evaluator.isApplicable(candidate('1.0', 'demo-1.0-cp312-cp312-win_amd64.whl'))).toBe(
+      false
+    );
+    expect(evaluator.isApplicable(candidate('1.0', 'demo-1.0-cp38-abi3-win_amd64.whl'))).toBe(true);
+  });
+
+  it('철회된 배포는 기본 제외하고 명시적으로 허용할 수 있다', () => {
+    const yanked = candidate('1.0', undefined, { yanked: true });
+    expect(new CandidateEvaluator(config).sortBestCandidate([yanked])).toBeNull();
+    expect(
+      new CandidateEvaluator({ ...config, allowYanked: true }).sortBestCandidate([yanked])
+    ).toBe(yanked);
+  });
+
+  it.each(['2.0a1', '2.0b1', '2.0rc1', '2.0.dev1'])(
+    '시험 배포 %s는 허용 옵션에 따라 제외한다',
+    (version) => {
+      const prerelease = candidate(version);
+      expect(new CandidateEvaluator(config).isApplicable(prerelease)).toBe(false);
+      expect(
+        new CandidateEvaluator({ ...config, allowPrerelease: true }).isApplicable(prerelease)
+      ).toBe(true);
+    }
+  );
+
+  it('같은 버전에서 네이티브 wheel을 순수 Python wheel 및 소스보다 우선한다', () => {
+    const native = candidate('1.0', 'demo-1.0-cp311-cp311-win_amd64.whl');
+    const pure = candidate();
+    const source = candidate('1.0', 'demo-1.0.tar.gz');
+    const input = [source, pure, native];
+    const result = new CandidateEvaluator(config).computeBestCandidate(input);
+    expect(result.bestCandidate).toBe(native);
+    expect(result.applicableCandidates).toEqual([native, pure, source]);
+    expect(input).toEqual([source, pure, native]);
+    expect(result.allCandidates).toBe(input);
+  });
+
+  it('binary 선호를 끄면 더 높은 소스 배포 버전을 선택한다', () => {
+    const binary = candidate('1.0');
+    const source = candidate('2.0', 'demo-2.0.tar.gz');
+    expect(new CandidateEvaluator(config).sortBestCandidate([source, binary])).toBe(binary);
+    expect(
+      new CandidateEvaluator({ ...config, preferBinary: false }).sortBestCandidate([source, binary])
+    ).toBe(source);
+  });
+
+  it('허용 해시가 일치하는 후보에 정렬 우선순위를 준다', () => {
+    const matching = candidate('1.0');
+    const other = candidate('2.0', undefined, { digests: { sha256: 'other-hash' } });
+    const evaluator = new CandidateEvaluator({ ...config, allowedHashes: new Set(['known-hash']) });
+    expect(evaluator.sortBestCandidate([other, matching])).toBe(matching);
+    expect(evaluator.getSortingKey(other).hasAllowedHash).toBe(false);
+  });
+
+  it('동일 버전과 태그이면 더 높은 빌드 번호를 선택한다', () => {
+    const older = candidate('1.0', 'demo-1.0-1-cp311-cp311-win_amd64.whl');
+    const newer = candidate('1.0', 'demo-1.0-2-cp311-cp311-win_amd64.whl');
+    expect(new CandidateEvaluator(config).sortBestCandidate([older, newer])).toBe(newer);
+  });
+
+  it('입력이 비거나 모든 후보가 제외되면 최적 후보가 없다', () => {
+    const evaluator = new CandidateEvaluator(config);
+    expect(evaluator.computeBestCandidate([])).toEqual({
+      allCandidates: [],
+      applicableCandidates: [],
+      bestCandidate: null,
+    });
+    expect(
+      evaluator.sortBestCandidate([candidate('1.0', undefined, { requires_python: '>=3.12' })])
+    ).toBeNull();
+    expect(selectBestCandidateFromReleases('demo', '1.0', [], config)).toBeNull();
+  });
+
+  it('버전별 빈 릴리스와 제약 밖 버전을 건너뛰고 선택한다', () => {
+    const result = selectBestCandidateFromAllVersions(
+      'demo',
+      {
+        '1.0': [release('demo-1.0-py3-none-any.whl')],
+        '1.5': [release('demo-1.5-py3-none-any.whl')],
+        '1.9': [],
+        '2.0': [release('demo-2.0-py3-none-any.whl')],
+      },
+      config,
+      '>=1.0,<2.0'
+    );
+    expect(result?.version).toBe('1.5');
+    expect(selectBestCandidateFromAllVersions('demo', {}, config)).toBeNull();
+  });
+
+  it('버전 제약이 없으면 최신 호환 릴리스를 선택한다', () => {
+    const result = selectBestCandidateFromAllVersions(
+      'demo',
+      {
+        '1.0': [release('demo-1.0-py3-none-any.whl')],
+        '2.0': [release('demo-2.0-py3-none-any.whl')],
+      },
+      config
+    );
+    expect(result?.version).toBe('2.0');
+  });
+});

--- a/src/core/shared/pip-provider.test.ts
+++ b/src/core/shared/pip-provider.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PipProvider } from './pip-provider';
+import type {
+  Candidate,
+  PackageInfoFetcher,
+  Preference,
+  ProviderConfig,
+  Requirement,
+  RequirementInformation,
+} from './pip-provider';
+import type { PyPIReleaseInfo } from './pip-candidate';
+
+const config: ProviderConfig = { pythonVersion: '3.11', platform: 'windows', arch: 'x86_64' };
+
+function release(
+  version: string,
+  filename = `demo-${version}-py3-none-any.whl`,
+  overrides: Partial<PyPIReleaseInfo> = {}
+): PyPIReleaseInfo {
+  return {
+    filename,
+    url: `https://files.example.test/${filename}`,
+    size: 100,
+    packagetype: filename.endsWith('.whl') ? 'bdist_wheel' : 'sdist',
+    python_version: 'py3',
+    digests: { sha256: 'test-digest' },
+    ...overrides,
+  };
+}
+
+function packageInfo(
+  releases: Record<string, PyPIReleaseInfo[]>,
+  requires_dist?: string[]
+): Awaited<ReturnType<PackageInfoFetcher>> {
+  return { info: { name: 'demo', version: '2.0', requires_dist }, releases };
+}
+
+function candidate(version = '1.0', name = 'demo'): Candidate {
+  return {
+    name,
+    version,
+    dependencies: [],
+    installationCandidate: {
+      name,
+      version,
+      filename: `${name}-${version}.tar.gz`,
+      url: 'https://files.example.test/demo.tar.gz',
+      packageType: 'sdist',
+    },
+  };
+}
+
+function requirementMap(...requirements: Requirement[]) {
+  return new Map([['demo', requirements]]);
+}
+
+function preference(
+  provider: PipProvider,
+  requirements: Requirement[],
+  identifier = 'demo'
+): Preference {
+  return provider.getPreference(
+    identifier,
+    new Map(),
+    new Map(),
+    new Map([[identifier, requirements.map((requirement) => ({ requirement, parent: null }))]]),
+    []
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('PipProvider matching', () => {
+  it('chooses one compatible artifact per release and returns versions newest first', async () => {
+    const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(
+      packageInfo({
+        '1.0': [release('1.0')],
+        '2.0': [
+          release('2.0', 'demo-2.0.tar.gz'),
+          release('2.0', 'demo-2.0-cp311-cp311-win_amd64.whl'),
+        ],
+        '3.0': [release('3.0', 'demo-3.0-cp312-cp312-win_amd64.whl')],
+        '4.0': [],
+      })
+    );
+    const provider = new PipProvider(config, fetcher);
+    const matches = await provider.findMatches('demo', new Map(), new Map());
+    expect(matches.map((item) => item.version)).toEqual(['2.0', '1.0']);
+    expect(matches[0]).toMatchObject({
+      name: 'demo',
+      version: '2.0',
+      dependencies: [],
+      installationCandidate: {
+        filename: 'demo-2.0-cp311-cp311-win_amd64.whl',
+        hash: 'test-digest',
+      },
+    });
+    expect(fetcher).toHaveBeenCalledExactlyOnceWith('demo');
+  });
+
+  it('intersects all requirements, configured constraints, and backtracked incompatibilities', async () => {
+    const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(
+      packageInfo({
+        '1.0': [release('1.0')],
+        '1.5': [release('1.5')],
+        '1.8': [release('1.8')],
+        '1.9': [release('1.9')],
+        '2.0': [release('2.0')],
+      })
+    );
+    const provider = new PipProvider(
+      { ...config, constraints: new Map([['demo', { versionSpec: '<=1.8' }]]) },
+      fetcher
+    );
+    const matches = await provider.findMatches(
+      'demo',
+      requirementMap({ name: 'demo', versionSpec: '>=1.5' }, { name: 'demo', versionSpec: '<2.0' }),
+      new Map([['demo', [candidate('1.8')]]])
+    );
+    expect(matches.map((item) => item.version)).toEqual(['1.5']);
+  });
+
+  it('re-filters cached releases when resolver requirements change without refetching', async () => {
+    const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(
+      packageInfo({
+        '1.0': [release('1.0')],
+        '2.0': [release('2.0')],
+      })
+    );
+    const provider = new PipProvider(config, fetcher);
+    const first = await provider.findMatches(
+      'demo',
+      requirementMap({ name: 'demo', versionSpec: '==1.0' }),
+      new Map()
+    );
+    const second = await provider.findMatches(
+      'demo',
+      new Map(),
+      new Map([['demo', [candidate('1.0')]]])
+    );
+    const all = await provider.findMatches('demo', new Map(), new Map());
+    expect(first.map((item) => item.version)).toEqual(['1.0']);
+    expect(second.map((item) => item.version)).toEqual(['2.0']);
+    expect(all.map((item) => item.version)).toEqual(['2.0', '1.0']);
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])(
+    'propagates prerelease allowance to candidate selection: %s',
+    async (allowPrerelease) => {
+      const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(
+        packageInfo({
+          '1.0': [release('1.0')],
+          '2.0rc1': [release('2.0rc1')],
+        })
+      );
+      const matches = await new PipProvider({ ...config, allowPrerelease }, fetcher).findMatches(
+        'demo',
+        new Map(),
+        new Map()
+      );
+      expect(matches.map((item) => item.version)).toEqual(
+        allowPrerelease ? ['2.0rc1', '1.0'] : ['1.0']
+      );
+    }
+  );
+
+  it('returns an empty list for no usable releases and caches the empty result', async () => {
+    const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(
+      packageInfo({
+        '1.0': [],
+        '2.0': [release('2.0', undefined, { yanked: true })],
+      })
+    );
+    const provider = new PipProvider(config, fetcher);
+    await expect(provider.findMatches('demo', new Map(), new Map())).resolves.toEqual([]);
+    await expect(provider.findMatches('demo', new Map(), new Map())).resolves.toEqual([]);
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it('does not cache a registry failure and permits the next lookup to recover', async () => {
+    const failure = new Error('registry offline');
+    const fetcher = vi
+      .fn<PackageInfoFetcher>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(packageInfo({ '1.0': [release('1.0')] }));
+    const provider = new PipProvider(config, fetcher);
+    await expect(provider.findMatches('demo', new Map(), new Map())).resolves.toEqual([]);
+    expect(console.error).toHaveBeenCalledWith('패키지 정보 조회 실패: demo', failure);
+    expect(
+      (await provider.findMatches('demo', new Map(), new Map())).map((item) => item.version)
+    ).toEqual(['1.0']);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [{ name: 'Demo-Package' }, 'demo_package', '1.5', true],
+    [{ name: 'Demo-Package', versionSpec: '>=1.0,<2.0' }, 'demo_package', '1.5', true],
+    [{ name: 'Demo-Package', versionSpec: '>=2.0' }, 'demo_package', '1.5', false],
+    [{ name: 'Demo-Package' }, 'different_package', '1.5', false],
+  ] as Array<[Requirement, string, string, boolean]>)(
+    'checks normalized names and version constraints: %j',
+    (requirement, name, version, satisfied) => {
+      const provider = new PipProvider(config, vi.fn<PackageInfoFetcher>());
+      expect(provider.isSatisfiedBy(requirement, candidate(version, name))).toBe(satisfied);
+      expect(provider.identify({ name: 'Demo-Package' })).toBe('demo_package');
+    }
+  );
+});
+
+describe('PipProvider dependency lookup', () => {
+  it('parses names, extras and version ranges and filters target-platform and optional-extra markers', async () => {
+    const fetcher = vi
+      .fn<PackageInfoFetcher>()
+      .mockResolvedValue(
+        packageInfo({ '1.0': [release('1.0')] }, [
+          'Requests-Security[tls, socks]>=2.0,<3.0',
+          'win-helper; platform_system == "Windows"',
+          'linux-helper; platform_system == "Linux"',
+          'test-helper; extra == "test"',
+          'plain-helper',
+        ])
+      );
+    const provider = new PipProvider(config, fetcher);
+    await expect(provider.getDependencies(candidate())).resolves.toEqual([
+      {
+        name: 'requests_security',
+        extras: ['tls', 'socks'],
+        versionSpec: '>=2.0,<3.0',
+        marker: undefined,
+      },
+      {
+        name: 'win_helper',
+        extras: undefined,
+        versionSpec: undefined,
+        marker: 'platform_system == "Windows"',
+      },
+      { name: 'plain_helper', extras: undefined, versionSpec: undefined, marker: undefined },
+    ]);
+  });
+
+  it.each([
+    ['>=', '3.10', true],
+    ['>=', '3.12', false],
+    ['>', '3.10', true],
+    ['>', '3.11', false],
+    ['<=', '3.11', true],
+    ['<=', '3.10', false],
+    ['<', '3.12', true],
+    ['<', '3.11', false],
+    ['==', '3.11', true],
+    ['==', '3.12', false],
+    ['!=', '3.12', true],
+    ['!=', '3.11', false],
+  ])('evaluates Python 3.11 dependency marker %s %s', async (operator, version, included) => {
+    const marker = `python_version ${operator} '${version}'`;
+    const fetcher = vi
+      .fn<PackageInfoFetcher>()
+      .mockResolvedValue(packageInfo({ '1.0': [release('1.0')] }, [`compat-helper; ${marker}`]));
+    const dependencies = await new PipProvider(config, fetcher).getDependencies(candidate());
+    expect(dependencies).toEqual(
+      included ? [{ name: 'compat_helper', versionSpec: undefined, extras: undefined, marker }] : []
+    );
+  });
+
+  it('caches dependencies per package version instead of sharing results across versions', async () => {
+    const fetcher = vi
+      .fn<PackageInfoFetcher>()
+      .mockResolvedValueOnce(packageInfo({ '1.0': [release('1.0')] }, ['old-dependency']))
+      .mockResolvedValueOnce(packageInfo({ '2.0': [release('2.0')] }, ['new-dependency']));
+    const provider = new PipProvider(config, fetcher);
+    const first = await provider.getDependencies(candidate('1.0'));
+    const cached = await provider.getDependencies(candidate('1.0'));
+    const other = await provider.getDependencies(candidate('2.0'));
+    expect(first.map((dependency) => dependency.name)).toEqual(['old_dependency']);
+    expect(cached).toEqual(first);
+    expect(other.map((dependency) => dependency.name)).toEqual(['new_dependency']);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignoring dependencies performs no metadata requests', async () => {
+    const fetcher = vi.fn<PackageInfoFetcher>();
+    await expect(
+      new PipProvider({ ...config, ignoreDependencies: true }, fetcher).getDependencies(candidate())
+    ).resolves.toEqual([]);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it.each<{ releases: Record<string, PyPIReleaseInfo[]> }>([
+    { releases: {} },
+    { releases: { '1.0': [] } },
+    { releases: { '1.0': [release('1.0')] } },
+  ])(
+    'returns an empty dependency list for missing release or requires_dist: %j',
+    async ({ releases }) => {
+      const fetcher = vi.fn<PackageInfoFetcher>().mockResolvedValue(packageInfo(releases));
+      await expect(new PipProvider(config, fetcher).getDependencies(candidate())).resolves.toEqual(
+        []
+      );
+    }
+  );
+
+  it('does not cache failed dependency fetches, allowing a later retry', async () => {
+    const error = new Error('metadata timed out');
+    const fetcher = vi
+      .fn<PackageInfoFetcher>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(packageInfo({ '1.0': [release('1.0')] }, ['dependency>=1.0']));
+    const provider = new PipProvider(config, fetcher);
+    await expect(provider.getDependencies(candidate())).resolves.toEqual([]);
+    expect(console.error).toHaveBeenCalledWith('의존성 조회 실패: demo@1.0', error);
+    expect(
+      (await provider.getDependencies(candidate())).map((dependency) => dependency.name)
+    ).toEqual(['dependency']);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('PipProvider resolver priorities', () => {
+  it('prioritizes Python requirements before backtracking causes', () => {
+    const provider = new PipProvider(config, vi.fn<PackageInfoFetcher>());
+    const causes: RequirementInformation[] = [
+      { requirement: { name: 'demo' }, parent: candidate('1.0', 'parent') },
+    ];
+    expect(
+      provider.narrowRequirementSelection(
+        ['demo', '_python_requires', 'parent'],
+        new Map(),
+        new Map(),
+        new Map(),
+        causes
+      )
+    ).toEqual(['_python_requires']);
+  });
+
+  it('narrows to both backtracking requirement and parent while preserving identifier order', () => {
+    const provider = new PipProvider(config, vi.fn<PackageInfoFetcher>());
+    const causes: RequirementInformation[] = [
+      { requirement: { name: 'demo' }, parent: candidate('1.0', 'parent') },
+      { requirement: { name: 'missing' }, parent: null },
+    ];
+    expect(
+      provider.narrowRequirementSelection(
+        ['other', 'parent', 'demo'],
+        new Map(),
+        new Map(),
+        new Map(),
+        causes
+      )
+    ).toEqual(['parent', 'demo']);
+    expect(
+      provider.narrowRequirementSelection(['other'], new Map(), new Map(), new Map(), causes)
+    ).toEqual(['other']);
+    expect(provider.narrowRequirementSelection([], new Map(), new Map(), new Map(), [])).toEqual(
+      []
+    );
+  });
+
+  it.each([
+    [[], [true, true, true, Infinity, true, 'demo']],
+    [
+      [{ name: 'demo', url: 'https://files.example.test/demo.whl' }],
+      [false, true, true, 2, true, 'demo'],
+    ],
+    [[{ name: 'demo', versionSpec: '==1.0' }], [true, false, true, 2, false, 'demo']],
+    [[{ name: 'demo', versionSpec: '==1.*' }], [true, true, false, 2, false, 'demo']],
+    [[{ name: 'demo', versionSpec: '>=1.0,<2.0' }], [true, true, false, 2, false, 'demo']],
+    [[{ name: 'demo', versionSpec: '~=1.4' }], [true, true, false, 2, false, 'demo']],
+  ] as Array<[Requirement[], Preference]>)(
+    'computes direct, pinned, bounded and user-order preferences: %j',
+    (requirements, expected) => {
+      const provider = new PipProvider(
+        { ...config, userRequested: new Map([['demo', 2]]) },
+        vi.fn<PackageInfoFetcher>()
+      );
+      expect(preference(provider, requirements)).toEqual(expected);
+    }
+  );
+
+  it('compares the preference tuple lexicographically with stable ties and alphabetic fallback', () => {
+    const provider = new PipProvider(config, vi.fn<PackageInfoFetcher>());
+    const direct = preference(provider, [
+      { name: 'demo', url: 'https://files.example.test/demo.whl' },
+    ]);
+    const pinned = preference(provider, [{ name: 'demo', versionSpec: '==1.0' }]);
+    expect(provider.comparePreferences(direct, pinned)).toBe(-1);
+    expect(provider.comparePreferences(pinned, direct)).toBe(1);
+    expect(provider.comparePreferences(pinned, [...pinned])).toBe(0);
+    expect(
+      provider.comparePreferences(
+        preference(provider, [], 'alpha'),
+        preference(provider, [], 'zeta')
+      )
+    ).toBe(-1);
+  });
+});

--- a/src/core/shared/pip-tags.test.ts
+++ b/src/core/shared/pip-tags.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateCompatibleTags,
+  generateCPythonTags,
+  generateLinuxPlatformTags,
+  generateMacOSPlatformTags,
+  generatePlatformTags,
+  generateWindowsPlatformTags,
+  getFullSupportedTags,
+  getSupportedTags,
+  getTagPriority,
+  isTagCompatible,
+  normalizeArch,
+  parseTag,
+  tagsToIndexMap,
+  tagToString,
+  versionToNodot,
+} from './pip-tags';
+
+describe('pip wheel 지원 태그', () => {
+  it('태그를 파싱하고 손실 없이 직렬화한다', () => {
+    const tag = { pythonTag: 'cp311', abiTag: 'abi3', platformTag: 'win_amd64' };
+    expect(parseTag(tagToString(tag))).toEqual(tag);
+  });
+  it.each(['', 'cp311', 'cp311-none', 'cp311-none-any-extra'])(
+    '잘못된 형식 %j는 태그가 아니다',
+    (value) => {
+      expect(parseTag(value)).toBeNull();
+    }
+  );
+  it.each([
+    ['3.11.9', '311'],
+    ['3.9', '39'],
+    ['', ''],
+  ])('버전 %j의 major/minor만 태그에 사용한다', (input, expected) => {
+    expect(versionToNodot(input)).toBe(expected);
+  });
+  it.each([
+    ['amd64', 'x86_64'],
+    ['i386', 'i686'],
+    ['arm64', 'arm64'],
+    ['aarch64', 'aarch64'],
+  ] as const)('아키텍처 별칭 %s를 정규화한다', (input, expected) => {
+    expect(normalizeArch(input)).toBe(expected);
+  });
+  it('CPython ABI를 먼저 생성하고 과거 stable ABI를 포함한다', () => {
+    const tags = generateCPythonTags({ version: '3.11', platforms: ['win_amd64'] }).map(
+      tagToString
+    );
+    expect(tags[0]).toBe('cp311-cp311-win_amd64');
+    expect(tags).toContain('cp32-abi3-win_amd64');
+    expect(tags).not.toContain('cp31-abi3-win_amd64');
+    expect(tags).not.toContain('cp312-abi3-win_amd64');
+  });
+  it('사용자 ABI와 빈 플랫폼 목록을 처리한다', () => {
+    expect(
+      generateCPythonTags({ version: '3.11', abis: ['custom'], platforms: ['any'] })[0]
+    ).toEqual({ pythonTag: 'cp311', abiTag: 'custom', platformTag: 'any' });
+    expect(generateCPythonTags({ version: '3.11', platforms: [] })).toEqual([]);
+    expect(generateCompatibleTags({ version: '3.11', platforms: [] })).toEqual([]);
+  });
+  it('순수 Python 태그는 하위 minor와 major 공용 태그를 포함한다', () => {
+    const tags = generateCompatibleTags({ version: '3.11' }).map(tagToString);
+    expect(tags[0]).toBe('py311-none-any');
+    expect(tags).toContain('py30-none-any');
+    expect(tags.at(-1)).toBe('py3-none-any');
+  });
+  it('비 CPython 구현체의 지원 목록은 CPython ABI를 포함하지 않는다', () => {
+    const tags = getSupportedTags({ version: '3.11', implementation: 'pp' }).map(tagToString);
+    expect(tags).toContain('py3-none-any');
+    expect(tags.some((tag) => tag.startsWith('cp'))).toBe(false);
+  });
+  it('중복 태그는 첫 우선순위를 유지한다', () => {
+    const tags = getFullSupportedTags('3.11', 'windows', 'x86_64');
+    const first = tags[0];
+    expect(tagsToIndexMap([...tags, first]).get(tagToString(first))).toBe(0);
+    expect(getTagPriority(first, tags)).toBe(0);
+    expect(isTagCompatible(first, tags)).toBe(true);
+    expect(getTagPriority(first, [])).toBe(-1);
+    expect(isTagCompatible(first, [])).toBe(false);
+    expect(tagsToIndexMap([]).size).toBe(0);
+  });
+  it('Linux 아키텍처에 맞는 manylinux와 legacy 태그를 생성한다', () => {
+    const x64 = generateLinuxPlatformTags('amd64');
+    expect(x64[0]).toBe('manylinux_2_35_x86_64');
+    expect(x64).toContain('manylinux1_x86_64');
+    expect(x64.at(-1)).toBe('linux_x86_64');
+    const arm = generateLinuxPlatformTags('aarch64');
+    expect(arm).toContain('manylinux2014_aarch64');
+    expect(arm).not.toContain('manylinux1_aarch64');
+  });
+  it.each([
+    ['x86_64', 'win_amd64'],
+    ['arm64', 'win_arm64'],
+    ['i386', 'win32'],
+    ['i686', 'win32'],
+  ] as const)('Windows %s의 플랫폼 태그를 생성한다', (arch, expected) => {
+    expect(generateWindowsPlatformTags(arch)).toEqual([expected]);
+  });
+  it('macOS ARM과 universal2 태그 및 지정한 최소 major를 반영한다', () => {
+    const tags = generateMacOSPlatformTags('arm64', [12, 0]);
+    expect(tags).toContain('macosx_12_0_arm64');
+    expect(tags).toContain('macosx_12_0_universal2');
+    expect(tags).not.toContain('macosx_11_0_arm64');
+  });
+  it.each(['linux', 'windows', 'macos', 'any'] as const)(
+    '%s 플랫폼은 순수 Python용 any를 포함한다',
+    (platform) => {
+      expect(generatePlatformTags(platform, 'x86_64').at(-1)).toBe('any');
+      expect(getFullSupportedTags('3.11', platform, 'x86_64').map(tagToString)).toContain(
+        'py3-none-any'
+      );
+    }
+  );
+});

--- a/src/core/shared/pypi-utils.test.ts
+++ b/src/core/shared/pypi-utils.test.ts
@@ -1,0 +1,140 @@
+import { EventEmitter } from 'events';
+import * as https from 'https';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchPackageFiles } from './pip-simple-api-client';
+import { extractVersionFromFilename, getPyPIDownloadUrl } from './pypi-utils';
+
+vi.mock('https', () => ({ get: vi.fn() }));
+vi.mock('./pip-simple-api-client', () => ({ fetchPackageFiles: vi.fn() }));
+const file = (filename: string) => ({ filename, url: `https://files.example/${filename}` });
+const index = 'https://registry.example/simple';
+
+beforeEach(() => vi.resetAllMocks());
+
+describe('PyPI 다운로드 파일 선택', () => {
+  it.each([
+    ['torch-2.1.0+cu121-cp311-cp311-linux_x86_64.whl', '2.1.0+cu121'],
+    ['demo-1.0-2-py3-none-any.whl', '1.0'],
+    ['demo-1.0rc1.tar.gz', '1.0rc1'],
+    ['my-package-2.3.zip', '2.3'],
+    ['', null],
+    ['not-a-distribution.txt', null],
+    ['package.whl', null],
+  ])('파일명 %j에서 버전을 추출한다', (filename, version) => {
+    expect(extractVersionFromFilename(filename)).toBe(version);
+  });
+
+  it.each([
+    ['linux', 'x86_64', 'manylinux_2_17_x86_64'],
+    ['linux', 'aarch64', 'manylinux2014_aarch64'],
+    ['windows', 'amd64', 'win_amd64'],
+    ['windows', 'arm64', 'win_arm64'],
+    ['macos', 'arm64', 'macosx_11_0_arm64'],
+    ['macos', 'x86_64', 'macosx_10_15_x86_64'],
+  ])('%s/%s에서 호환 wheel을 소스와 공용 wheel보다 우선한다', async (os, arch, tag) => {
+    const native = file(`demo-1.0-cp311-cp311-${tag}.whl`);
+    vi.mocked(fetchPackageFiles).mockResolvedValue([
+      file('demo-1.0.tar.gz'),
+      file('demo-1.0-py3-none-any.whl'),
+      native,
+      file('demo-2.0-py3-none-any.whl'),
+    ]);
+    await expect(getPyPIDownloadUrl('demo', '1.0', arch, os, '3.11', index)).resolves.toEqual({
+      ...native,
+      size: 0,
+    });
+    expect(fetchPackageFiles).toHaveBeenCalledExactlyOnceWith(index, 'demo');
+    expect(https.get).not.toHaveBeenCalled();
+  });
+
+  it('다른 플랫폼 wheel과 잘못된 wheel 파일명은 소스 선택을 방해하지 않는다', async () => {
+    const source = file('demo-1.0.tar.gz');
+    vi.mocked(fetchPackageFiles).mockResolvedValue([
+      file('demo-1.0-cp311-cp311-win_amd64.whl'),
+      file('demo-1.0.whl'),
+      source,
+    ]);
+    await expect(
+      getPyPIDownloadUrl('demo', '1.0', 'x86_64', 'linux', '3.11', index)
+    ).resolves.toEqual({ ...source, size: 0 });
+  });
+
+  it('이전 CPython의 stable ABI wheel도 선택할 수 있다', async () => {
+    const stable = file('demo-1.0-cp38-abi3-win_amd64.whl');
+    vi.mocked(fetchPackageFiles).mockResolvedValue([file('demo-1.0.tar.gz'), stable]);
+    await expect(
+      getPyPIDownloadUrl('demo', '1.0', 'x86_64', 'windows', '3.11', index)
+    ).resolves.toEqual({ ...stable, size: 0 });
+  });
+
+  it.each([
+    { scenario: '빈 목록', files: [] },
+    { scenario: '요청 버전 없음', files: [file('demo-2.0-py3-none-any.whl')] },
+  ])('$scenario이면 null을 반환한다', async ({ files }) => {
+    vi.mocked(fetchPackageFiles).mockResolvedValue(files);
+    await expect(
+      getPyPIDownloadUrl('demo', '1.0', undefined, undefined, undefined, index)
+    ).resolves.toBeNull();
+  });
+
+  it.each(['403 Forbidden', 'ETIMEDOUT', 'invalid index'])(
+    '인덱스 접근 실패는 null을 반환한다: %s',
+    async (message) => {
+      vi.mocked(fetchPackageFiles).mockRejectedValue(new Error(message));
+      await expect(
+        getPyPIDownloadUrl('demo', '1.0', undefined, undefined, undefined, index)
+      ).resolves.toBeNull();
+      expect(https.get).not.toHaveBeenCalled();
+    }
+  );
+
+  function jsonTransport() {
+    const response = new EventEmitter();
+    const request = new EventEmitter();
+    vi.mocked(https.get).mockImplementationOnce(((
+      _url: unknown,
+      _options: unknown,
+      callback: (value: EventEmitter) => void
+    ) => {
+      callback(response);
+      return request;
+    }) as never);
+    return { response, request };
+  }
+
+  it('JSON API 청크를 합쳐 다운로드 크기와 URL을 보존한다', async () => {
+    const { response } = jsonTransport();
+    const selected = file('demo-1.0-py3-none-any.whl');
+    const pending = getPyPIDownloadUrl('demo', '1.0');
+    const body = JSON.stringify({
+      urls: [{ ...selected, size: 321, packagetype: 'bdist_wheel', python_version: 'py3' }],
+    });
+    response.emit('data', body.slice(0, 20));
+    response.emit('data', body.slice(20));
+    response.emit('end');
+    await expect(pending).resolves.toEqual({ ...selected, size: 321 });
+    expect(https.get).toHaveBeenCalledWith(
+      'https://pypi.org/pypi/demo/1.0/json',
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it.each(['', '<html>Forbidden</html>', '{}', '{"urls":[]}'])(
+    '비어 있거나 잘못된 API 본문 %j는 null을 반환한다',
+    async (body) => {
+      const { response } = jsonTransport();
+      const pending = getPyPIDownloadUrl('demo', '1.0');
+      response.emit('data', body);
+      response.emit('end');
+      await expect(pending).resolves.toBeNull();
+    }
+  );
+
+  it('JSON API 네트워크 오류도 null을 반환한다', async () => {
+    const { request } = jsonTransport();
+    const pending = getPyPIDownloadUrl('demo', '1.0');
+    request.emit('error', new Error('offline'));
+    await expect(pending).resolves.toBeNull();
+  });
+});

--- a/src/renderer/pages/download-page/hooks/use-os-download-flow.test.ts
+++ b/src/renderer/pages/download-page/hooks/use-os-download-flow.test.ts
@@ -1,0 +1,561 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  OSDistribution,
+  OSDownloadProgress,
+  OSPackageInfo,
+  OSPackageOutputOptions,
+} from '../../../../core/downloaders/os-shared/types';
+import type { CartItem } from '../../../stores/cart-store';
+import type { OSDownloadResultData } from '../types';
+import { useOSDownloadFlow } from './use-os-download-flow';
+
+const mocks = vi.hoisted(() => ({
+  message: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+  confirm: vi.fn(),
+  cart: { items: [] as CartItem[] },
+}));
+
+vi.mock('antd', () => ({ message: mocks.message, Modal: { confirm: mocks.confirm } }));
+vi.mock('../../../stores/cart-store', () => ({ useCartStore: { getState: () => mocks.cart } }));
+
+const distribution: OSDistribution = {
+  id: 'rocky-9',
+  name: 'Rocky Linux 9',
+  version: '9',
+  packageManager: 'yum',
+  architectures: ['x86_64', 'aarch64'],
+  defaultRepos: [],
+  extendedRepos: [],
+};
+const pkg: OSPackageInfo = {
+  name: 'nginx',
+  version: '1.24.0',
+  architecture: 'x86_64',
+  size: 2048,
+  checksum: { type: 'sha256', value: 'test-checksum' },
+  location: 'Packages/nginx.rpm',
+  dependencies: [],
+  repository: {
+    id: 'baseos',
+    name: 'BaseOS',
+    baseUrl: 'https://repo.example.test/',
+    enabled: true,
+    gpgCheck: true,
+    isOfficial: true,
+  },
+};
+const outputOptions: OSPackageOutputOptions = {
+  type: 'both',
+  archiveFormat: 'tar.gz',
+  generateScripts: true,
+  scriptTypes: ['local-repo'],
+};
+const progress: OSDownloadProgress = {
+  phase: 'downloading',
+  currentPackage: pkg.name,
+  currentIndex: 0,
+  totalPackages: 1,
+  bytesDownloaded: 1024,
+  totalBytes: 2048,
+  speed: 100,
+};
+
+function cartItem(overrides: Partial<CartItem> = {}): CartItem {
+  return {
+    id: 'nginx-yum',
+    type: 'yum',
+    name: pkg.name,
+    version: pkg.version,
+    arch: 'x86_64',
+    addedAt: 1,
+    metadata: {
+      osPackageInfo: pkg,
+      osContext: { distributionId: 'rocky-9', architecture: 'x86_64', packageManager: 'yum' },
+    },
+    ...overrides,
+  };
+}
+
+function downloadResult(overrides: Partial<OSDownloadResultData> = {}): OSDownloadResultData {
+  return {
+    success: [pkg],
+    failed: [],
+    skipped: [],
+    outputPath: '/downloads/os.tar.gz',
+    packageManager: 'yum',
+    outputOptions,
+    warnings: [],
+    unresolved: [],
+    conflicts: [],
+    cancelled: false,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function createApi() {
+  const listeners = new Set<(event: OSDownloadProgress) => void>();
+  const unsubscribe = vi.fn();
+  return {
+    listeners,
+    unsubscribe,
+    os: {
+      getDistribution: vi.fn().mockResolvedValue(distribution),
+      download: {
+        start: vi.fn().mockResolvedValue(downloadResult()),
+        cancel: vi.fn().mockResolvedValue(undefined),
+        onProgress: vi.fn((listener: (event: OSDownloadProgress) => void) => {
+          listeners.add(listener);
+          return () => {
+            listeners.delete(listener);
+            unsubscribe();
+          };
+        }),
+      },
+    },
+  };
+}
+
+function mountFlow(overrides: Partial<Parameters<typeof useOSDownloadFlow>[0]> = {}) {
+  const args = {
+    cartItems: [cartItem()],
+    outputDir: '/downloads',
+    includeDependencies: true,
+    concurrentDownloads: 4,
+    cartSnapshotRef: { current: [] as CartItem[] },
+    addHistory: vi.fn().mockResolvedValue('history-1'),
+    clearCart: vi.fn(() => {
+      mocks.cart.items = [];
+    }),
+    removeCartItem: vi.fn(),
+    checkOutputPath: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+  mocks.cart.items = args.cartItems;
+  const hook = renderHook((props) => useOSDownloadFlow(props), { initialProps: args });
+  return { ...hook, args };
+}
+
+let api: ReturnType<typeof createApi>;
+const originalApi = Object.getOwnPropertyDescriptor(window, 'electronAPI');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api = createApi();
+  Object.defineProperty(window, 'electronAPI', { configurable: true, value: api });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  if (originalApi) Object.defineProperty(window, 'electronAPI', originalApi);
+  else Reflect.deleteProperty(window, 'electronAPI');
+});
+
+describe('useOSDownloadFlow selection and validation', () => {
+  it.each([
+    ['empty cart', []],
+    ['library cart', [{ id: 'pip', type: 'pip', name: 'requests', version: '2.32.0', addedAt: 1 }]],
+    [
+      'mixed libraries and OS packages',
+      [cartItem(), { id: 'npm', type: 'npm', name: 'react', version: '19.0.0', addedAt: 1 }],
+    ],
+  ] as Array<[string, CartItem[]]>)(
+    'does not subscribe to OS download events for %s',
+    (_label, cartItems) => {
+      const { result } = mountFlow({ cartItems });
+      expect(result.current).toMatchObject({
+        isDedicatedOSFlow: false,
+        requiresOSCartReselection: false,
+        shouldRenderDedicatedOSFlow: false,
+      });
+      expect(api.os.getDistribution).not.toHaveBeenCalled();
+      expect(api.os.download.onProgress).not.toHaveBeenCalled();
+    }
+  );
+
+  it('requires reselection for old OS cart entries without an environment snapshot', () => {
+    const { result } = mountFlow({ cartItems: [cartItem({ metadata: { osPackageInfo: pkg } })] });
+    expect(result.current).toMatchObject({
+      requiresOSCartReselection: true,
+      isDedicatedOSFlow: false,
+      effectiveOSContext: null,
+    });
+    expect(api.os.getDistribution).not.toHaveBeenCalled();
+  });
+
+  it('does not combine packages selected for different distributions', () => {
+    const other = cartItem({
+      id: 'nginx-other',
+      metadata: {
+        osPackageInfo: pkg,
+        osContext: { distributionId: 'rocky-10', architecture: 'x86_64', packageManager: 'yum' },
+      },
+    });
+    const { result } = mountFlow({ cartItems: [cartItem(), other] });
+    expect(result.current.isDedicatedOSFlow).toBe(false);
+    expect(result.current.effectiveOSContext).toBeNull();
+    expect(api.os.download.onProgress).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale distribution response when the selected environment changes', async () => {
+    const oldRequest = deferred<OSDistribution>();
+    api.os.getDistribution.mockReturnValueOnce(oldRequest.promise);
+    const { result, args, rerender } = mountFlow();
+    const newerDistribution = { ...distribution, id: 'rocky-10', version: '10' };
+    api.os.getDistribution.mockResolvedValueOnce(newerDistribution);
+    rerender({
+      ...args,
+      cartItems: [
+        cartItem({
+          metadata: {
+            osPackageInfo: pkg,
+            osContext: {
+              distributionId: 'rocky-10',
+              architecture: 'x86_64',
+              packageManager: 'yum',
+            },
+          },
+        }),
+      ],
+    });
+    await waitFor(() => expect(result.current.osDistribution).toEqual(newerDistribution));
+    await act(async () => {
+      oldRequest.resolve(distribution);
+      await oldRequest.promise;
+    });
+    expect(result.current.osDistribution).toEqual(newerDistribution);
+  });
+
+  it('reports failed distribution lookup and blocks download before path checks', async () => {
+    api.os.getDistribution.mockRejectedValueOnce(new Error('offline'));
+    const { result, args } = mountFlow();
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    await act(() => result.current.handleStartOSDownload(outputOptions));
+    expect(result.current.osDistribution).toBeNull();
+    expect(args.checkOutputPath).not.toHaveBeenCalled();
+    expect(api.os.download.start).not.toHaveBeenCalled();
+    expect(mocks.message.error).toHaveBeenCalledWith('OS 배포판 정보를 아직 불러오지 못했습니다');
+  });
+
+  it.each(['empty-output', 'missing-metadata', 'path-rejected', 'missing-api'] as const)(
+    'prevents download and history changes when %s',
+    async (failure) => {
+      const { result, args } = mountFlow({
+        ...(failure === 'empty-output' ? { outputDir: '' } : {}),
+        ...(failure === 'missing-metadata'
+          ? {
+              cartItems: [
+                cartItem({
+                  metadata: {
+                    osContext: {
+                      distributionId: 'rocky-9',
+                      architecture: 'x86_64',
+                      packageManager: 'yum',
+                    },
+                  },
+                }),
+              ],
+            }
+          : {}),
+      });
+      await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+      if (failure === 'path-rejected') vi.mocked(args.checkOutputPath).mockResolvedValueOnce(false);
+      if (failure === 'missing-api') Reflect.deleteProperty(api.os.download, 'start');
+      await act(() => result.current.handleStartOSDownload(outputOptions));
+      if (failure !== 'missing-api') expect(api.os.download.start).not.toHaveBeenCalled();
+      expect(args.addHistory).not.toHaveBeenCalled();
+      expect(args.clearCart).not.toHaveBeenCalled();
+      expect(args.cartSnapshotRef.current).toEqual([]);
+      expect(result.current.osDownloading).toBe(false);
+      if (failure === 'empty-output')
+        expect(mocks.message.warning).toHaveBeenCalledWith('출력 폴더를 선택하세요');
+      if (failure === 'missing-metadata')
+        expect(mocks.message.error).toHaveBeenCalledWith(
+          '장바구니의 OS 패키지 메타데이터가 부족합니다. 다시 검색 후 담아주세요.'
+        );
+      if (failure === 'missing-api')
+        expect(mocks.message.error).toHaveBeenCalledWith(
+          'OS 패키지 다운로드 API를 사용할 수 없습니다'
+        );
+    }
+  );
+});
+
+describe('useOSDownloadFlow results and cart preservation', () => {
+  it('sends the selected environment and options, saves artifact history, then clears the matching cart', async () => {
+    const saving = deferred<string>();
+    const { result, args, rerender } = mountFlow();
+    args.addHistory.mockReturnValueOnce(saving.promise);
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    let downloading!: Promise<void>;
+    act(() => {
+      downloading = result.current.handleStartOSDownload(outputOptions);
+    });
+    await waitFor(() => expect(args.addHistory).toHaveBeenCalledOnce());
+    expect(api.os.download.start).toHaveBeenCalledWith({
+      packages: [pkg],
+      outputDir: '/downloads',
+      distribution,
+      architecture: 'x86_64',
+      resolveDependencies: true,
+      includeOptionalDeps: true,
+      concurrency: 4,
+      outputOptions,
+    });
+    expect(result.current.osDownloading).toBe(true);
+    expect(args.clearCart).not.toHaveBeenCalled();
+    expect(args.addHistory).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          name: 'nginx',
+          version: '1.24.0',
+          type: 'yum',
+          arch: 'x86_64',
+          metadata: {
+            osPackageInfo: pkg,
+            osContext: { distributionId: 'rocky-9', architecture: 'x86_64', packageManager: 'yum' },
+          },
+        }),
+      ],
+      {
+        outputFormat: 'tar.gz',
+        includeScripts: true,
+        includeDependencies: true,
+        deliveryMethod: 'local',
+        osOutputOptions: outputOptions,
+      },
+      '/downloads/os.tar.gz',
+      2048,
+      'success',
+      1,
+      0
+    );
+    await act(async () => {
+      saving.resolve('history-1');
+      await downloading;
+    });
+    expect(args.clearCart).toHaveBeenCalledOnce();
+    expect(result.current).toMatchObject({
+      osDownloading: false,
+      osResult: downloadResult(),
+      osDownloadError: null,
+      isOSPackaging: true,
+    });
+    expect(mocks.message.success).toHaveBeenCalledWith('OS 패키지 다운로드가 완료되었습니다');
+    rerender({ ...args, cartItems: [] });
+    expect(result.current.shouldRenderDedicatedOSFlow).toBe(true);
+    expect(result.current.activeOSPackageManager).toBe('yum');
+  });
+
+  it('keeps a cart modified while history is being saved', async () => {
+    const saving = deferred<string>();
+    const { result, args } = mountFlow();
+    args.addHistory.mockReturnValueOnce(saving.promise);
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    let downloading!: Promise<void>;
+    act(() => {
+      downloading = result.current.handleStartOSDownload(outputOptions);
+    });
+    await waitFor(() => expect(args.addHistory).toHaveBeenCalledOnce());
+    mocks.cart.items = [...args.cartItems, cartItem({ id: 'new-selection', name: 'curl' })];
+    await act(async () => {
+      saving.resolve('history-1');
+      await downloading;
+    });
+    expect(args.clearCart).not.toHaveBeenCalled();
+    expect(mocks.cart.items.map((item) => item.name)).toEqual(['nginx', 'curl']);
+    expect(result.current.osResult?.success).toEqual([pkg]);
+  });
+
+  it('preserves completed results and the cart if history persistence fails', async () => {
+    const { result, args } = mountFlow();
+    args.addHistory.mockRejectedValueOnce(new Error('EACCES: history write denied'));
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    await act(() => result.current.handleStartOSDownload(outputOptions));
+    expect(result.current).toMatchObject({
+      osDownloading: false,
+      osResult: downloadResult(),
+      osDownloadError: null,
+    });
+    expect(args.clearCart).not.toHaveBeenCalled();
+    expect(mocks.message.error).toHaveBeenCalledWith('다운로드 히스토리 저장에 실패했습니다');
+  });
+
+  it.each([
+    [
+      'partial',
+      downloadResult({
+        failed: [{ package: { ...pkg, name: 'curl' }, error: 'checksum mismatch' }],
+      }),
+      1,
+      1,
+    ],
+    [
+      'failed',
+      downloadResult({ success: [], failed: [{ package: pkg, error: 'download denied' }] }),
+      0,
+      1,
+    ],
+    ['partial', downloadResult({ skipped: [{ ...pkg, name: 'curl' }] }), 1, 0],
+  ] as const)(
+    'records %s history for unsuccessful package outcomes',
+    async (status, response, downloaded, failed) => {
+      api.os.download.start.mockResolvedValueOnce(response);
+      const { result, args } = mountFlow({ includeDependencies: false });
+      await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+      await act(() => result.current.handleStartOSDownload(outputOptions));
+      expect(api.os.download.start).toHaveBeenCalledWith(
+        expect.objectContaining({ resolveDependencies: false, includeOptionalDeps: false })
+      );
+      expect(args.addHistory).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.any(Object),
+        response.outputPath,
+        downloaded * pkg.size,
+        status,
+        downloaded,
+        failed
+      );
+      expect(args.clearCart).not.toHaveBeenCalled();
+      expect(result.current.osResult).toEqual(response);
+      expect(mocks.message.warning).toHaveBeenCalledWith(
+        'OS 패키지 다운로드가 부분 완료되었습니다'
+      );
+    }
+  );
+
+  it('shows dependency resolution errors without recording or clearing a download that never started', async () => {
+    api.os.download.start.mockResolvedValueOnce(
+      downloadResult({
+        success: [],
+        unresolved: [{ name: 'libssl', operator: '>=', version: '3' }],
+        warnings: ['repository is incomplete'],
+      })
+    );
+    const { result, args } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    await act(() => result.current.handleStartOSDownload(outputOptions));
+    expect(result.current.osDownloadError).toContain('libssl >= 3');
+    expect(result.current.osDownloadError).toContain('repository is incomplete');
+    expect(result.current).toMatchObject({ osDownloading: false, osResult: null });
+    expect(args.addHistory).not.toHaveBeenCalled();
+    expect(args.clearCart).not.toHaveBeenCalled();
+  });
+
+  it('retains a cancelled result without saving history or clearing the cart', async () => {
+    const response = downloadResult({ cancelled: true });
+    api.os.download.start.mockResolvedValueOnce(response);
+    const { result, args } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    await act(() => result.current.handleStartOSDownload(outputOptions));
+    expect(result.current).toMatchObject({
+      osResult: response,
+      osDownloading: false,
+      isOSPackaging: false,
+    });
+    expect(args.addHistory).not.toHaveBeenCalled();
+    expect(args.clearCart).not.toHaveBeenCalled();
+    expect(mocks.message.warning).toHaveBeenCalledWith('OS 패키지 다운로드가 취소되었습니다');
+  });
+
+  it.each([new Error('EACCES: output write denied'), 'connection closed'])(
+    'recovers from a rejected download and resets transient state: %s',
+    async (error) => {
+      api.os.download.start.mockRejectedValueOnce(error);
+      const { result, args } = mountFlow();
+      await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+      await act(() => result.current.handleStartOSDownload(outputOptions));
+      expect(result.current).toMatchObject({
+        osDownloading: false,
+        osResult: null,
+        osDownloadError: error instanceof Error ? error.message : error,
+      });
+      expect(args.addHistory).not.toHaveBeenCalled();
+      expect(args.clearCart).not.toHaveBeenCalled();
+      act(() => result.current.resetOSFlow());
+      expect(result.current).toMatchObject({
+        osDownloading: false,
+        osProgress: null,
+        osResult: null,
+        osDownloadError: null,
+      });
+      await act(() => result.current.handleStartOSDownload(outputOptions));
+      expect(result.current.osResult?.success).toEqual([pkg]);
+      expect(api.os.download.start).toHaveBeenCalledTimes(2);
+    }
+  );
+});
+
+describe('useOSDownloadFlow progress and cancellation', () => {
+  it('subscribes to progress and releases the listener when unmounted', async () => {
+    const { result, unmount } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    expect(api.listeners.size).toBe(1);
+    act(() => api.listeners.forEach((listener) => listener(progress)));
+    expect(result.current.osProgress).toEqual(progress);
+    unmount();
+    expect(api.listeners.size).toBe(0);
+    expect(api.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('waits for cancellation confirmation before invoking IPC', async () => {
+    const { result } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    act(() => api.listeners.forEach((listener) => listener(progress)));
+    act(() => result.current.handleCancelOSDownload());
+    expect(api.os.download.cancel).not.toHaveBeenCalled();
+    expect(mocks.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'OS 패키지 다운로드 취소' })
+    );
+    const onOk = mocks.confirm.mock.lastCall![0].onOk as () => Promise<void>;
+    await act(onOk);
+    expect(api.os.download.cancel).toHaveBeenCalledOnce();
+    expect(result.current.osProgress).toMatchObject({
+      currentPackage: '취소 요청 중',
+      bytesDownloaded: 1024,
+    });
+    expect(mocks.message.warning).toHaveBeenCalledWith('OS 패키지 다운로드 취소를 요청했습니다');
+  });
+
+  it('rejects cancellation while packaging without opening a confirmation dialog', async () => {
+    const { result } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    act(() => api.listeners.forEach((listener) => listener({ ...progress, phase: 'packaging' })));
+    act(() => result.current.handleCancelOSDownload());
+    expect(result.current.isOSPackaging).toBe(true);
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(api.os.download.cancel).not.toHaveBeenCalled();
+    expect(mocks.message.info).toHaveBeenCalledWith('패키징 단계에서는 취소할 수 없습니다');
+  });
+
+  it('reports unavailable cancellation IPC without pretending to request cancellation', async () => {
+    const { result } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    Reflect.deleteProperty(api.os.download, 'cancel');
+    act(() => result.current.handleCancelOSDownload());
+    await act(mocks.confirm.mock.lastCall![0].onOk as () => Promise<void>);
+    expect(mocks.message.error).toHaveBeenCalledWith('OS 패키지 취소 API를 사용할 수 없습니다');
+    expect(mocks.message.warning).not.toHaveBeenCalled();
+  });
+
+  it('removes only the requested package in the active OS manager', async () => {
+    const { result, args } = mountFlow();
+    await waitFor(() => expect(result.current.osDistribution).toEqual(distribution));
+    act(() => result.current.handleRemoveOSPackage({ ...pkg, version: 'different' }));
+    expect(args.removeCartItem).not.toHaveBeenCalled();
+    act(() => result.current.handleRemoveOSPackage(pkg));
+    expect(args.removeCartItem).toHaveBeenCalledExactlyOnceWith('nginx-yum');
+  });
+});

--- a/src/renderer/pages/settings/use-settings-form-actions.test.ts
+++ b/src/renderer/pages/settings/use-settings-form-actions.test.ts
@@ -1,0 +1,477 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { FormInstance } from 'antd';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSettingsFormActions } from './use-settings-form-actions';
+import type { SettingsFormSubmission, SettingsStoreSnapshot } from './settings-form-utils';
+
+const mocks = vi.hoisted(() => ({
+  message: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn(), loading: vi.fn() },
+  blocker: { state: 'unblocked', proceed: vi.fn(), reset: vi.fn() },
+  useBlocker: vi.fn(),
+}));
+
+vi.mock('antd', () => ({ message: mocks.message }));
+vi.mock('react-router-dom', () => ({
+  useBlocker: (predicate: unknown) => {
+    mocks.useBlocker(predicate);
+    return mocks.blocker;
+  },
+}));
+
+const snapshot: SettingsStoreSnapshot = {
+  concurrentDownloads: 3,
+  enableCache: true,
+  cachePath: '/cache',
+  includeDependencies: true,
+  defaultDownloadPath: '/downloads',
+  defaultOutputFormat: 'zip',
+  includeInstallScripts: true,
+  enableFileSplit: false,
+  maxFileSize: 25,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpUser: '',
+  smtpPassword: '',
+  smtpFrom: '',
+  smtpTo: '',
+  languageVersions: { python: '3.12' },
+  defaultTargetOS: 'linux',
+  defaultArchitecture: 'x86_64',
+  pipTargetPlatform: { os: 'linux', arch: 'x86_64', linuxDistro: 'rocky9', glibcVersion: '2.34' },
+  condaChannel: 'defaults',
+  cudaVersion: null,
+  yumDistribution: { id: 'rocky-9', architecture: 'x86_64' },
+  aptDistribution: { id: 'ubuntu-24.04', architecture: 'amd64' },
+  apkDistribution: { id: 'alpine-3.20', architecture: 'aarch64' },
+  dockerArchitecture: 'amd64',
+  dockerLayerCompression: 'gzip',
+  dockerIncludeLoadScript: true,
+  autoUpdate: false,
+  autoDownloadUpdate: false,
+  downloadRenderInterval: 100,
+};
+
+function createApi() {
+  return {
+    cache: {
+      getStats: vi.fn().mockResolvedValue({
+        totalSize: 4096,
+        entryCount: 3,
+        details: { pip: { diskEntries: 2, diskSize: 4096 }, npm: { entries: 1 } },
+      }),
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    selectDirectory: vi.fn().mockResolvedValue('/selected-downloads'),
+    selectFolder: vi.fn().mockResolvedValue('/selected-cache'),
+    testSmtpConnection: vi.fn().mockResolvedValue({ success: true }),
+    updater: { check: vi.fn().mockResolvedValue({ success: true }) },
+  };
+}
+
+function installApi(api: unknown) {
+  Object.defineProperty(window, 'electronAPI', { configurable: true, value: api });
+}
+
+function mountActions() {
+  let values: SettingsFormSubmission = {};
+  const form = {
+    getFieldsValue: vi.fn(() => ({ ...values })),
+    setFieldsValue: vi.fn((updates: SettingsFormSubmission) => {
+      values = { ...values, ...updates };
+    }),
+    setFieldValue: vi.fn((field: string, value: unknown) => {
+      values = { ...values, [field]: value };
+    }),
+    resetFields: vi.fn(() => {
+      values = {};
+    }),
+    validateFields: vi.fn().mockResolvedValue(undefined),
+  };
+  const updateSettings = vi.fn();
+  const resetSettings = vi.fn();
+  const hook = renderHook(
+    ({ settingsSnapshot }) =>
+      useSettingsFormActions({
+        form: form as unknown as FormInstance,
+        settingsSnapshot,
+        updateSettings,
+        resetSettings,
+      }),
+    { initialProps: { settingsSnapshot: { ...snapshot } } }
+  );
+  return { ...hook, form, updateSettings, resetSettings };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let api: ReturnType<typeof createApi>;
+const originalApi = Object.getOwnPropertyDescriptor(window, 'electronAPI');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.blocker.state = 'unblocked';
+  api = createApi();
+  installApi(api);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  if (originalApi) Object.defineProperty(window, 'electronAPI', originalApi);
+  else Reflect.deleteProperty(window, 'electronAPI');
+});
+
+describe('useSettingsFormActions form and navigation', () => {
+  it('keeps a dirty draft across equivalent store snapshots and marks a normalized save clean', async () => {
+    const { result, form, updateSettings, rerender } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    act(() => {
+      form.setFieldValue('yumDistributionId', 'rocky-10');
+      result.current.handleFormChange();
+    });
+    expect(result.current.isDirty).toBe(true);
+    rerender({ settingsSnapshot: { ...snapshot } });
+    expect(form.getFieldsValue().yumDistributionId).toBe('rocky-10');
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => result.current.handleSave(form.getFieldsValue()));
+    expect(updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        yumDistribution: { id: 'rocky-10', architecture: 'x86_64' },
+      })
+    );
+    expect(updateSettings.mock.calls[0][0]).not.toHaveProperty('yumDistributionId');
+    expect(result.current.isDirty).toBe(false);
+    expect(mocks.message.success).toHaveBeenCalledWith('설정이 저장되었습니다');
+    act(() => result.current.handleFormChange());
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('blocks only a dirty path change and removes the unload protection on unmount', async () => {
+    const { result, form, unmount } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    const cleanEvent = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(cleanEvent);
+    expect(cleanEvent.defaultPrevented).toBe(false);
+    act(() => {
+      form.setFieldValue('smtpHost', 'smtp.example.test');
+      result.current.handleFormChange();
+    });
+    const predicate = mocks.useBlocker.mock.lastCall![0] as (locations: {
+      currentLocation: { pathname: string };
+      nextLocation: { pathname: string };
+    }) => boolean;
+    expect(
+      predicate({
+        currentLocation: { pathname: '/settings' },
+        nextLocation: { pathname: '/settings' },
+      })
+    ).toBe(false);
+    expect(
+      predicate({ currentLocation: { pathname: '/settings' }, nextLocation: { pathname: '/cart' } })
+    ).toBe(true);
+    const dirtyEvent = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(dirtyEvent);
+    expect(dirtyEvent.defaultPrevented).toBe(true);
+    unmount();
+    const unmountedEvent = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(unmountedEvent);
+    expect(unmountedEvent.defaultPrevented).toBe(false);
+  });
+
+  it('keeps navigation blocked after form validation fails, then saves before proceeding', async () => {
+    mocks.blocker.state = 'blocked';
+    const { result, form, updateSettings } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    form.validateFields.mockRejectedValueOnce({ errorFields: [{ name: ['smtpPort'] }] });
+    await act(() => result.current.handleNavigationConfirm(true));
+    expect(result.current.showNavigationModal).toBe(true);
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(mocks.blocker.proceed).not.toHaveBeenCalled();
+    expect(mocks.message.error).toHaveBeenCalledWith('설정 저장에 실패했습니다');
+
+    await act(() => result.current.handleNavigationConfirm(true));
+    expect(updateSettings).toHaveBeenCalledOnce();
+    expect(mocks.blocker.proceed).toHaveBeenCalledOnce();
+    expect(updateSettings.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.blocker.proceed.mock.invocationCallOrder[0]
+    );
+    expect(result.current.showNavigationModal).toBe(false);
+  });
+
+  it.each(['discard', 'cancel'] as const)(
+    '%s navigation does not save or validate the draft',
+    async (action) => {
+      mocks.blocker.state = 'blocked';
+      const { result, form, updateSettings } = mountActions();
+      await waitFor(() => expect(result.current.loadingCache).toBe(false));
+      if (action === 'discard') await act(() => result.current.handleNavigationConfirm(false));
+      else act(() => result.current.handleNavigationCancel());
+      expect(form.validateFields).not.toHaveBeenCalled();
+      expect(updateSettings).not.toHaveBeenCalled();
+      expect(mocks.blocker.proceed).toHaveBeenCalledTimes(action === 'discard' ? 1 : 0);
+      expect(mocks.blocker.reset).toHaveBeenCalledTimes(action === 'cancel' ? 1 : 0);
+      expect(result.current.showNavigationModal).toBe(false);
+    }
+  );
+
+  it('reset removes fields outside the snapshot even when persisted defaults are unchanged', async () => {
+    const { result, form, resetSettings, rerender } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    act(() => {
+      form.setFieldValue('hiddenDraft', 'stale');
+      result.current.handleFormChange();
+    });
+    act(() => result.current.handleReset());
+    rerender({ settingsSnapshot: { ...snapshot } });
+    expect(resetSettings).toHaveBeenCalledOnce();
+    expect(form.resetFields).toHaveBeenCalledOnce();
+    expect(form.getFieldsValue()).not.toHaveProperty('hiddenDraft');
+    expect(form.getFieldsValue().defaultDownloadPath).toBe('/downloads');
+    expect(result.current.isDirty).toBe(false);
+  });
+});
+
+describe('useSettingsFormActions cache and folders', () => {
+  it('loads cache statistics, clears only after successful deletion, and releases loading state', async () => {
+    const pending = deferred<void>();
+    api.cache.clear.mockReturnValueOnce(pending.promise);
+    const { result } = mountActions();
+    await waitFor(() => expect(result.current.cacheSize).toBe(4096));
+    expect(result.current.cacheCount).toBe(3);
+    expect(result.current.cacheDetails).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'pip', entryCount: 2, sizeBytes: 4096 }),
+        expect.objectContaining({ key: 'npm', entryCount: 1 }),
+      ])
+    );
+    let clearing!: Promise<void>;
+    act(() => {
+      clearing = result.current.handleClearCache();
+    });
+    expect(result.current.clearingCache).toBe(true);
+    expect(result.current.cacheCount).toBe(3);
+    await act(async () => {
+      pending.resolve();
+      await clearing;
+    });
+    expect(result.current.clearingCache).toBe(false);
+    expect(result.current.cacheSize).toBe(0);
+    expect(result.current.cacheCount).toBe(0);
+    expect(result.current.cacheDetails.every((detail) => detail.entryCount === 0)).toBe(true);
+    expect(mocks.message.success).toHaveBeenCalledWith('패키지 캐시가 삭제되었습니다');
+  });
+
+  it('retains cache statistics after a deletion permission error and permits a retry', async () => {
+    api.cache.clear.mockRejectedValueOnce(new Error('EACCES: permission denied'));
+    const { result } = mountActions();
+    await waitFor(() => expect(result.current.cacheCount).toBe(3));
+    await act(() => result.current.handleClearCache());
+    expect(result.current.cacheSize).toBe(4096);
+    expect(result.current.cacheCount).toBe(3);
+    expect(result.current.clearingCache).toBe(false);
+    expect(mocks.message.error).toHaveBeenCalledWith('패키지 캐시 삭제에 실패했습니다');
+    expect(mocks.message.success).not.toHaveBeenCalled();
+    await act(() => result.current.handleClearCache());
+    expect(result.current.cacheCount).toBe(0);
+  });
+
+  it('replaces stale statistics with an empty state if cache refresh fails', async () => {
+    const { result } = mountActions();
+    await waitFor(() => expect(result.current.cacheCount).toBe(3));
+    api.cache.getStats.mockRejectedValueOnce(new Error('cache unavailable'));
+    await act(() => result.current.loadCacheInfo());
+    expect(result.current).toMatchObject({ cacheSize: 0, cacheCount: 0, loadingCache: false });
+    expect(result.current.cacheDetails.every((detail) => detail.entryCount === 0)).toBe(true);
+  });
+
+  it('reports unavailable cache and folder APIs in browser mode without changing the form', async () => {
+    installApi(undefined);
+    const { result, form } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    await act(() => result.current.handleClearCache());
+    await act(() => result.current.handleSelectCacheFolder());
+    await act(() => result.current.handleSelectDownloadFolder());
+    expect(result.current).toMatchObject({
+      cacheCount: 0,
+      cacheSize: 0,
+      clearingCache: false,
+      isDirty: false,
+    });
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+    expect(mocks.message.error).toHaveBeenCalledWith('패키지 캐시 삭제에 실패했습니다');
+    expect(mocks.message.info).toHaveBeenCalledWith(
+      '폴더 선택 기능은 Electron 환경에서 사용 가능합니다'
+    );
+    expect(mocks.message.info).toHaveBeenCalledWith('폴더 선택은 Electron 환경에서만 가능합니다');
+  });
+
+  it.each([
+    ['handleSelectDownloadFolder', 'selectDirectory', 'defaultDownloadPath', '/selected-downloads'],
+    ['handleSelectCacheFolder', 'selectFolder', 'cachePath', '/selected-cache'],
+  ] as const)(
+    '%s keeps cancelled selection clean and marks a chosen folder dirty',
+    async (handler, picker, field, path) => {
+      api[picker].mockResolvedValueOnce(null);
+      const { result, form } = mountActions();
+      await waitFor(() => expect(result.current.loadingCache).toBe(false));
+      await act(() => result.current[handler]());
+      expect(form.setFieldValue).not.toHaveBeenCalled();
+      expect(result.current.isDirty).toBe(false);
+      await act(() => result.current[handler]());
+      expect(form.getFieldsValue()[field]).toBe(path);
+      expect(result.current.isDirty).toBe(true);
+    }
+  );
+});
+
+describe('useSettingsFormActions SMTP and updates', () => {
+  it.each([
+    { smtpHost: '', smtpPort: 587 },
+    { smtpHost: 'smtp.example.test', smtpPort: 0 },
+  ])('rejects missing SMTP host or port before invoking IPC: %j', async (fields) => {
+    const { result, form } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    form.setFieldsValue(fields);
+    await act(() => result.current.handleTestSmtp());
+    expect(api.testSmtpConnection).not.toHaveBeenCalled();
+    expect(result.current).toMatchObject({ testingSmtp: false, smtpTestResult: null });
+    expect(mocks.message.warning).toHaveBeenCalledWith('SMTP 서버와 포트를 입력하세요');
+  });
+
+  it('passes the current unsaved SMTP fields and resolves the pending state from IPC', async () => {
+    const pending = deferred<{ success: boolean }>();
+    api.testSmtpConnection.mockReturnValueOnce(pending.promise);
+    const { result, form, updateSettings } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    form.setFieldsValue({
+      smtpHost: 'smtp.example.test',
+      smtpPort: 2525,
+      smtpUser: 'sender',
+      smtpPassword: 'test-only',
+      smtpFrom: 'sender@example.test',
+    });
+    let testing!: Promise<void>;
+    act(() => {
+      testing = result.current.handleTestSmtp();
+    });
+    expect(result.current).toMatchObject({
+      testingSmtp: true,
+      smtpTestResult: null,
+      smtpTestMode: 'ipc',
+    });
+    expect(api.testSmtpConnection).toHaveBeenCalledWith({
+      host: 'smtp.example.test',
+      port: 2525,
+      user: 'sender',
+      password: 'test-only',
+      from: 'sender@example.test',
+    });
+    await act(async () => {
+      pending.resolve({ success: true });
+      await testing;
+    });
+    expect(result.current).toMatchObject({ testingSmtp: false, smtpTestResult: 'success' });
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [false, 'SMTP 연결 테스트 실패'],
+    [{ success: false, error: 'Authentication rejected' }, 'Authentication rejected'],
+    [{ success: false }, 'SMTP 연결 테스트 실패'],
+  ])('displays a failed SMTP response without throwing: %j', async (response, errorMessage) => {
+    api.testSmtpConnection.mockResolvedValueOnce(response);
+    const { result, form } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    form.setFieldValue('smtpHost', 'smtp.example.test');
+    await act(() => result.current.handleTestSmtp());
+    expect(result.current).toMatchObject({ smtpTestResult: 'failed', testingSmtp: false });
+    expect(mocks.message.error).toHaveBeenCalledWith(errorMessage);
+  });
+
+  it.each([new Error('Connection timed out'), 'non-error rejection'])(
+    'recovers from an SMTP exception and can retry: %s',
+    async (failure) => {
+      api.testSmtpConnection.mockRejectedValueOnce(failure).mockResolvedValueOnce(true);
+      const { result, form } = mountActions();
+      await waitFor(() => expect(result.current.loadingCache).toBe(false));
+      form.setFieldValue('smtpHost', 'smtp.example.test');
+      await act(() => result.current.handleTestSmtp());
+      expect(result.current).toMatchObject({ smtpTestResult: 'failed', testingSmtp: false });
+      expect(mocks.message.error).toHaveBeenCalledWith(
+        failure instanceof Error ? failure.message : 'SMTP 연결 테스트 실패'
+      );
+      await act(() => result.current.handleTestSmtp());
+      expect(result.current).toMatchObject({ smtpTestResult: 'success', testingSmtp: false });
+    }
+  );
+
+  it('does not simulate success when Electron is present but SMTP IPC is missing', async () => {
+    installApi({ cache: api.cache });
+    const { result, form } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    form.setFieldValue('smtpHost', 'smtp.example.test');
+    await act(() => result.current.handleTestSmtp());
+    expect(result.current).toMatchObject({
+      smtpTestMode: 'missing-ipc',
+      smtpTestResult: 'failed',
+      testingSmtp: false,
+    });
+    expect(mocks.message.warning).toHaveBeenCalledWith(
+      '현재 Electron 빌드에는 SMTP 연결 테스트 IPC가 연결되어 있지 않습니다.'
+    );
+    expect(mocks.message.success).not.toHaveBeenCalled();
+  });
+
+  it('labels browser SMTP simulation and completes it only after its delay', async () => {
+    installApi(undefined);
+    const { result, form } = mountActions();
+    await waitFor(() => expect(result.current.loadingCache).toBe(false));
+    vi.useFakeTimers();
+    form.setFieldValue('smtpHost', 'smtp.example.test');
+    let testing!: Promise<void>;
+    act(() => {
+      testing = result.current.handleTestSmtp();
+    });
+    expect(result.current).toMatchObject({
+      smtpTestMode: 'browser-simulated',
+      testingSmtp: true,
+      smtpTestResult: null,
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+      await testing;
+    });
+    expect(result.current).toMatchObject({ smtpTestResult: 'success', testingSmtp: false });
+    expect(mocks.message.success).toHaveBeenCalledWith('SMTP 연결 테스트 성공 (시뮬레이션)');
+    expect(api.testSmtpConnection).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    'replaces update progress with the reported result: success=%s',
+    async (success) => {
+      api.updater.check.mockResolvedValueOnce({ success, error: 'network unavailable' });
+      const { result } = mountActions();
+      await waitFor(() => expect(result.current.loadingCache).toBe(false));
+      await act(() => result.current.handleCheckForUpdates());
+      expect(mocks.message.loading).toHaveBeenCalledWith({
+        content: '업데이트 확인 중...',
+        key: 'update-check',
+      });
+      expect(success ? mocks.message.success : mocks.message.error).toHaveBeenCalledWith({
+        content: success ? '업데이트 확인 완료' : '업데이트 확인 실패: network unavailable',
+        key: 'update-check',
+      });
+    }
+  );
+});

--- a/tests/e2e/cart-input-regression.spec.ts
+++ b/tests/e2e/cart-input-regression.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readMockElectronAppState, setupMockElectronApp } from './fixtures/mock-electron-app';
+
+async function openTextInput(page: Page, tab = 'requirements.txt') {
+  // Ant Design includes the icon label in the button's accessible name.
+  // Anchor the text suffix to exclude the separate "텍스트로 추가하기" button.
+  await page.getByRole('button', { name: /텍스트로 추가$/ }).click();
+  const dialog = page.getByRole('dialog', { name: '패키지 목록 붙여넣기' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('tab', { name: tab, exact: true }).click();
+  return dialog;
+}
+
+test('빈 장바구니와 다운로드 화면은 입력·검색으로 돌아갈 수 있고 빈 입력은 추가하지 않는다', async ({
+  page,
+}) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  await expect(page.getByText('장바구니가 비어있습니다')).toBeVisible();
+  await expect(page.getByRole('button', { name: '다운로드 시작' })).toHaveCount(0);
+  const dialog = await openTextInput(page);
+  await dialog.getByRole('textbox').fill('   \n  ');
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('내용을 입력하세요')).toBeVisible();
+  await expect(dialog).toBeVisible();
+  expect((await readMockElectronAppState(page)).cart.items).toEqual([]);
+  await dialog.getByRole('button', { name: '취소', exact: true }).click();
+
+  await page.goto('/#/download');
+  await expect(page.getByText('다운로드할 패키지가 없습니다')).toBeVisible();
+  await expect(page.getByRole('button', { name: '다운로드 시작' })).toHaveCount(0);
+  await page.getByRole('button', { name: '장바구니로 이동' }).click();
+  await expect(page.getByText('장바구니가 비어있습니다')).toBeVisible();
+  expect((await readMockElectronAppState(page)).runtime.downloadCalls).toEqual([]);
+});
+
+test('requirements 입력은 주석과 옵션을 제외하고 중복 없이 저장하며 다시 가져와도 유지된다', async ({
+  page,
+}) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  const input =
+    '# pinned packages\nrequests==2.32.3\n\n-r base.txt\nnumpy==2.2.0\nrequests==2.32.3';
+  let dialog = await openTextInput(page);
+  await dialog.getByRole('textbox').fill(input);
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('2개 패키지가 추가되었습니다')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'requests', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'numpy', exact: true })).toBeVisible();
+  let state = await readMockElectronAppState(page);
+  expect(state.cart.items.map(({ type, name, version }) => ({ type, name, version }))).toEqual([
+    { type: 'pip', name: 'requests', version: '2.32.3' },
+    { type: 'pip', name: 'numpy', version: '2.2.0' },
+  ]);
+
+  await page.reload();
+  await expect(page.getByRole('cell', { name: 'requests', exact: true })).toBeVisible();
+  dialog = await openTextInput(page);
+  await dialog.getByRole('textbox').fill(input);
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('모든 패키지가 이미 장바구니에 있습니다')).toBeVisible();
+  state = await readMockElectronAppState(page);
+  expect(state.cart.items).toHaveLength(2);
+  expect(state.runtime.downloadCalls).toEqual([]);
+});
+
+test('버전을 생략한 입력은 최신 버전을 조회하고 조회 실패 패키지는 latest로 유지한다', async ({
+  page,
+}) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  await page.evaluate(() => {
+    window.electronAPI!.search.versions = async (_type, name) => {
+      if (name === 'offline-package') throw new Error('mock registry unavailable');
+      return { versions: ['3.1.0', '3.0.0'] };
+    };
+  });
+  const dialog = await openTextInput(page);
+  await dialog.getByRole('textbox').fill('flask\noffline-package');
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('2개 패키지가 추가되었습니다')).toBeVisible();
+  const state = await readMockElectronAppState(page);
+  expect(state.cart.items.map(({ name, version }) => ({ name, version }))).toEqual([
+    { name: 'flask', version: '3.1.0' },
+    { name: 'offline-package', version: 'latest' },
+  ]);
+});
+
+for (const [label, input] of [
+  ['문법 오류', '{ "dependencies": '],
+  ['문자열이 아닌 버전', '{ "dependencies": { "react": 19 } }'],
+]) {
+  test(`package.json ${label}는 기존 장바구니를 변경하지 않는다`, async ({ page }) => {
+    await setupMockElectronApp(page, {
+      cartItems: [{ id: 'existing', type: 'pip', name: 'requests', version: '2.32.3', addedAt: 1 }],
+    });
+    await page.goto('/#/cart');
+    const before = (await readMockElectronAppState(page)).cart.items;
+    const dialog = await openTextInput(page, 'package.json');
+    await dialog.getByRole('textbox').fill(input);
+    await dialog.getByRole('button', { name: '추가', exact: true }).click();
+    await expect(page.getByText('package.json 파싱 실패')).toBeVisible();
+    expect((await readMockElectronAppState(page)).cart.items).toEqual(before);
+    await expect(page.getByRole('cell', { name: 'requests', exact: true })).toBeVisible();
+  });
+}
+
+test('package.json 입력은 일반·개발 의존성과 scoped 이름을 장바구니에 담는다', async ({ page }) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  const dialog = await openTextInput(page, 'package.json');
+  await dialog.getByRole('textbox').fill(
+    JSON.stringify({
+      name: 'application',
+      dependencies: { react: '^19.0.0', '@example/cli': '~1.3.0' },
+      devDependencies: { typescript: '5.9.3' },
+    })
+  );
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('3개 패키지가 추가되었습니다')).toBeVisible();
+  const state = await readMockElectronAppState(page);
+  expect(state.cart.items.map(({ type, name, version }) => ({ type, name, version }))).toEqual([
+    { type: 'npm', name: 'react', version: '19.0.0' },
+    { type: 'npm', name: '@example/cli', version: '1.3.0' },
+    { type: 'npm', name: 'typescript', version: '5.9.3' },
+  ]);
+  await expect(page.getByRole('cell', { name: '@example/cli', exact: true })).toBeVisible();
+});
+
+test('requirements 파일 업로드는 파일 내용을 읽어 패키지를 추가한다', async ({ page }) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  await page
+    .locator('input[type="file"]')
+    .first()
+    .setInputFiles({
+      name: 'requirements.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('requests==2.32.3\n# upload comment\nflask==3.1.0\n'),
+    });
+  await expect(page.getByText('2개 패키지가 추가되었습니다')).toBeVisible();
+  const state = await readMockElectronAppState(page);
+  expect(state.cart.items.map(({ name, version }) => ({ name, version }))).toEqual([
+    { name: 'requests', version: '2.32.3' },
+    { name: 'flask', version: '3.1.0' },
+  ]);
+  await expect(page.getByText('장바구니가 비어있습니다')).toHaveCount(0);
+});
+
+test('pom.xml 입력은 같은 좌표의 JAR와 POM 아티팩트를 구분해 보존한다', async ({ page }) => {
+  await setupMockElectronApp(page);
+  await page.goto('/#/cart');
+  const dialog = await openTextInput(page, 'pom.xml');
+  await dialog.getByRole('textbox').fill(`<dependencies>
+    <dependency><groupId>org.example</groupId><artifactId>platform</artifactId><version>1.0</version><type>pom</type></dependency>
+    <dependency><groupId>org.example</groupId><artifactId>platform</artifactId><version>1.0</version></dependency>
+  </dependencies>`);
+  await dialog.getByRole('button', { name: '추가', exact: true }).click();
+  await expect(page.getByText('2개 패키지가 추가되었습니다')).toBeVisible();
+  const items = (await readMockElectronAppState(page)).cart.items;
+  expect(items).toHaveLength(2);
+  expect(items[0]).toMatchObject({
+    type: 'maven',
+    name: 'org.example:platform',
+    version: '1.0',
+    metadata: { type: 'pom' },
+  });
+  expect(items[1]).toMatchObject({ type: 'maven', name: 'org.example:platform', version: '1.0' });
+  expect(items[1].metadata?.type).toBeUndefined();
+});

--- a/tests/e2e/download-cancel-retry.spec.ts
+++ b/tests/e2e/download-cancel-retry.spec.ts
@@ -30,7 +30,33 @@ const retryCartItems: CartItem[] = [
   },
 ];
 
+async function advanceFixtureClock(page: Page, milliseconds: number) {
+  await page.clock.runFor(milliseconds);
+  // Progress handlers schedule a zero-delay render batch on the next timer tick.
+  await page.clock.runFor(1);
+}
+
+async function confirmDownloadCancellation(page: Page) {
+  await page.getByRole('button', { name: '취소' }).click();
+  // Modal.confirm renders asynchronously and schedules its opening animation frame.
+  await advanceFixtureClock(page, 16);
+  const dialog = page.getByRole('dialog', { name: '다운로드 취소', includeHidden: true });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: '취소', exact: true }).click();
+  // Let rc-motion finish its queued frames before the overlay can intercept the next action.
+  await expect
+    .poll(
+      async () => {
+        await advanceFixtureClock(page, 16);
+        return dialog.count();
+      },
+      { intervals: [16] }
+    )
+    .toBe(0);
+}
+
 async function openDownloadPage(page: Page, expectedNames: string[]) {
+  await page.clock.install({ time: new Date('2025-01-01T00:00:00Z') });
   await page.goto('/#/cart');
   for (const name of expectedNames) {
     await expect(page.getByText(name)).toBeVisible();
@@ -38,6 +64,8 @@ async function openDownloadPage(page: Page, expectedNames: string[]) {
   await page.getByRole('button', { name: '다운로드 시작' }).click();
   await expect(page.getByRole('heading', { name: '다운로드' })).toBeVisible();
   await expect(page.getByRole('button', { name: '다운로드 시작' })).toBeVisible();
+  // Keep fixture deadlines frozen while the test operates confirmation dialogs.
+  await page.clock.pauseAt(new Date('2025-01-01T01:00:00Z'));
 }
 
 test('느린 다운로드는 취소 후 취소됨 상태로 고정된다', async ({ page }) => {
@@ -60,17 +88,16 @@ test('느린 다운로드는 취소 후 취소됨 상태로 고정된다', async
   await openDownloadPage(page, ['requests']);
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
   await expect(page.getByText('다운로드 중')).toBeVisible();
 
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  await confirmDownloadCancellation(page);
 
   const cancelledRow = page.locator('tr', { hasText: 'requests' });
   await expect(cancelledRow.getByText('취소됨', { exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: '다운로드 시작' })).toBeVisible();
-  await page.waitForTimeout(1500);
+  await advanceFixtureClock(page, 1500);
   await expect(cancelledRow.getByText('취소됨', { exact: true })).toBeVisible();
   await expect(cancelledRow.getByText('완료', { exact: true })).toHaveCount(0);
   await expect(page.getByText('실제 산출물:')).toHaveCount(0);
@@ -101,6 +128,7 @@ test('1회 실패한 다운로드는 개별 재시도로 성공까지 복구할 
   await openDownloadPage(page, ['requests', 'urllib3']);
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
 
   await expect(page.getByText('부분 완료', { exact: true })).toBeVisible();
   await expect(page.getByText('실제 산출물:')).toBeVisible();
@@ -109,6 +137,7 @@ test('1회 실패한 다운로드는 개별 재시도로 성공까지 복구할 
   await expect(failedRow.getByText('실패')).toBeVisible();
   await expect(completedRow.getByText('완료', { exact: true })).toBeVisible();
   await failedRow.getByRole('button', { name: '재시도' }).click();
+  await advanceFixtureClock(page, 150);
 
   await expect(page.getByText('다운로드 완료', { exact: true })).toBeVisible();
   await expect(page.getByText('실제 산출물:')).toBeVisible();
@@ -130,7 +159,9 @@ test('1회 실패한 다운로드는 개별 재시도로 성공까지 복구할 
   ]);
 });
 
-test('취소 직후 새 다운로드를 시작해도 이전 세션의 늦은 완료 이벤트는 섞이지 않는다', async ({ page }) => {
+test('취소 직후 새 다운로드를 시작해도 이전 세션의 늦은 완료 이벤트는 섞이지 않는다', async ({
+  page,
+}) => {
   await setupMockElectronApp(page, {
     config: {
       includeDependencies: false,
@@ -162,25 +193,30 @@ test('취소 직후 새 다운로드를 시작해도 이전 세션의 늦은 완
   await openDownloadPage(page, ['requests']);
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 1650);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  // The cancel button appears during checkPath too; wait for the first IPC session to download.
+  await expect(
+    page.locator('tr', { hasText: 'requests' }).getByText('다운로드 중', { exact: true })
+  ).toBeVisible();
+  await confirmDownloadCancellation(page);
 
   await expect(page.getByRole('button', { name: '다운로드 시작' })).toBeVisible();
   await page.getByRole('button', { name: '다운로드 시작' }).click();
 
-  await page.waitForTimeout(900);
+  await advanceFixtureClock(page, 900);
   const pendingState = await readMockElectronAppState(page);
   expect(pendingState.runtime.downloadCalls).toHaveLength(1);
   await expect(page.getByText('다운로드 완료', { exact: true })).toHaveCount(0);
   await expect(page.getByText('다운로드 실패', { exact: true })).toHaveCount(0);
 
+  // Finish the second path check and its package failure after inspecting the late first completion.
+  await advanceFixtureClock(page, 750);
   const failedRow = page.locator('tr', { hasText: 'requests' });
   await expect(page.getByText('다운로드 실패', { exact: true })).toBeVisible();
   await expect(failedRow.getByText('실패')).toBeVisible();
 
-  await page.waitForTimeout(1500);
+  await advanceFixtureClock(page, 1500);
   await expect(page.getByText('다운로드 실패', { exact: true })).toBeVisible();
   await expect(page.getByText('다운로드 완료', { exact: true })).toHaveCount(0);
   await expect(failedRow.getByText('실패')).toBeVisible();
@@ -218,10 +254,9 @@ test('이메일 전달이 이미 끝난 취소 완료는 경고와 히스토리�
   await expect(page.getByText('현재 수신자: offline@example.com')).toBeVisible();
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  await confirmDownloadCancellation(page);
 
   const cancelledRow = page.locator('tr', { hasText: 'requests' });
   await expect(cancelledRow.getByText('취소됨', { exact: true })).toBeVisible();
@@ -271,10 +306,9 @@ test('이메일 전달 실패와 취소가 겹치면 산출물과 오류를 유�
   await openDownloadPage(page, ['requests']);
   await page.getByRole('radio', { name: '이메일로 전달' }).click();
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  await confirmDownloadCancellation(page);
 
   await expect(page.getByText('전달 실패', { exact: true })).toBeVisible();
   await expect(page.getByText('복구 가능한 산출물:')).toBeVisible();
@@ -333,18 +367,21 @@ test('취소 후 전달 실패 화면에서도 실패 항목 재시도가 새 �
   await openDownloadPage(page, ['requests', 'urllib3']);
   await page.getByRole('radio', { name: '이메일로 전달' }).click();
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 50);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
-
+  // This scenario cancels delivery after the package results are already known.
   const failedRow = page.locator('tr', { hasText: 'requests' });
   const completedRow = page.locator('tr', { hasText: 'urllib3' });
+  await expect(failedRow.getByText('실패', { exact: true })).toBeVisible();
+  await expect(completedRow.getByText('완료', { exact: true })).toBeVisible();
+  await confirmDownloadCancellation(page);
+
   await expect(page.getByText('전달 실패', { exact: true })).toBeVisible();
   await expect(failedRow.getByText('실패')).toBeVisible();
   await expect(completedRow.getByText('완료', { exact: true })).toBeVisible();
 
   await failedRow.getByRole('button', { name: '재시도' }).click();
+  await advanceFixtureClock(page, 150);
 
   await expect(page.getByText('다운로드 완료', { exact: true })).toBeVisible();
   await expect(failedRow.getByText('완료', { exact: true })).toBeVisible();
@@ -362,7 +399,9 @@ test('취소 후 전달 실패 화면에서도 실패 항목 재시도가 새 �
   ]);
 });
 
-test('덮어쓰기 확인 대기 중 completion이 와도 직전 취소 세션의 전달 결과는 보존된다', async ({ page }) => {
+test('덮어쓰기 확인 대기 중 completion이 와도 직전 취소 세션의 전달 결과는 보존된다', async ({
+  page,
+}) => {
   await setupMockElectronApp(page, {
     config: {
       includeDependencies: false,
@@ -404,16 +443,28 @@ test('덮어쓰기 확인 대기 중 completion이 와도 직전 취소 세션�
   await expect(page.getByText('현재 수신자: offline@example.com')).toBeVisible();
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  await confirmDownloadCancellation(page);
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
-  const overwriteDialog = page.getByRole('dialog', { name: '기존 데이터 발견' });
+  await advanceFixtureClock(page, 16);
+  const overwriteDialog = page.getByRole('dialog', {
+    name: '기존 데이터 발견',
+    includeHidden: true,
+  });
   await expect(overwriteDialog).toBeVisible();
-  await page.waitForTimeout(900);
+  await advanceFixtureClock(page, 900);
   await overwriteDialog.getByRole('button', { name: '취소' }).click();
+  await expect
+    .poll(
+      async () => {
+        await advanceFixtureClock(page, 16);
+        return overwriteDialog.count();
+      },
+      { intervals: [16] }
+    )
+    .toBe(0);
 
   await expect(page.getByText('취소 후 이메일 전달 완료', { exact: true })).toBeVisible();
   await expect(page.getByText('실제 산출물:')).toBeVisible();
@@ -472,17 +523,19 @@ test('취소 후 전달 실패 화면에서 재시도 시작이 실패해도 이
   await openDownloadPage(page, ['requests', 'urllib3']);
   await page.getByRole('radio', { name: '이메일로 전달' }).click();
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 50);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
-
   const failedRow = page.locator('tr', { hasText: 'requests' });
   const completedRow = page.locator('tr', { hasText: 'urllib3' });
+  await expect(failedRow.getByText('실패', { exact: true })).toBeVisible();
+  await expect(completedRow.getByText('완료', { exact: true })).toBeVisible();
+  await confirmDownloadCancellation(page);
+
   await expect(page.getByText('전달 실패', { exact: true })).toBeVisible();
   await expect(failedRow.getByText('실패')).toBeVisible();
   await expect(completedRow.getByText('완료', { exact: true })).toBeVisible();
   await failedRow.getByRole('button', { name: '재시도' }).click();
+  await advanceFixtureClock(page, 150);
 
   await expect(page.getByText('전달 실패', { exact: true })).toBeVisible();
   await expect(page.getByText('복구 가능한 산출물:', { exact: true })).toBeVisible();
@@ -503,7 +556,9 @@ test('취소 후 전달 실패 화면에서 재시도 시작이 실패해도 이
   );
 });
 
-test('취소 후 전달 완료 흐름에서 전체 재시작이 늦게 실패해도 이전 결과를 유지한다', async ({ page }) => {
+test('취소 후 전달 완료 흐름에서 전체 재시작이 늦게 실패해도 이전 결과를 유지한다', async ({
+  page,
+}) => {
   await setupMockElectronApp(page, {
     config: {
       includeDependencies: false,
@@ -539,13 +594,13 @@ test('취소 후 전달 완료 흐름에서 전체 재시작이 늦게 실패해
   await expect(page.getByText('현재 수신자: offline@example.com')).toBeVisible();
 
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 150);
   await expect(page.getByRole('button', { name: '취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).click();
-  await expect(page.getByRole('dialog', { name: '다운로드 취소' })).toBeVisible();
-  await page.getByRole('button', { name: '취소' }).last().click();
+  await confirmDownloadCancellation(page);
 
   await expect(page.getByRole('button', { name: '다운로드 시작' })).toBeVisible();
   await page.getByRole('button', { name: '다운로드 시작' }).click();
+  await advanceFixtureClock(page, 1200);
 
   await expect(page.getByText('취소 후 이메일 전달 완료', { exact: true })).toBeVisible();
   await expect(page.getByText('실제 산출물:')).toBeVisible();


### PR DESCRIPTION
## 요약

기존 동작을 기준으로 CLI·Electron·패키지 다운로드/의존성 해결·캐시·메일·렌더러 훅 전반에 회귀 테스트 574개를 추가하고, 장바구니 입력 E2E 8개를 추가합니다. 핵심 기능뿐 아니라 빈 값, 잘못된 입력, 인증/파일 권한 오류, 취소·재시도 및 실패 이후 부작용을 검증합니다. 서비스 로직과 의존성 선언은 변경하지 않습니다.

## 변경 사항

- 테스트 파일 33개 보강: CLI 2개, Electron 9개, core 19개, 렌더러 훅 2개, E2E 1개. 최신 main과 겹친 core 파일 2개는 양쪽 테스트를 모두 보존했습니다 (신규 31개 + 기존 2개 확장).
- Docker 인증·manifest·blob·catalog, OS 압축/의존성 트리, pip 후보/태그/provider, PyPI/Conda/Maven 조회 및 fallback 경로를 직접 검증합니다.
- HTTP·파일 전송·캐시·메일의 오류 전파, 정리, TTL/첨부 크기 경계와 실패 후 재시도를 검증합니다.
- 장바구니 requirements/package.json/pom.xml/파일 업로드와 빈 상태를 브라우저에서 검증합니다.
- 기존 취소 E2E의 시나리오 사전 조건을 실제 다운로드/패키지 결과에 맞추고 시간 제어를 결정적으로 만듭니다. 최종 결과 검증을 유지합니다.

## 검증

- 표준 진입점 `bash scripts/verify-worktree.sh`로 DOM 환경을 제외한 전체 실행: 2,462개 통과 (최신 main 병합 기준), 외부 연동 등 기존 186개 skip.
- 로컬 공유 node_modules에 선언된 jsdom/@testing-library/react가 없어 DOM 훅 3개 파일은 CI의 npm ci 환경에서 검증했습니다. 테스트 설정에서 제외하지 않았습니다.
- 신규 Node 테스트 strict TypeScript 검사 및 프로젝트 `tsc --noEmit` 통과.
- `npm run lint`: 오류 0개 (기존 경고 포함).
- 작업 시작 시점 대비 core 라인 커버리지 66.17% → 78.13%, 분기 55.19% → 66.88%.
- `npm run test:e2e`: 전체 22개 통과 (최신 main 병합 후).
- CI 7개 항목 모두 통과: Windows/macOS/Linux 단위 테스트, Test Coverage, Lint, Type Check, Playwright E2E. Ubuntu 전체 실행은 DOM 훅 포함 2,518개 통과·기존 186개 skip입니다.

## 문서

- `docs/testing.md`: 영역별 회귀 범위, 실행 전제, 오류/시간 제어 원칙.
- `docs/ui-testing-playwright-conversion.md`: 장바구니 E2E 및 훅 자동화 범위.
- API·화면 동작·배포 절차 변경은 없어 해당 사용 문서는 유지합니다.
