### PR TITLE
CLI 버전 출력을 패키지 메타데이터와 일치

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,16 @@ npm install -g .
 depssmuggler --help
 ```
 
+## 버전 확인
+
+`-v`와 `--version`은 실행 파일의 위치에서 상위 디렉터리를 검색해 버전 필드가 있는 패키지 `package.json`을 읽습니다. 따라서 소스 실행, 빌드 산출물 실행, npm으로 설치한 CLI가 배포 패키지 버전을 함께 표시합니다. Electron 빌드가 생성하는 `dist/package.json`에는 모듈 형식만 기록되므로, 버전 필드가 없으면 패키지 루트의 메타데이터를 계속 검색합니다.
+
+```bash
+npm run cli -- --version
+npm run cli -- -v
+node dist/src/cli/index.js --version
+```
+
 ## 명령 구조
 
 ```text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,8 @@ npm audit
 
 `scripts/verify-worktree.sh`는 현재 저장소의 `scripts.test` 계약을 그대로 호출하는 얇은 래퍼이며, worktree에서 공통 검증 진입점으로 사용합니다. 현재 자동 생성 범위는 `test`만 포함하고 `lint`/`typecheck`는 별도 명령으로 유지합니다.
 
+CLI 버전 회귀 테스트(`src/cli/version.integration.test.ts`)는 실제 하위 프로세스를 사용해 `npm run cli -- --version`과 `-v`, 빌드 후 `dist/src/cli/index.js`, 그리고 `dist/package.json`에 버전이 없는 설치 레이아웃을 확인합니다. 모든 진입점은 루트 `package.json`의 버전을 출력해야 하며, 테스트가 임시 빌드 산출물을 생성하므로 저장소의 추적 파일은 변경하지 않습니다.
+
 `INTEGRATION_TEST=true` 표기는 POSIX shell 예시입니다. PowerShell에서는 `$env:INTEGRATION_TEST='true'`를 지정한 뒤 `npm run test`를 실행합니다. 이 환경 변수는 외부 저장소 호출을 활성화하므로 기본 mock 테스트 실행과 구분합니다.
 
 두 TypeScript 설정 모두 `noUnusedLocals`와 `noUnusedParameters`를 활성화합니다. 죽은 코드·미사용 인수 정리 후 재유입을 검사하며, 외부 호출 규약을 유지할 인수에는 `_` 접두어를 붙입니다. `retry-utils.test.ts`는 `unknown` 오류 처리에서도 HTTP 상태 코드·타임아웃 판정과 비정형 값의 기존 결과가 유지되는지 확인합니다.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,11 +3,12 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { registerOSCommands } from './commands/os';
+import { getPackageVersion } from './version';
 import { logger } from '../utils/logger';
 import { maskString } from '../utils/mask';
 
 // 버전 정보
-const VERSION = '1.0.0';
+const VERSION = getPackageVersion();
 
 // 로거 초기화 (파일 로깅 활성화)
 async function initializeLogger(): Promise<void> {

--- a/src/cli/version.integration.test.ts
+++ b/src/cli/version.integration.test.ts
@@ -58,7 +58,7 @@ describe('CLI version entrypoints', () => {
     const env = {
       ...process.env,
       DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
-      NODE_OPTIONS: `${existingNodeOptions}--require ${homeIsolationScript}`,
+      NODE_OPTIONS: `${existingNodeOptions}--require ${JSON.stringify(homeIsolationScript)}`,
     };
 
     expect(runSourceCliVersion('--version', env)).toBe(packageVersion);

--- a/src/cli/version.integration.test.ts
+++ b/src/cli/version.integration.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const projectRoot = resolve(__dirname, '../..');
+const packageVersion = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8')).version as string;
+const npmExecPath = process.env.npm_execpath;
+const homeIsolationScript = join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+const temporaryFixtures: string[] = [];
+
+interface RunOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function run(command: string, args: string[], options: RunOptions = {}): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? projectRoot,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: options.env,
+  }).trim();
+}
+
+function runNpm(args: string[], options: RunOptions = {}): string {
+  if (npmExecPath) {
+    return run(process.execPath, [npmExecPath, ...args], options);
+  }
+
+  return run(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, options);
+}
+
+function runSourceCliVersion(alias: '--version' | '-v', env: NodeJS.ProcessEnv): string {
+  const output = runNpm(['run', 'cli', '--', alias], { env });
+  return output.split(/\r?\n/).filter(Boolean).at(-1) ?? '';
+}
+
+function runPackedCli(args: string[], cwd: string, env: NodeJS.ProcessEnv): string {
+  return run(process.execPath, args, {
+    cwd,
+    env: { ...env, NODE_PATH: join(projectRoot, 'node_modules') },
+  });
+}
+
+describe('CLI version entrypoints', () => {
+  afterAll(() => {
+    for (const fixture of temporaryFixtures) {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('reports package metadata from source, built, and packed-style entrypoints', () => {
+    const isolatedHome = mkdtempSync(join(tmpdir(), 'depssmuggler-cli-home-'));
+    temporaryFixtures.push(isolatedHome);
+    const existingNodeOptions = process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : '';
+    const env = {
+      ...process.env,
+      DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+      NODE_OPTIONS: `${existingNodeOptions}--require ${homeIsolationScript}`,
+    };
+
+    expect(runSourceCliVersion('--version', env)).toBe(packageVersion);
+    expect(runSourceCliVersion('-v', env)).toBe(packageVersion);
+
+    runNpm(['run', 'build:electron'], { env });
+    expect(run(process.execPath, ['dist/src/cli/index.js', '--version'], { env })).toBe(packageVersion);
+    expect(run(process.execPath, ['dist/src/cli/index.js', '-v'], { env })).toBe(packageVersion);
+
+    const fixture = mkdtempSync(join(tmpdir(), 'depssmuggler-cli-version-'));
+    temporaryFixtures.push(fixture);
+    cpSync(join(projectRoot, 'dist'), join(fixture, 'dist'), { recursive: true });
+    cpSync(join(projectRoot, 'package.json'), join(fixture, 'package.json'));
+
+    expect(runPackedCli([join(fixture, 'dist/src/cli/index.js'), '--version'], dirname(fixture), env)).toBe(packageVersion);
+  }, 60_000);
+});

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+interface PackageMetadata {
+  version?: unknown;
+}
+
+/**
+ * Finds the package metadata that belongs to this CLI installation.
+ *
+ * The Electron build creates a `dist/package.json` containing only the module
+ * type, so metadata lookup must continue upward until it finds a real version.
+ * Starting from `__dirname` keeps this independent of the caller's cwd.
+ */
+export function getPackageVersion(startDirectory = __dirname): string {
+  let directory = startDirectory;
+
+  while (directory.length > 0) {
+    const metadataPath = join(directory, 'package.json');
+    try {
+      const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as PackageMetadata;
+      if (typeof metadata.version === 'string' && metadata.version.length > 0) {
+        return metadata.version;
+      }
+    } catch {
+      // Continue searching parent directories when this is not package metadata.
+    }
+
+    const parentDirectory = dirname(directory);
+    if (parentDirectory === directory) {
+      break;
+    }
+    directory = parentDirectory;
+  }
+
+  throw new Error(`패키지 버전 정보를 찾을 수 없습니다: ${startDirectory}`);
+}

--- a/tests/fixtures/isolate-home.cjs
+++ b/tests/fixtures/isolate-home.cjs
@@ -1,0 +1,10 @@
+const os = require('node:os');
+const { syncBuiltinESMExports } = require('node:module');
+
+const target = process.env.DEPS_SMUGGLER_TEST_USER_DIR;
+if (!target) {
+  throw new Error('DEPS_SMUGGLER_TEST_USER_DIR is required');
+}
+
+os.homedir = () => target;
+syncBuiltinESMExports();


### PR DESCRIPTION
## 요약
- CLI의 `-v`/`--version`이 패키지 메타데이터의 버전을 표시하도록 수정했습니다.
- 소스, 빌드 산출물, 설치 레이아웃을 실제 하위 프로세스로 검증하는 회귀 테스트를 추가했습니다.

## 배경
- `src/cli/index.ts`가 `1.0.0`을 하드코딩해 패키지 버전 `0.2.24`와 다른 값을 표시했습니다.

## 변경 사항
- 실행 파일 디렉터리부터 상위로 검색해 버전 필드가 있는 `package.json`을 읽는 공통 조회 로직을 추가했습니다.
- 빌드가 생성하는 버전 없는 `dist/package.json`을 건너뛰고 패키지 루트 메타데이터를 사용합니다.
- CLI 사용법과 테스트 범위를 문서화했습니다.

## 검증
- `bash scripts/verify-worktree.sh` — 2614 passed, 186 skipped
- `npm run lint` — 0 errors (기존 warnings)
- `npx tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.electron.json`
- 실제 source/built CLI `--version` 및 `-v` — `0.2.24`, 종료 코드 0

Closes #65
