### PR TITLE
Maven 부속 파일을 CLI 아카이브에 포함

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,6 +94,8 @@ depssmuggler download [옵션]
 
 `--target-os`는 CLI에서 선택한 OS 값을 pip·Conda·Maven 다운로드 핸들러의 대상 환경 옵션으로 전달합니다. 따라서 `linux`, `windows`, `macos`를 지정하면 해당 플랫폼에 맞는 아티팩트를 선택하며, 지원하지 않는 OS나 적용할 수 없는 패키지 타입은 다운로드 전에 오류로 종료합니다.
 
+Maven ZIP/TAR.GZ에는 선택된 각 아티팩트의 부속 POM과 다운로드에 성공한 `.sha1` 체크섬도 포함됩니다. `--no-deps`나 `--max-depth`로 의존성 탐색 범위를 줄여도 선택된 JAR 자체의 POM은 함께 전달됩니다. 파일은 `packages/` 아래 Maven 저장소 디렉터리 구조를 유지하며, 같은 POM을 여러 항목에서 참조해도 한 번만 포함합니다.
+
 `pip`에서 `--python-version`을 지정하면 해당 버전의 `python_version` 환경 마커를 평가하고, `--target-os` 및 `--arch`와 호환되는 wheel 태그를 선택합니다. Python 버전은 `major.minor` 형식만 허용합니다. 따라서 `python_full_version`과 `implementation_version`처럼 patch가 필요한 marker는 값을 알 수 없는 조건으로 처리합니다. wheel은 대상 버전의 CPython 태그와 범용 `py3`/`py2.py3` 태그, 또는 대상보다 같거나 낮은 CPython 버전의 `abi3` 태그만 선택합니다. PyPI의 패키지·파일 `requires_python`과 Simple API 파일의 `requiresPython`도 PEP 440 specifier set으로 확인하므로, 대상 Python보다 높은 버전만 지원하는 wheel과 source distribution은 선택하지 않습니다. `latest`와 버전 범위는 PyPI 또는 Simple API에서 대상 Python과 호환되는 산출물이 있는 가장 높은 안정 버전을 선택하고, 철회(yanked) 릴리스는 wildcard가 없는 정확한 버전 고정 외에는 제외합니다. 프리릴리스는 버전 제약이 명시적으로 포함하거나 안정 후보가 없을 때만 선택합니다. 지원하지 않는 marker 문법이나 값이 없는 `platform_release`/`platform_version`은 의존성을 포함하지 않는 것으로 처리합니다.
 
 대상 환경 옵션은 다운로드 전에 검증됩니다.

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -228,6 +228,7 @@ if (expectedMd5) await downloader.verifyChecksum(filePath, expectedMd5, 'md5');
 | `getVersions` | packageName: string (groupId:artifactId) | Promise<string[]> | 아티팩트 버전 목록 조회 |
 | `getPackageMetadata` | name: string, version: string | Promise<PackageInfo> | 아티팩트 메타데이터 조회 |
 | `downloadPackage` | info: PackageInfo, destPath, onProgress?, _options? | Promise<string> | 아티팩트 다운로드 (jar, pom, 체크섬 포함) |
+| `downloadPackageFiles` | info: PackageInfo, destPath, onProgress?, _options? | Promise<string[]> | 이번 다운로드에서 저장한 전체 파일 경로 반환 (첫 항목은 주 아티팩트) |
 | `downloadArtifact` | groupId, artifactId, version, destPath, artifactType?, onProgress?, classifier? | Promise<string> | 특정 타입 아티팩트 다운로드 |
 | `downloadPom` | groupId, artifactId, version, destPath | Promise<string> | POM 파일 다운로드 |
 | `downloadSources` | groupId, artifactId, version, destPath | Promise<string> | 소스 JAR 다운로드 |
@@ -301,6 +302,8 @@ if (isPomOnly) {
 4. **POM 체크섬** (`.pom.sha1`) - POM 무결성 검증용
 
 POM 파일은 모든 아티팩트에서 필수입니다. 일반 JAR를 받은 뒤라도 부속 POM 다운로드가 실패하면 해당 패키지는 실패로 처리합니다. `.sha1` companion 파일은 선택 사항이므로 조회 실패 후 계속할 수 있습니다. `_options`의 OS/아키텍처는 현재 사용하지 않으며 네이티브 classifier는 metadata에서 명시해야 합니다.
+
+`downloadPackageFiles`는 실제 저장에 성공한 주 아티팩트, 부속 POM, 선택적 체크섬 경로를 한 번의 다운로드 결과로 반환합니다. 기존 `downloadPackage`는 같은 다운로드를 수행하고 첫 번째 경로만 반환하므로 기존 호출 계약을 유지합니다. CLI는 전체 경로를 압축기에 전달해 JAR만 포함되던 누락을 방지합니다. POM-only 항목이나 classifier가 있는 JAR에도 적용하며, 출력 디렉터리의 기존 파일을 검색해 결과에 추가하지 않습니다.
 
 의존성 해결에 필요한 Parent/BOM의 조회 실패는 resolver의 실패로 전달됩니다. 모델 조회가 성공했더라도 이후 실제 POM 파일 저장이 실패하면 다운로드를 성공으로 반환하지 않습니다.
 
@@ -958,9 +961,16 @@ interface IDownloader {
     destPath: string,
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string>;
+  downloadPackageFiles?(
+    info: PackageInfo,
+    destPath: string,
+    onProgress?: (progress: DownloadProgressEvent) => void
+  ): Promise<string[]>;
   verifyChecksum?(filePath: string, expected: string): Promise<boolean>;
 }
 ```
+
+`downloadPackageFiles`는 여러 파일을 생성하는 다운로더가 선택적으로 구현합니다. CLI 다운로드 매니저는 이 메서드가 있으면 전체 파일 목록을 사용하고, 없으면 기존 `downloadPackage`의 단일 파일 경로를 사용합니다. 두 메서드를 함께 호출해 중복 다운로드하지 않습니다.
 
 ---
 

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -82,6 +82,8 @@ const result = await packager.createArchiveFromDirectory(
 
 GUI 다운로드 경로에서는 `electron/download-handlers.ts`가 `createArchiveFromDirectory(...)`를 사용합니다. 그래서 `outputDir` 아래에 만들어 둔 `packages/`, `install.sh`, `install.ps1` 같은 파일이 그대로 아카이브에 포함되고, 최종 완료 이벤트는 실제 `.zip` 또는 `.tar.gz` 파일 경로를 반환합니다.
 
+CLI는 완료된 다운로드 항목이 반환한 파일 목록으로 `createArchive(...)`를 호출합니다. Maven 항목은 주 아티팩트와 부속 POM, 저장에 성공한 체크섬을 모두 포함하며 중복 경로는 제거합니다. 출력 디렉터리를 통째로 검색하지 않으므로 이전 압축물이나 다른 파일은 추가하지 않습니다. ZIP과 TAR.GZ 모두 동일한 목록과 Maven 상대 경로를 사용합니다.
+
 `getArchiveInfo()`는 확장자로 형식을 판별하고 파일 크기를 조회합니다. `fileCount`는 항상 0이며, `verifyArchive()`는 압축 해제나 내부 CRC 검사를 수행하지 않습니다. `onProgress`는 입력 파일 크기를 조사하는 준비 단계의 진행률이며 압축 스트림의 진행률이 아닙니다.
 
 현재 구현은 다운로드 산출물을 별도 staging 디렉터리로 한 번 더 복사하지 않고, 원본 디렉터리/파일 엔트리를 아카이브 스트림에 직접 추가한 뒤 `manifest.json`, `README.txt`만 추가 entry로 주입합니다.

--- a/src/cli/commands/download-archive-integration.test.ts
+++ b/src/cli/commands/download-archive-integration.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { createRequire } from 'module';
+import * as tar from 'tar';
+import { downloadCommand } from './download';
+
+const require = createRequire(import.meta.url);
+const yauzl = require('yauzl') as {
+  open: (
+    filePath: string,
+    options: { lazyEntries: boolean },
+    callback: (error: Error | null, zipFile?: {
+      readEntry: () => void;
+      on: (event: string, listener: (...args: any[]) => void) => void;
+      openReadStream: (entry: any, callback: (error: Error | null, stream?: NodeJS.ReadableStream) => void) => void;
+      close: () => void;
+    }) => void,
+  ) => void;
+};
+
+const {
+  reset,
+  addToQueue,
+  on,
+  startDownload,
+  generateAllScripts,
+  create,
+  stop,
+  resolveAllDependencies,
+} = vi.hoisted(() => ({
+  reset: vi.fn(),
+  addToQueue: vi.fn(),
+  on: vi.fn(),
+  startDownload: vi.fn(),
+  generateAllScripts: vi.fn(),
+  create: vi.fn(() => ({ update: vi.fn() })),
+  stop: vi.fn(),
+  resolveAllDependencies: vi.fn(),
+}));
+
+vi.mock('cli-progress', () => ({
+  default: {
+    MultiBar: vi.fn(function MultiBarMock() {
+      return { create, stop };
+    }),
+    Presets: { shades_classic: {} },
+  },
+}));
+
+vi.mock('./download-runner', () => ({
+  DownloadManager: vi.fn(function DownloadManagerMock() {
+    return { reset, addToQueue, on, startDownload };
+  }),
+}));
+
+vi.mock('../../core/shared', () => ({
+  resolveAllDependencies,
+}));
+
+vi.mock('../../core/packager/script-generator', () => ({
+  getScriptGenerator: vi.fn(() => ({ generateAllScripts })),
+}));
+
+interface ArchiveContents {
+  names: string[];
+  text: Map<string, string>;
+}
+
+async function readZip(filePath: string): Promise<ArchiveContents> {
+  return new Promise((resolve, reject) => {
+    yauzl.open(filePath, { lazyEntries: true }, (error, zipFile) => {
+      if (error || !zipFile) {
+        reject(error ?? new Error('ZIP 열기 실패'));
+        return;
+      }
+
+      const names: string[] = [];
+      const text = new Map<string, string>();
+      zipFile.on('error', reject);
+      zipFile.on('end', () => resolve({ names, text }));
+      zipFile.on('entry', (entry: { fileName: string }) => {
+        names.push(entry.fileName);
+        zipFile.openReadStream(entry, (streamError, stream) => {
+          if (streamError || !stream) {
+            reject(streamError ?? new Error(`ZIP entry 열기 실패: ${entry.fileName}`));
+            zipFile.close();
+            return;
+          }
+          const chunks: Buffer[] = [];
+          stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+          stream.on('error', reject);
+          stream.on('end', () => {
+            text.set(entry.fileName, Buffer.concat(chunks).toString('utf8'));
+            zipFile.readEntry();
+          });
+        });
+      });
+      zipFile.readEntry();
+    });
+  });
+}
+
+async function readTarGz(filePath: string): Promise<ArchiveContents> {
+  const names: string[] = [];
+  const text = new Map<string, string>();
+  await tar.t({
+    file: filePath,
+    onentry: (entry) => {
+      names.push(entry.path);
+      if (entry.type === 'File') {
+        const chunks: Buffer[] = [];
+        entry.on('data', (chunk: Buffer) => chunks.push(chunk));
+        entry.on('end', () => {
+          text.set(entry.path, Buffer.concat(chunks).toString('utf8'));
+        });
+      } else {
+        entry.resume();
+      }
+    },
+  });
+  return { names, text };
+}
+
+describe('downloadCommand Maven archive integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-issue-67-'));
+    generateAllScripts.mockResolvedValue(undefined);
+    resolveAllDependencies.mockResolvedValue({
+      originalPackages: [
+        { type: 'maven', name: 'com.example:demo', version: '1.0.0' },
+        { type: 'maven', name: 'org.example:parent', version: '1.0.0' },
+      ],
+      allPackages: [
+        { type: 'maven', name: 'com.example:demo', version: '1.0.0' },
+        { type: 'maven', name: 'org.example:parent', version: '1.0.0' },
+      ],
+      dependencyTrees: [],
+      failedPackages: [],
+    });
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it.each(['zip', 'tar.gz'] as const)('최종 %s에 완료 Maven artifact와 companion POM/checksum만 넣는다', async (format) => {
+    const outputDir = path.join(tempDir, format);
+    await fs.ensureDir(outputDir);
+
+    const demoDir = path.join(outputDir, 'com/example/demo/1.0.0');
+    const parentDir = path.join(outputDir, 'org/example/parent/1.0.0');
+    await fs.ensureDir(demoDir);
+    await fs.ensureDir(parentDir);
+
+    const demoJar = path.join(demoDir, 'demo-1.0.0.jar');
+    const demoJarSha = `${demoJar}.sha1`;
+    const demoPom = path.join(demoDir, 'demo-1.0.0.pom');
+    const demoPomSha = `${demoPom}.sha1`;
+    const parentPom = path.join(parentDir, 'parent-1.0.0.pom');
+    const parentPomSha = `${parentPom}.sha1`;
+    const stalePath = path.join(outputDir, 'stale-archive.zip');
+
+    await Promise.all([
+      fs.writeFile(demoJar, 'jar'),
+      fs.writeFile(demoJarSha, 'jar-sha'),
+      fs.writeFile(demoPom, '<project/>'),
+      fs.writeFile(demoPomSha, 'pom-sha'),
+      fs.writeFile(parentPom, '<project/>'),
+      fs.writeFile(parentPomSha, 'parent-sha'),
+      fs.writeFile(stalePath, 'must not be archived'),
+    ]);
+
+    startDownload.mockResolvedValueOnce({
+      success: true,
+      totalSize: 42,
+      duration: 1,
+      items: [
+        {
+          id: 'maven-demo-1.0.0',
+          package: { type: 'maven', name: 'com.example:demo', version: '1.0.0' },
+          status: 'completed',
+          progress: 100,
+          filePath: demoJar,
+          filePaths: [demoJar, demoJarSha, demoPom, demoPom, demoPomSha],
+        },
+        {
+          id: 'maven-parent-1.0.0',
+          package: { type: 'maven', name: 'org.example:parent', version: '1.0.0' },
+          status: 'completed',
+          progress: 100,
+          filePath: parentPom,
+          filePaths: [parentPom, parentPom, parentPomSha],
+        },
+        {
+          id: 'maven-failed-1.0.0',
+          package: { type: 'maven', name: 'com.example:failed', version: '1.0.0' },
+          status: 'failed',
+          progress: 0,
+          filePath: stalePath,
+          filePaths: [stalePath],
+        },
+      ],
+    });
+
+    await downloadCommand({
+      type: 'maven',
+      package: 'com.example:demo',
+      pkgVersion: '1.0.0',
+      arch: 'x86_64',
+      targetOS: 'any',
+      condaChannel: 'conda-forge',
+      output: outputDir,
+      format,
+      deps: true,
+      concurrency: '1',
+    } as Parameters<typeof downloadCommand>[0]);
+
+    const archivePath = (await fs.readdir(outputDir))
+      .filter((entry) => entry.startsWith('packages-') && entry.endsWith(format === 'zip' ? '.zip' : '.tar.gz'))
+      .map((entry) => path.join(outputDir, entry))[0];
+    expect(archivePath).toBeDefined();
+
+    const archive = format === 'zip'
+      ? await readZip(archivePath)
+      : await readTarGz(archivePath);
+    const expectedNames = [
+      'packages/com/example/demo/1.0.0/demo-1.0.0.jar',
+      'packages/com/example/demo/1.0.0/demo-1.0.0.jar.sha1',
+      'packages/com/example/demo/1.0.0/demo-1.0.0.pom',
+      'packages/com/example/demo/1.0.0/demo-1.0.0.pom.sha1',
+      'packages/org/example/parent/1.0.0/parent-1.0.0.pom',
+      'packages/org/example/parent/1.0.0/parent-1.0.0.pom.sha1',
+      'manifest.json',
+      'README.txt',
+    ];
+
+    expect([...archive.names].sort()).toEqual([...expectedNames].sort());
+    expect(archive.names.filter((name) => name === 'packages/com/example/demo/1.0.0/demo-1.0.0.pom'))
+      .toHaveLength(1);
+    expect(JSON.parse(archive.text.get('manifest.json') ?? '{}').packages).toHaveLength(2);
+  });
+});

--- a/src/cli/commands/download-runner.test.ts
+++ b/src/cli/commands/download-runner.test.ts
@@ -763,6 +763,55 @@ describe('DownloadManager 단위 테스트', () => {
       });
     });
 
+    it('파일 목록을 반환하는 다운로더를 우선 사용하고 모든 경로를 item에 기록한다', async () => {
+      const primaryPath = '/test/output/demo-1.0.0.jar';
+      const companionPaths = [
+        primaryPath,
+        '/test/output/demo-1.0.0.jar.sha1',
+        '/test/output/demo-1.0.0.pom',
+        '/test/output/demo-1.0.0.pom.sha1',
+      ];
+      const downloadPackage = vi.fn().mockResolvedValue(primaryPath);
+      const downloadPackageFiles = vi.fn().mockResolvedValue(companionPaths);
+      const downloader = {
+        type: 'maven' as const,
+        downloadPackage,
+        downloadPackageFiles,
+      } as unknown as IDownloader;
+      asTestable(manager).downloaders.set('maven', downloader);
+      manager.addToQueue([
+        { type: 'maven' as const, name: 'com.example:demo', version: '1.0.0' },
+      ]);
+
+      const result = await manager.startDownload({ outputPath: '/test/output' });
+
+      expect(downloadPackageFiles).toHaveBeenCalledTimes(1);
+      expect(downloadPackage).not.toHaveBeenCalled();
+      expect(result.items[0].filePath).toBe(primaryPath);
+      expect((result.items[0] as DownloadManagerItem & { filePaths?: string[] }).filePaths)
+        .toEqual(companionPaths);
+    });
+
+    it('파일 목록 API가 없는 다운로더는 기존 단일 경로 API로 대체한다', async () => {
+      const primaryPath = '/test/output/requests.whl';
+      const downloadPackage = vi.fn().mockResolvedValue(primaryPath);
+      const downloader = {
+        type: 'pip' as const,
+        downloadPackage,
+      } as unknown as IDownloader;
+      asTestable(manager).downloaders.set('pip', downloader);
+      manager.addToQueue([
+        { type: 'pip' as const, name: 'requests', version: '2.28.0' },
+      ]);
+
+      const result = await manager.startDownload({ outputPath: '/test/output' });
+
+      expect(downloadPackage).toHaveBeenCalledTimes(1);
+      expect(result.items[0].filePath).toBe(primaryPath);
+      expect((result.items[0] as DownloadManagerItem & { filePaths?: string[] }).filePaths)
+        .toBeUndefined();
+    });
+
     it('allComplete 이벤트 발생', async () => {
       const listener = vi.fn();
       manager.on('allComplete', listener);

--- a/src/cli/commands/download-runner.ts
+++ b/src/cli/commands/download-runner.ts
@@ -23,6 +23,7 @@ export type DownloadManagerItemStatus = CanonicalDownloadStatus;
 
 // 다운로드 아이템
 export interface DownloadManagerItem extends CanonicalDownloadItem {
+  filePaths?: string[];
   downloadedBytes: number;
   totalBytes: number;
   speed: number;
@@ -230,13 +231,22 @@ export class DownloadManager extends EventEmitter<DownloadManagerEvents> {
     this.emit('itemStart', item);
 
     try {
-      const filePath = await downloader.downloadPackage(
-        item.package,
-        this.options.outputPath,
-        (progress: DownloadProgressEvent) => {
-          this.updateItemProgress(id, progress);
-        }
-      );
+      const onProgress = (progress: DownloadProgressEvent) => {
+        this.updateItemProgress(id, progress);
+      };
+      let filePath: string;
+      if (downloader.downloadPackageFiles) {
+        const files = await downloader.downloadPackageFiles(
+          item.package, this.options.outputPath, onProgress
+        );
+        if (!files[0]) throw new Error('다운로드된 파일이 없습니다.');
+        filePath = files[0];
+        item.filePaths = [...files];
+      } else {
+        filePath = await downloader.downloadPackage(
+          item.package, this.options.outputPath, onProgress
+        );
+      }
 
       item.status = 'completed';
       item.progress = 100;

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -138,6 +138,58 @@ describe('downloadCommand', () => {
     });
   });
 
+  it('완료된 Maven 항목의 모든 파일을 중복 없이 아카이브하고 실패 항목은 제외한다', async () => {
+    const jarPath = '/tmp/output/com/example/demo/1.0.0/demo-1.0.0.jar';
+    const pomPath = '/tmp/output/com/example/demo/1.0.0/demo-1.0.0.pom';
+    const pomChecksumPath = `${pomPath}.sha1`;
+    const staleFailedPath = '/tmp/output/stale/old-artifact.pom';
+
+    startDownload.mockResolvedValueOnce({
+      success: true,
+      totalSize: 1024,
+      duration: 1000,
+      items: [
+        {
+          id: 'maven-demo-1.0.0',
+          package: {
+            type: 'maven',
+            name: 'com.example:demo',
+            version: '1.0.0',
+          },
+          status: 'completed',
+          progress: 100,
+          filePath: jarPath,
+          filePaths: [jarPath, pomPath, pomPath, pomChecksumPath],
+        },
+        {
+          id: 'maven-failed-1.0.0',
+          package: {
+            type: 'maven',
+            name: 'com.example:failed',
+            version: '1.0.0',
+          },
+          status: 'failed',
+          progress: 0,
+          filePath: staleFailedPath,
+          filePaths: [staleFailedPath],
+        },
+      ],
+    });
+
+    await downloadCommand(commandOptions({
+      type: 'maven',
+      package: 'com.example:demo',
+      pkgVersion: '1.0.0',
+    }));
+
+    expect(createArchive).toHaveBeenCalledWith(
+      [jarPath, pomPath, pomChecksumPath],
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ format: 'zip' }),
+    );
+  });
+
   it('deps가 true면 의존성을 해결한 패키지 목록을 큐에 추가한다', async () => {
     await downloadCommand(commandOptions());
 

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -385,10 +385,11 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
       console.log(chalk.gray(`  소요 시간: ${formatDuration(result.duration)}`));
 
       // 패키징 처리
-      const files = result.items
-        .flatMap((item) => (
-          item.status === 'completed' && item.filePath ? [item.filePath] : []
-        ));
+      const files = [...new Set(result.items.flatMap((item) => (
+        item.status === 'completed' && item.filePath
+          ? item.filePaths ?? [item.filePath]
+          : []
+      )))];
 
       // 압축 파일 생성
       console.log(chalk.cyan('\n압축 파일 생성 중...'));

--- a/src/core/downloaders/maven-download.test.ts
+++ b/src/core/downloaders/maven-download.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
+import * as path from 'path';
 
 // vi.hoisted를 사용하여 모킹 함수 정의
 const { mockAxiosDefault, mockAxiosGet } = vi.hoisted(() => {
@@ -39,6 +40,7 @@ vi.mock('fs-extra', async () => {
     createReadStream: vi.fn(),
     remove: vi.fn().mockResolvedValue(undefined),
     readFile: vi.fn(),
+    writeFile: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -47,6 +49,60 @@ import { MavenDownloader } from './maven';
 
 describe('MavenDownloader downloadPackage 테스트', () => {
   let downloader: MavenDownloader;
+
+  const downloadPackageFiles = async (
+    info: Parameters<MavenDownloader['downloadPackage']>[0],
+    destPath: string,
+  ): Promise<string[]> => {
+    const filesMethod = (downloader as MavenDownloader & {
+      downloadPackageFiles?: (
+        info: Parameters<MavenDownloader['downloadPackage']>[0],
+        destPath: string,
+      ) => Promise<string[]>;
+    }).downloadPackageFiles;
+
+    // The compatibility adapter makes the RED failure assert the missing
+    // companion files, while still allowing this test to compile before the
+    // additive downloader API exists.
+    if (filesMethod) {
+      return filesMethod.call(downloader, info, destPath);
+    }
+    return [await downloader.downloadPackage(info, destPath)];
+  };
+
+  const prepareArtifactNetworkMocks = (missingChecksumSuffix?: string) => {
+    mockAxiosGet.mockImplementation(async (url: string) => {
+      if (url.endsWith('.sha1')) {
+        if (missingChecksumSuffix && url.endsWith(missingChecksumSuffix)) {
+          throw new Error('404 Not Found');
+        }
+        return { data: '0123456789abcdef0123456789abcdef01234567' };
+      }
+      return { data: '<project><packaging>jar</packaging></project>' };
+    });
+
+    mockAxiosDefault.mockImplementation(async () => {
+      const stream = new EventEmitter() as EventEmitter & {
+        pipe: (writer: EventEmitter) => EventEmitter;
+      };
+      stream.pipe = (writer) => {
+        process.nextTick(() => {
+          stream.emit('data', Buffer.from('artifact'));
+          writer.emit('finish');
+        });
+        return writer;
+      };
+
+      return {
+        data: stream,
+        headers: { 'content-length': '8' },
+      };
+    });
+
+    (fs.createWriteStream as any).mockImplementation(() => new EventEmitter());
+    (fs.writeFile as any).mockResolvedValue(undefined);
+    (downloader as any).verifyChecksum = vi.fn().mockResolvedValue(true);
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -495,6 +551,77 @@ describe('MavenDownloader downloadPackage 테스트', () => {
         onProgress,
         undefined
       );
+    });
+
+    it('JAR와 classifier companion POM 및 체크섬의 모든 파일 경로를 반환한다', async () => {
+      prepareArtifactNetworkMocks();
+      const info = {
+        type: 'maven' as const,
+        name: 'com.example:demo',
+        version: '1.0.0',
+        metadata: {
+          groupId: 'com.example',
+          artifactId: 'demo',
+          packaging: 'jar',
+          classifier: 'sources',
+        },
+      };
+      const destination = '/tmp/depssmuggler-issue-67-maven';
+
+      const files = await downloadPackageFiles(info, destination);
+
+      expect(files).toEqual([
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0-sources.jar'),
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0-sources.jar.sha1'),
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0.pom'),
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0.pom.sha1'),
+      ]);
+    });
+
+    it('POM-only 패키지는 POM과 체크섬만 반환한다', async () => {
+      prepareArtifactNetworkMocks();
+      const info = {
+        type: 'maven' as const,
+        name: 'org.example:demo-bom',
+        version: '1.0.0',
+        metadata: {
+          groupId: 'org.example',
+          artifactId: 'demo-bom',
+          packaging: 'pom',
+        },
+      };
+      const destination = '/tmp/depssmuggler-issue-67-maven';
+
+      const files = await downloadPackageFiles(info, destination);
+
+      expect(files).toEqual([
+        path.join(destination, 'org/example/demo-bom/1.0.0/demo-bom-1.0.0.pom'),
+        path.join(destination, 'org/example/demo-bom/1.0.0/demo-bom-1.0.0.pom.sha1'),
+      ]);
+    });
+
+    it('없는 선택적 체크섬은 파일 목록에서 제외한다', async () => {
+      prepareArtifactNetworkMocks('demo-1.0.0.pom.sha1');
+      const info = {
+        type: 'maven' as const,
+        name: 'com.example:demo',
+        version: '1.0.0',
+        metadata: {
+          groupId: 'com.example',
+          artifactId: 'demo',
+          packaging: 'jar',
+        },
+      };
+      const destination = '/tmp/depssmuggler-issue-67-maven';
+
+      const files = await downloadPackageFiles(info, destination);
+
+      expect(files).toEqual([
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0.jar'),
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0.jar.sha1'),
+        path.join(destination, 'com/example/demo/1.0.0/demo-1.0.0.pom'),
+      ]);
+      expect(files.some((file) => file.endsWith('.pom.sha1'))).toBe(false);
     });
   });
 

--- a/src/core/downloaders/maven.ts
+++ b/src/core/downloaders/maven.ts
@@ -431,6 +431,20 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
       targetArchitecture?: string;
     }
   ): Promise<string> {
+    const files = await this.downloadPackageFiles(info, destPath, onProgress, _options);
+    return files[0];
+  }
+
+  /** Download the primary artifact and its POM/checksums as one file set. */
+  async downloadPackageFiles(
+    info: PackageInfo,
+    destPath: string,
+    onProgress?: (progress: DownloadProgressEvent) => void,
+    _options?: {
+      targetOS?: string;
+      targetArchitecture?: string;
+    }
+  ): Promise<string[]> {
     const groupId = (info.metadata?.groupId as string) || info.name.split(':')[0];
     const artifactId = (info.metadata?.artifactId as string) || info.name.split(':')[1];
     const classifier = info.metadata?.classifier as string | undefined;
@@ -480,11 +494,11 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
       });
     }
 
-    let mainArtifactPath: string;
+    const files: string[] = [];
 
     // 1. 메인 아티팩트 다운로드 (POM-only가 아닌 경우)
     if (!isPomOnly) {
-      mainArtifactPath = await this.downloadArtifact(
+      const mainArtifactPath = await this.downloadArtifact(
         groupId,
         artifactId,
         info.version,
@@ -493,11 +507,13 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
         onProgress,
         classifier
       );
+      files.push(mainArtifactPath);
 
       // 메인 아티팩트 체크섬 파일 다운로드 (.sha1)
-      await this.downloadChecksumFile(groupId, artifactId, info.version, destPath, artifactType, classifier);
-    } else {
-      mainArtifactPath = ''; // POM 경로로 대체될 예정
+      const checksumPath = await this.downloadChecksumFile(
+        groupId, artifactId, info.version, destPath, artifactType, classifier
+      );
+      if (checksumPath) files.push(checksumPath);
     }
 
     // 2. pom 파일 다운로드 (모든 타입에 필요)
@@ -510,12 +526,12 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
         'pom',
         isPomOnly ? onProgress : undefined // POM-only인 경우에만 진행률 표시
       );
+      files.push(pomPath);
       // pom 체크섬 파일 다운로드 (.sha1)
-      await this.downloadChecksumFile(groupId, artifactId, info.version, destPath, 'pom');
-
-      if (isPomOnly) {
-        mainArtifactPath = pomPath;
-      }
+      const checksumPath = await this.downloadChecksumFile(
+        groupId, artifactId, info.version, destPath, 'pom'
+      );
+      if (checksumPath) files.push(checksumPath);
     } catch (error) {
       // JAR가 있어도 POM이 없으면 오프라인 Maven 저장소가 불완전하다.
       throw new Error(
@@ -532,7 +548,7 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
       isPomOnly,
     });
 
-    return mainArtifactPath;
+    return files;
   }
 
   /**
@@ -734,7 +750,7 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
     destPath: string,
     artifactType: ArtifactType,
     classifier?: string
-  ): Promise<void> {
+  ): Promise<string | undefined> {
     const baseUrl = this.buildDownloadUrl(groupId, artifactId, version, artifactType, classifier);
     const baseFileName = this.buildFileName(artifactId, version, artifactType, classifier);
 
@@ -762,6 +778,7 @@ export class MavenDownloader extends BaseLanguageDownloader implements IDownload
       logger.debug('체크섬 파일 다운로드 완료', {
         file: checksumFileName,
       });
+      return checksumFilePath;
     } catch (error) {
       // 체크섬 파일이 없을 수 있으므로 경고만 로깅
       logger.debug('sha1 파일 다운로드 실패 (선택적)', {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -16,6 +16,12 @@ export interface IDownloader {
     destPath: string,
     onProgress?: (progress: DownloadProgressEvent) => void
   ): Promise<string>;
+  /** All files saved by one download, with the primary artifact first. */
+  downloadPackageFiles?(
+    info: PackageInfo,
+    destPath: string,
+    onProgress?: (progress: DownloadProgressEvent) => void
+  ): Promise<string[]>;
   verifyChecksum?(filePath: string, expected: string): Promise<boolean>;
 }
 


### PR DESCRIPTION
## 요약
- Maven 다운로드가 저장한 주 JAR/POM과 선택적 `.sha1` 경로를 모두 최종 ZIP/TAR.GZ에 포함하도록 수정했습니다.
- 완료된 항목만 중복 없이 아카이브하며 출력 디렉터리 전체를 재검색하지 않습니다.

## 배경
- Maven downloader가 companion POM과 checksum을 출력 디렉터리에 저장했지만 CLI는 각 항목의 주 `filePath`만 아카이브에 전달했습니다.
- 그 결과 JAR와 같은 좌표의 POM이 전달물에서 누락됐습니다.

## 변경 사항
- Maven에 다운로드 파일 목록 API를 추가하고 기존 단일 경로 API는 호환 wrapper로 유지했습니다.
- DownloadManager가 파일 목록을 보존하고, CLI가 완료된 항목의 전체 목록을 dedupe해 ArchivePackager에 전달합니다.
- POM-only, classifier, 선택적 checksum 누락, legacy downloader fallback을 회귀 테스트로 추가했습니다.
- CLI·downloader·packager 문서를 갱신했습니다.

## 검증
- RED: Maven 3건, runner/CLI 2건의 기대 회귀 실패를 확인했습니다.
- `bash scripts/verify-worktree.sh`: 2627 passed, 186 skipped
- 실제 `downloadCommand` ZIP/TAR.GZ 통합 테스트: 2 passed
- `npx tsc --noEmit -p tsconfig.json`
- `npm run lint`: 0 errors, 539 warnings
- 감사 live artifact 검사: 전체 ZIP 214개 파일, depth0 TAR 22개, no-deps ZIP 4개, coordinates TAR 8개 확인

## 문서
- `docs/cli.md`
- `docs/downloaders.md`
- `docs/packagers.md`

Closes #67
