### PR TITLE
fix: 레거시 비밀번호 복호화의 잘못된 성공 판정 수정

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 import { getConfigManager, ConfigManager, Config } from './config';
 
 const testHome = vi.hoisted(() => ({ path: '' }));
+vi.mock('node-machine-id', () => ({ machineIdSync: () => 'config-test-machine-id' }));
 vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
   return { ...actual, homedir: () => testHome.path };
@@ -49,8 +50,7 @@ describe('ConfigManager', () => {
       }
     });
 
-    it('SMTP 비밀번호 암호화/복호화 라운드트립', async () => {
-      const testPassword = 'test-smtp-password-123!@#';
+    it.each(['test-smtp-password-123!@#', '\uFEFF비밀번호\uFFFD🔐'])('SMTP 비밀번호 암호화/복호화 라운드트립 (%s)', async (testPassword) => {
 
       // 설정 저장 (비밀번호가 암호화됨)
       const testConfig: Config = {
@@ -328,6 +328,39 @@ describe('ConfigManager', () => {
   });
 
   describe('암호화 마이그레이션', () => {
+    it.each([-1, 5])('잘못된 머신 키가 CBC 패딩을 통과해도 레거시 비밀번호를 복원한다 (%s)', async (concurrentDownloads) => {
+      const manager = new ConfigManager();
+      const configPath = path.join(manager.getConfigDir(), 'settings.json');
+      // 이 벡터는 고정된 테스트 머신 키에서 패딩 검사는 통과하지만 UTF-8은 깨진다.
+      const encrypted = '0000000000000000000000000000000b:458405b2bbd8bf4b8a2424319b57f9e86c3432eb5b6145b44f809393c8cbe2b2';
+      await fs.outputJson(configPath, { concurrentDownloads, smtpPassword: encrypted });
+      const original = await fs.readFile(configPath, 'utf8');
+
+      expect((await manager.loadConfig()).smtpPassword).toBe('legacy-test-password');
+      if (concurrentDownloads < 0) {
+        expect(await fs.readFile(configPath, 'utf8')).toBe(original);
+        await manager.updateConfig({ concurrentDownloads: 7 });
+      } else {
+        expect((await fs.readJson(configPath)).smtpPassword).not.toBe(encrypted);
+      }
+      expect((await manager.loadConfig()).smtpPassword).toBe('legacy-test-password');
+    });
+
+    it.each(['machine', 'legacy'])('유효한 UTF-8 비밀번호를 복원할 수 없으면 저장된 원문을 보존한다 (%s 키)', async (keyType) => {
+      const manager = new ConfigManager();
+      const configPath = path.join(manager.getConfigDir(), 'settings.json');
+      const machineKey = crypto.createHash('sha256').update('config-test-machine-iddepssmuggler-salt').digest();
+      const key = keyType === 'machine' ? machineKey : Buffer.from('depssmuggler-secret-key-32bytes!');
+      const cipher = crypto.createCipheriv('aes-256-cbc', key, Buffer.alloc(16));
+      const ciphertext = Buffer.concat([cipher.update(Buffer.from([0xff, 0xfe])), cipher.final()]);
+      const encrypted = `${Buffer.alloc(16).toString('hex')}:${ciphertext.toString('hex')}`;
+      await fs.outputJson(configPath, { concurrentDownloads: 5, smtpPassword: encrypted });
+      const original = await fs.readFile(configPath, 'utf8');
+
+      expect((await manager.loadConfig()).smtpPassword).toBe(encrypted);
+      expect(await fs.readFile(configPath, 'utf8')).toBe(original);
+    });
+
     it.each([-1, 5])('레거시 비밀번호 로드는 잘못된 설정(%s)을 자동 저장하지 않고 정상 설정만 마이그레이션한다', async (concurrentDownloads) => {
       const manager = new ConfigManager();
       const configPath = path.join(manager.getConfigDir(), 'settings.json');

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,8 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-import * as os from 'os';
 import * as crypto from 'crypto';
+import { TextDecoder } from 'node:util';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import { machineIdSync } from 'node-machine-id';
 import { mask } from '../utils/mask';
 
@@ -321,6 +322,9 @@ export class ConfigManager {
       }
       const iv = Buffer.from(parts[0], 'hex');
       const encrypted = parts[1];
+      // 잘못된 키도 CBC 패딩 검사를 통과할 수 있으므로 UTF-8 유효성까지 확인한다.
+      // 비밀번호에 포함된 선행 BOM은 제거하지 않는다.
+      const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true });
       
       // 새로운 머신별 키로 복호화 시도
       try {
@@ -329,9 +333,7 @@ export class ConfigManager {
           ENCRYPTION_KEY,
           iv
         );
-        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-        decrypted += decipher.final('utf8');
-        return decrypted;
+        return decoder.decode(Buffer.concat([decipher.update(encrypted, 'hex'), decipher.final()]));
       } catch {
         // 새 키로 실패 시 레거시 키로 복호화 시도 (마이그레이션)
         const legacyDecipher = crypto.createDecipheriv(
@@ -339,8 +341,7 @@ export class ConfigManager {
           Buffer.from(LEGACY_ENCRYPTION_KEY),
           iv
         );
-        let decrypted = legacyDecipher.update(encrypted, 'hex', 'utf8');
-        decrypted += legacyDecipher.final('utf8');
+        const decrypted = decoder.decode(Buffer.concat([legacyDecipher.update(encrypted, 'hex'), legacyDecipher.final()]));
         this.needsEncryptionMigration = true;
         console.info('[config] 레거시 키로 복호화 성공 - 마이그레이션을 수행합니다.');
         return decrypted;


### PR DESCRIPTION
## 변경 내용
v0.2.24 승격 PR #63의 Windows CI에서 기존 SMTP 비밀번호 마이그레이션 테스트가 실패했습니다. 잘못된 머신 키로 AES-CBC 복호화를 시도해도 패딩 검사가 통과하는 경우, 깨진 UTF-8 문자열을 정상 비밀번호로 반환해 레거시 키 재시도를 건너뛰었습니다.

복호화한 바이트를 엄격하게 UTF-8로 검증해 잘못된 결과는 레거시 키로 재시도합니다. 두 키로도 정상 문자열을 복원하지 못하면 기존 저장값을 보존합니다. 저장 형식과 키는 그대로 유지하며 선행 BOM과 정상 U+FFFD 문자도 보존합니다.

## 검증
- 고정 머신 ID와 암호문으로 회귀 테스트 4개가 수정 전 실패하는 것을 확인했습니다.
- 설정 테스트 28개, 전체 테스트 2,613개 통과(186개 기존 skip).
- 앱·Electron TypeScript 검사 통과, 변경 파일 ESLint 오류 0개(기존 경고 있음).
- 기존 무인증 CBC 형식의 키 판별 모호성 전체를 해결하는 변경은 아닙니다.
