### PR TITLE
fix: download target-os 옵션 전달 수정

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,6 +92,8 @@ depssmuggler download [옵션]
 
 `--no-deps`는 의도적으로 루트 패키지의 대상 아티팩트만 선택해 다운로드하는 옵션입니다. 전이 의존성을 탐색하지 않으며 최대 깊이 경고도 기록하지 않으므로, `--no-deps` 결과를 깊이 제한으로 인한 경고나 실패로 해석하면 안 됩니다. 직접 지정한 패키지 중 실제로 해결하지 못한 항목이 있으면 기본 모드는 실패한 직접 패키지만 경고와 함께 건너뛰고, 나머지 해결된 패키지와 의존성을 계속 다운로드합니다. 모든 직접 패키지를 해결하지 못해 남은 다운로드 항목이 없으면 빈 아카이브를 만들지 않고 오류로 종료합니다. 전체 실패 정책이 필요하면 `--strict`를 사용합니다. OS 패키지 의존성 다운로드는 `depssmuggler os download` 경로를 사용합니다.
 
+`--target-os`는 CLI에서 선택한 OS 값을 pip·Conda·Maven 다운로드 핸들러의 대상 환경 옵션으로 전달합니다. 따라서 `linux`, `windows`, `macos`를 지정하면 해당 플랫폼에 맞는 아티팩트를 선택하며, 지원하지 않는 OS나 적용할 수 없는 패키지 타입은 다운로드 전에 오류로 종료합니다.
+
 `pip`에서 `--python-version`을 지정하면 해당 버전의 `python_version` 환경 마커를 평가하고, `--target-os` 및 `--arch`와 호환되는 wheel 태그를 선택합니다. Python 버전은 `major.minor` 형식만 허용합니다. 따라서 `python_full_version`과 `implementation_version`처럼 patch가 필요한 marker는 값을 알 수 없는 조건으로 처리합니다. wheel은 대상 버전의 CPython 태그와 범용 `py3`/`py2.py3` 태그, 또는 대상보다 같거나 낮은 CPython 버전의 `abi3` 태그만 선택합니다. PyPI의 패키지·파일 `requires_python`과 Simple API 파일의 `requiresPython`도 PEP 440 specifier set으로 확인하므로, 대상 Python보다 높은 버전만 지원하는 wheel과 source distribution은 선택하지 않습니다. `latest`와 버전 범위는 PyPI 또는 Simple API에서 대상 Python과 호환되는 산출물이 있는 가장 높은 안정 버전을 선택하고, 철회(yanked) 릴리스는 wildcard가 없는 정확한 버전 고정 외에는 제외합니다. 프리릴리스는 버전 제약이 명시적으로 포함하거나 안정 후보가 없을 때만 선택합니다. 지원하지 않는 marker 문법이나 값이 없는 `platform_release`/`platform_version`은 의존성을 포함하지 않는 것으로 처리합니다.
 
 대상 환경 옵션은 다운로드 전에 검증됩니다.

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Command } from 'commander';
 
-const mocks = vi.hoisted(() => ({ initialize: vi.fn(), error: vi.fn(), warn: vi.fn(), action: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  action: vi.fn(),
+  downloadCommand: vi.fn(),
+}));
 vi.mock('../utils/logger', () => ({ logger: mocks }));
+vi.mock('./commands/download', () => ({ downloadCommand: mocks.downloadCommand }));
 vi.mock('./commands/os', () => ({
   registerOSCommands: (program: Command) => {
     program.command('boundary-test').action(mocks.action);
@@ -18,6 +25,7 @@ describe('CLI async command boundary', () => {
     process.exitCode = undefined;
     process.argv = ['node', 'depssmuggler', 'boundary-test'];
     mocks.initialize.mockResolvedValue(undefined);
+    mocks.downloadCommand.mockResolvedValue(undefined);
   });
   afterEach(() => {
     process.exitCode = exitCode;
@@ -31,7 +39,10 @@ describe('CLI async command boundary', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await import('./index');
     await vi.waitFor(() => expect(process.exitCode).toBe(1));
-    expect(mocks.error).toHaveBeenCalledWith(expect.stringContaining('CLI'), expect.objectContaining({ error: failure }));
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringContaining('CLI'),
+      expect.objectContaining({ error: failure })
+    );
   });
 
   it('파일 로거 초기화 실패 시 경고를 남기되 정상 명령은 계속한다', async () => {
@@ -42,4 +53,57 @@ describe('CLI async command boundary', () => {
     expect(mocks.warn).toHaveBeenCalled();
     expect(process.exitCode).not.toBe(1);
   });
+
+  it.each(['linux', 'windows', 'macos'])(
+    'download --target-os %s를 핸들러의 targetOS 계약으로 전달한다',
+    async (targetOS) => {
+      process.argv = [
+        'node',
+        'depssmuggler',
+        'download',
+        '--target-os',
+        targetOS,
+        '--type',
+        'pip',
+        '--package',
+        'cryptography',
+        '--python-version',
+        '3.12',
+        '--arch',
+        'x86_64',
+      ];
+
+      await import('./index');
+      await vi.waitFor(() => expect(mocks.downloadCommand).toHaveBeenCalled());
+
+      expect(mocks.downloadCommand).toHaveBeenCalledWith(expect.objectContaining({ targetOS }));
+    }
+  );
+
+  it.each([
+    ['freebsd', 'pip'],
+    ['linux', 'npm'],
+  ])(
+    '지원하지 않는 target-os/type 조합도 원래 값 그대로 핸들러에 전달한다: %s/%s',
+    async (targetOS, type) => {
+      process.argv = [
+        'node',
+        'depssmuggler',
+        'download',
+        '--target-os',
+        targetOS,
+        '--type',
+        type,
+        '--package',
+        'example',
+      ];
+
+      await import('./index');
+      await vi.waitFor(() => expect(mocks.downloadCommand).toHaveBeenCalled());
+
+      expect(mocks.downloadCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ targetOS, type })
+      );
+    }
+  );
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,7 +51,10 @@ program
   .option('--concurrency <num>', '동시 다운로드 수', '3')
   .action(async (options) => {
     const { downloadCommand } = await import('./commands/download');
-    await downloadCommand(options);
+    // Commander camel-cases `--target-os` to `targetOs`; keep the command
+    // handler's existing `targetOS` contract at this CLI boundary.
+    const { targetOs, ...downloadOptions } = options;
+    await downloadCommand({ ...downloadOptions, targetOS: targetOs });
   });
 
 // config 명령어


### PR DESCRIPTION
## 요약
- `download --target-os` 값을 실제 다운로드 핸들러의 `targetOS` 옵션으로 전달합니다.
- Linux, Windows, macOS 및 잘못된 대상 OS/타입 조합의 argv 회귀 테스트를 추가했습니다.

## 배경
Commander는 `--target-os`를 `targetOs`로 camel-case하지만 핸들러는 `targetOS`를 읽어 대상 OS가 `any`로 처리되었습니다.

## 변경 사항
- CLI 경계에서 Commander의 `targetOs`를 내부 계약인 `targetOS`로 매핑했습니다.
- CLI 문서에 대상 OS 전달 및 검증 동작을 기록했습니다.

## 검증
- `bash scripts/verify-worktree.sh` (2619 passed, 186 skipped)
- `npx tsc -p tsconfig.cli.json --noEmit`
- 실제 격리 CLI smoke: cryptography 43.0.0 Linux/Windows/macOS 대상 wheel 선택 확인
- 잘못된 대상 OS 및 타입 조합은 종료 코드 1, 출력 파일 0개 확인

Closes #66
