### PR TITLE
fix: Docker 설치 스크립트의 이미지 파일명 일치

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Test generated installer with native Docker
+        if: runner.os == 'Linux'
+        env:
+          DEPS_SMUGGLER_NATIVE_DOCKER: '1'
+        run: bash scripts/verify-worktree.sh src/core/packager/docker-install-script.integration.test.ts -t 'native Docker'
+
       - name: Build project
         run: npm run build
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,7 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
 ### 현재 동작
 
 - 다운로드 성공 시 출력 디렉터리에 `packages-<timestamp>.zip` 또는 `.tar.gz`를 만든 뒤, 같은 디렉터리에 설치 스크립트를 생성합니다. 이 호출 순서에서는 별도로 생성한 설치 스크립트가 앞서 만든 아카이브에 포함되지 않습니다.
+- Docker는 압축을 풀어 생긴 `packages/`와 설치 스크립트를 같은 폴더에 두고 실행합니다. Bash·PowerShell 모두 실제 이미지 파일명(예: `packages/busybox-1.36.tar`)을 `docker load -i`에 전달합니다. `amd64`·`arm64`와 ZIP·tar.gz 출력에서 같은 이름 규칙을 사용하며, 대상 환경에는 실행 중인 Docker가 필요합니다.
 - npm은 압축을 풀어 생긴 `packages/` 폴더와 설치 스크립트를 같은 폴더에 두고 실행합니다. Node.js와 npm이 설치된 환경에서 전달된 `.tgz`를 `npm install --offline`으로 설치하며, 결과는 스크립트 폴더의 `npm-project/node_modules`에 생깁니다. 이 전용 프로젝트에 설치용 `package.json`을 생성하며 상위 폴더의 사용자 manifest는 변경하지 않습니다.
 - npm 설치 스크립트는 tarball 내부 이름·버전과 전달 경로를 기록합니다. 직접 요청한 패키지만 최상위 의존성으로 등록하고, 선택한 버전과 전이 의존성의 여러 버전을 필요한 하위 경로에 설치합니다. scoped 패키지도 지원합니다. 같은 이름의 서로 다른 버전을 직접 루트로 함께 지정하면 모호한 설치 결과를 만들지 않고 스크립트 생성에 실패합니다. 기존 `npm-project`에 사용자 프로젝트가 있으면 다른 폴더에 압축을 풀어 실행해야 합니다.
 - `--no-deps` 출력에 필요한 npm 의존성이 빠져 있으면 오프라인 설치가 실패할 수 있으며, 이 경우 스크립트도 오류로 종료합니다. 설치 대상 환경의 Node.js·OS·아키텍처에 맞는 패키지를 전달해야 하며, npm의 일반 설치 lifecycle은 그대로 실행됩니다.

--- a/docs/docker-architecture.md
+++ b/docs/docker-architecture.md
@@ -188,12 +188,15 @@ interface DockerManifestEntry {
 |------|------|
 | `extractRegistry(fullName)` | 알려진 호스트 또는 점이 있는 첫 경로 요소를 레지스트리로 분리 |
 | `parseImageName(name)` | 레지스트리를 제거하고 namespace/repo로 분리; 단일 이름은 library namespace 사용 |
+| `buildDockerArchiveFilename(repository, tag)` | 다운로더와 설치 스크립트가 공유하는 이미지 tar 파일명 생성 |
 | `getRegistryType(registry)` | Docker Hub/GHCR/ECR Public/Quay/custom 분류 |
 | `createCustomRegistryConfig(registryUrl)` | `/v2` API와 `/v2/auth` 기본 인증 URL 구성 |
 | `calculateSha256(filePath)` | 공통 checksum 유틸리티로 SHA256 계산 |
 | `ARCH_MAP` | x86_64→amd64, ARM64, 386, arm/v7 variant 매핑 |
 
 이미지 이름과 태그는 각각 전달합니다. `extractRegistry()`는 태그를 분리하는 함수가 아니며 `localhost:5000`처럼 점이 없는 주소는 이름에서 자동 추출되지 않습니다. 이 경우 registry 인수를 명시합니다.
+
+이미지 tar 파일명은 기존 다운로드 규칙인 `<안전한 repo 이름>-<안전한 tag>.tar`를 사용합니다. 예를 들어 `busybox:1.36`과 `library/busybox:1.36`은 모두 `busybox-1.36.tar`가 됩니다. `buildDockerArchiveFilename()`이 이름 분리와 파일명 정규화를 함께 적용하며, 다운로더와 Bash·PowerShell 생성기가 이를 공유해 실제 파일과 `docker load -i` 인자가 일치합니다. 아키텍처와 바깥 아카이브 형식은 이 이름을 바꾸지 않습니다.
 
 ---
 

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -192,6 +192,8 @@ CLI는 `npmRootPackages`에 실제 직접 요청 목록과 해결된 버전을 �
 
 일반 `ScriptGenerator`에는 APT·APK 전용 설치 블록이 없고, Conda 항목도 pip 설치 블록으로 묶입니다. `.conda` 파일을 설치하는 Conda 전용 스크립트로 간주하면 안 됩니다. OS 다운로드 전용 스크립트는 별도의 `OSScriptGenerator`가 제공합니다. `includeVerification`/`mirrorPath` 옵션은 이 클래스에 없습니다.
 
+Docker 설치 블록은 다운로더와 같은 `buildDockerArchiveFilename()`을 사용해 `packages/<repo>-<tag>.tar`를 로드합니다. namespace·registry 제거와 파일명 정규화도 동일하게 적용하므로 `busybox:1.36`은 `busybox-1.36.tar`를 참조합니다. Bash와 PowerShell 모두 파일명을 인용해 공백이 포함된 추출 경로에서도 하나의 `docker load -i` 인자로 전달합니다. 아키텍처나 ZIP·tar.gz 선택은 내부 이미지 tar 이름에 영향을 주지 않습니다.
+
 ### 사용 예시
 ```typescript
 import { getScriptGenerator } from './core/packager/script-generator';

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -115,6 +115,19 @@ bash scripts/verify-worktree.sh \
 
 이 fixture 검증은 실제 Maven Central의 현재 파일 존재 여부나 외부 Maven 실행의 오프라인 성공을 보장하지 않습니다. 외부 저장소 검증에는 아래 통합 테스트를 별도로 사용하고, 실행 명령·대상 좌표·파일 확인 결과를 해당 작업의 검증 기록에 남깁니다.
 
+### Docker 설치 스크립트 파일명과 실제 로드 검증
+
+`src/core/downloaders/docker-download.test.ts`는 이미지 이름·태그 정규화와 아키텍처별 실제 반환 파일명을 확인합니다. `src/core/packager/docker-install-script.integration.test.ts`는 같은 파일명 fixture를 준비하고, 공백이 있는 폴더와 외부 작업 디렉터리에서 생성 스크립트를 실행합니다. macOS·Linux에서는 Bash, Windows에서는 PowerShell을 사용하며 Docker 기록용 대체 명령이 받은 `load -i` 인자와 실제 파일 경로를 검사합니다. 이 검증은 Docker 엔진의 이미지 로드를 대신하지 않습니다.
+
+Docker 엔진이 실행 중인 환경에서는 아래 명령으로 실제 로드 테스트를 실행합니다. 테스트가 만든 고유 태그의 로컬 이미지 tar를 생성 스크립트로 로드하고, Docker에서 이미지 ID를 확인한 뒤 해당 태그만 정리합니다. 외부 레지스트리 다운로드는 필요하지 않습니다. 명시적으로 활성화한 상태에서 Docker에 연결할 수 없으면 테스트가 실패하며, 기본 단위 테스트에서는 이 사례를 건너뜁니다. Ubuntu CI는 별도 단계에서 이 검증을 활성화합니다.
+
+```bash
+DEPS_SMUGGLER_NATIVE_DOCKER=1 bash scripts/verify-worktree.sh \
+  src/core/packager/docker-install-script.integration.test.ts -t 'native Docker'
+```
+
+실제 CLI 다운로드 검증은 `busybox:1.36`의 `--arch amd64 --format zip`과 `--arch arm64 --format tar.gz` 출력에서 `packages/busybox-1.36.tar`, tar 내부 manifest와 config 아키텍처, 원본 설치 스크립트의 참조 경로를 함께 확인합니다. Docker가 없는 환경의 파일·스크립트 검사와 엔진을 사용한 로드 결과는 구분해 기록합니다.
+
 ### npm 설치 스크립트 오프라인 검증
 
 `src/core/packager/npm-install-script.integration.test.ts`는 레지스트리에 연결하지 않고 로컬 tarball fixture로 생성 스크립트를 실제 실행합니다. macOS·Linux에서는 Bash, Windows에서는 `powershell.exe`와 해당 환경의 npm을 사용합니다. 빈 npm 캐시와 별도 설정·설치 경로를 사용하며, 공백이 포함된 경로와 scoped 전이 의존성을 설치한 뒤 Node.js에서 실제 모듈을 불러와 검사합니다. 같은 패키지의 1.x·2.x를 요구하는 두 루트가 각각 올바른 버전을 불러오는지, 명시적으로 선택한 직접 버전이 유지되는지도 검증합니다. 서로 다른 peer 버전을 요구하는 전이 플러그인과 순환 의존성도 실제 npm 설치 및 모듈 로딩으로 확인합니다. 설치 대상은 `npm-project/node_modules`이며 상위 사용자 manifest 보존과 기존 사용자 프로젝트 덮어쓰기 방지를 확인합니다. 패키지 파일 또는 필요한 의존성이 없거나 tarball이 손상된 경우에는 오류 종료와 성공 문구 부재를 확인합니다. macOS 임시 디렉터리의 `/var`→`/private/var` 경로 차이에서도 여러 버전을 설치할 수 있어야 합니다. Windows의 `NODE_OPTIONS` preload 경로는 `JSON.stringify`로 인코딩해 역슬래시가 손실되지 않도록 합니다.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -119,6 +119,8 @@ bash scripts/verify-worktree.sh \
 
 `src/core/downloaders/docker-download.test.ts`는 이미지 이름·태그 정규화와 아키텍처별 실제 반환 파일명을 확인합니다. `src/core/packager/docker-install-script.integration.test.ts`는 같은 파일명 fixture를 준비하고, 공백이 있는 폴더와 외부 작업 디렉터리에서 생성 스크립트를 실행합니다. macOS·Linux에서는 Bash, Windows에서는 PowerShell을 사용하며 Docker 기록용 대체 명령이 받은 `load -i` 인자와 실제 파일 경로를 검사합니다. 이 검증은 Docker 엔진의 이미지 로드를 대신하지 않습니다.
 
+경로 비교에는 Node.js의 `realpathSync.native()`를 사용합니다. Windows 임시 폴더의 8.3 짧은 이름(`RUNNER~1`)과 PowerShell이 전달하는 긴 이름이 같은 실제 파일을 가리키는 경우도 동일하게 판정합니다.
+
 Docker 엔진이 실행 중인 환경에서는 아래 명령으로 실제 로드 테스트를 실행합니다. 테스트가 만든 고유 태그의 로컬 이미지 tar를 생성 스크립트로 로드하고, Docker에서 이미지 ID를 확인한 뒤 해당 태그만 정리합니다. 외부 레지스트리 다운로드는 필요하지 않습니다. 명시적으로 활성화한 상태에서 Docker에 연결할 수 없으면 테스트가 실패하며, 기본 단위 테스트에서는 이 사례를 건너뜁니다. Ubuntu CI는 별도 단계에서 이 검증을 활성화합니다.
 
 ```bash

--- a/src/core/downloaders/docker-download.test.ts
+++ b/src/core/downloaders/docker-download.test.ts
@@ -5,8 +5,8 @@
  * ESM 환경에서 vi.hoisted() + vi.mock()을 사용하여 모듈 모킹
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // vi.hoisted()로 모킹 함수들을 먼저 정의
 const {
@@ -148,6 +148,36 @@ describe('DockerDownloader - Download Methods', () => {
   });
 
   describe('downloadImage', () => {
+    it.each([
+      ['x86_64', 'busybox-1.36.tar'],
+      ['arm64', 'busybox-1.36.tar'],
+    ] as const)('returns the downloader archive basename for busybox %s', async (arch, expectedBasename) => {
+      const result = await downloader.downloadImage(
+        'busybox',
+        '1.36',
+        arch,
+        tmpDir
+      );
+
+      expect(path.basename(result)).toBe(expectedBasename);
+    });
+
+    it.each([
+      ['library/busybox', '1.36', 'busybox-1.36.tar'],
+      ['ghcr.io/acme/web-app', 'release:v1', 'web-app-release_v1.tar'],
+    ] as const)('uses the same safe basename for %s:%s', async (repository, tag, expectedBasename) => {
+      const result = await downloader.downloadImage(
+        repository,
+        tag,
+        'x86_64',
+        tmpDir,
+        undefined,
+        repository.startsWith('ghcr.io') ? 'ghcr.io' : 'docker.io'
+      );
+
+      expect(path.basename(result)).toBe(expectedBasename);
+    });
+
     it('should download docker image successfully', async () => {
       const repository = 'library/nginx';
       const tag = 'latest';

--- a/src/core/downloaders/docker-utils.ts
+++ b/src/core/downloaders/docker-utils.ts
@@ -1,5 +1,7 @@
 import { Architecture } from '../../types';
 import { calculateFileChecksum } from '../shared/integrity/checksum';
+import { sanitizeDockerTag } from '../shared/filename-utils';
+import { sanitizePath } from '../shared/path-utils';
 
 /**
  * Docker 플랫폼 정보 인터페이스
@@ -141,6 +143,12 @@ export function parseImageName(name: string): [string, string] {
   }
   // library 이미지 (예: nginx, ubuntu)
   return ['library', imageName];
+}
+
+/** 다운로드와 설치 스크립트가 공유하는 Docker 이미지 tar 파일명. */
+export function buildDockerArchiveFilename(repository: string, tag: string): string {
+  const [, repo] = parseImageName(repository);
+  return `${sanitizePath(repo)}-${sanitizeDockerTag(tag)}.tar`;
 }
 
 /**

--- a/src/core/downloaders/docker.ts
+++ b/src/core/downloaders/docker.ts
@@ -23,7 +23,7 @@ import {
 import logger from '../../utils/logger';
 import { sanitizeDockerTag } from '../shared/filename-utils';
 import { sanitizePath } from '../shared/path-utils';
-import { ARCH_MAP, extractRegistry, parseImageName } from './docker-utils';
+import { ARCH_MAP, buildDockerArchiveFilename, extractRegistry, parseImageName } from './docker-utils';
 import { DockerAuthClient } from './docker-auth-client';
 import { DockerCatalogCache, CatalogCacheStatus } from './docker-catalog-cache';
 import { DockerManifestService } from './docker-manifest-service';
@@ -339,7 +339,7 @@ export class DockerDownloader implements IDownloader {
     await fs.writeJson(path.join(ctx.imageDir, 'manifest.json'), manifestJson);
 
     // tar 파일로 패키징
-    const tarPath = path.join(destPath, `${ctx.safeRepo}-${ctx.safeTag}.tar`);
+    const tarPath = path.join(destPath, buildDockerArchiveFilename(ctx.repository, ctx.tag));
     await this.blobDownloader.createImageTar(ctx.imageDir, tarPath);
 
     // 임시 디렉토리 삭제

--- a/src/core/packager/docker-install-script.integration.test.ts
+++ b/src/core/packager/docker-install-script.integration.test.ts
@@ -1,0 +1,176 @@
+import { execFile } from 'child_process';
+import { createHash } from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getScriptGenerator } from './script-generator';
+import type { PackageInfo } from '../../types';
+
+const execFileAsync = promisify(execFile);
+const generator = getScriptGenerator();
+const createdRoots: string[] = [];
+
+async function createDockerFixture(pkg: PackageInfo, expectedBasename: string) {
+  const root = path.join(
+    os.tmpdir(),
+    `deps smuggler docker archive-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  const packagesDir = path.join(root, 'packages');
+  const externalCwd = path.join(root, 'caller cwd with spaces');
+  const shimDir = path.join(root, 'docker shim');
+  const recordPath = path.join(root, 'docker argv.txt');
+  const bashPath = path.join(root, 'install.sh');
+  const powershellPath = path.join(root, 'install.ps1');
+  const recorderPath = path.join(shimDir, 'docker-recorder.cjs');
+
+  createdRoots.push(root);
+  await fs.ensureDir(packagesDir);
+  await fs.ensureDir(externalCwd);
+  await fs.ensureDir(shimDir);
+  await fs.writeFile(path.join(packagesDir, expectedBasename), 'docker archive fixture');
+
+  const dockerRecorder = `const fs = require('fs');
+const args = process.argv.slice(2);
+const record = { args, cwd: process.cwd() };
+fs.writeFileSync(process.env.DOCKER_ARGV_RECORD, JSON.stringify(record));
+if (args.length !== 3 || args[0] !== 'load' || args[1] !== '-i' || !fs.existsSync(args[2])) process.exit(17);
+`;
+  const dockerShim = `#!/bin/sh
+exec node "$DOCKER_RECORDER_SCRIPT" "$@"
+`;
+  await fs.writeFile(recorderPath, dockerRecorder);
+  await fs.writeFile(path.join(shimDir, 'docker'), dockerShim, { mode: 0o755 });
+
+  await generator.generateBashScript([pkg], bashPath);
+  await generator.generatePowerShellScript([pkg], powershellPath);
+
+  return { root, packagesDir, externalCwd, shimDir, recordPath, recorderPath, bashPath, powershellPath };
+}
+
+async function runScript(
+  fixture: Awaited<ReturnType<typeof createDockerFixture>>,
+  command: string,
+  args: string[],
+) {
+  await execFileAsync(command, args, {
+    cwd: fixture.externalCwd,
+    env: {
+      ...process.env,
+      PATH: `${fixture.shimDir}${path.delimiter}${process.env.PATH || ''}`,
+      DOCKER_ARGV_RECORD: fixture.recordPath,
+      DOCKER_RECORDER_SCRIPT: fixture.recorderPath,
+    },
+    timeout: 45_000,
+  });
+  return JSON.parse(await fs.readFile(fixture.recordPath, 'utf8')) as { args: string[]; cwd: string };
+}
+
+async function runPowerShellIfAvailable(fixture: Awaited<ReturnType<typeof createDockerFixture>>) {
+  if (process.platform !== 'win32') return undefined;
+
+  await fs.writeFile(
+    path.join(fixture.shimDir, 'docker.cmd'),
+    '@echo off\r\nnode "%DOCKER_RECORDER_SCRIPT%" %*\r\nexit /b %ERRORLEVEL%\r\n',
+  );
+  return runScript(fixture, 'powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    fixture.powershellPath,
+  ]);
+}
+
+afterEach(async () => {
+  await Promise.all(createdRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+describe('Docker install scripts use downloader archive names', () => {
+  it.each([
+    ['busybox', '1.36', 'busybox-1.36.tar', 'x86_64'],
+    ['busybox', '1.36', 'busybox-1.36.tar', 'arm64'],
+    ['library/busybox', '1.36', 'busybox-1.36.tar', 'x86_64'],
+    ['ghcr.io/acme/web-app', 'release:v1', 'web-app-release_v1.tar', 'x86_64'],
+  ] as const)(
+    'loads the existing archive for %s:%s (%s) from an external cwd',
+    async (name, version, expectedBasename, arch) => {
+      const pkg: PackageInfo = { type: 'docker', name, version, arch };
+      const fixture = await createDockerFixture(pkg, expectedBasename);
+
+      const bashContent = await fs.readFile(fixture.bashPath, 'utf8');
+      const powershellContent = await fs.readFile(fixture.powershellPath, 'utf8');
+      expect(bashContent).toContain(expectedBasename);
+      expect(powershellContent).toContain(`'${expectedBasename}'`);
+
+      const expectedArtifact = await fs.realpath(path.join(fixture.packagesDir, expectedBasename));
+      const command = process.platform === 'win32' ? 'powershell.exe' : 'bash';
+      const commandArgs = process.platform === 'win32'
+        ? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', fixture.powershellPath]
+        : [fixture.bashPath];
+      const recorded = process.platform === 'win32'
+        ? await runPowerShellIfAvailable(fixture)
+        : await runScript(fixture, command, commandArgs);
+      if (!recorded) throw new Error('Docker recording shim did not capture argv');
+      expect(recorded.args).toHaveLength(3);
+      expect(recorded.args.slice(0, 2)).toEqual(['load', '-i']);
+      expect(await fs.realpath(path.resolve(recorded.cwd, recorded.args[2]))).toBe(expectedArtifact);
+
+    },
+    90_000,
+  );
+
+  it.skipIf(process.env.DEPS_SMUGGLER_NATIVE_DOCKER !== '1')(
+    'loads a fixture archive with native Docker',
+    async () => {
+      const dockerVersion = await execFileAsync('docker', ['version', '--format', '{{.Server.Version}}'], { timeout: 10_000 });
+      expect(dockerVersion.stdout.trim()).not.toBe('');
+
+      const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const imageName = `depssmuggler-native-${suffix}`;
+      const tag = `${imageName}:1.0`;
+      const pkg: PackageInfo = { type: 'docker', name: imageName, version: '1.0', arch: 'x86_64' };
+      const fixture = await createDockerFixture(pkg, `${imageName}-1.0.tar`);
+      const saveRoot = path.join(fixture.root, 'docker-save');
+      const rootfs = path.join(saveRoot, 'rootfs');
+      const layerPath = path.join(saveRoot, 'layer.tar');
+      const configPath = path.join(saveRoot, 'config.json');
+      const manifestPath = path.join(saveRoot, 'manifest.json');
+      const archivePath = path.join(fixture.packagesDir, `${imageName}-1.0.tar`);
+
+      await expect(execFileAsync('docker', ['image', 'inspect', tag], { timeout: 10_000 })).rejects.toThrow();
+
+      try {
+        await fs.ensureDir(rootfs);
+        await fs.writeFile(path.join(rootfs, 'depssmuggler.txt'), 'native fixture');
+        await execFileAsync('tar', ['-cf', layerPath, '-C', rootfs, 'depssmuggler.txt']);
+        const layerDigest = createHash('sha256').update(await fs.readFile(layerPath)).digest('hex');
+        await fs.writeJson(configPath, {
+          architecture: 'amd64',
+          os: 'linux',
+          config: { Cmd: ['/bin/sh'], Labels: { 'com.depssmuggler.test': suffix } },
+          rootfs: { type: 'layers', diff_ids: [`sha256:${layerDigest}`] },
+        });
+        const configDigest = createHash('sha256').update(await fs.readFile(configPath)).digest('hex');
+        await fs.writeJson(manifestPath, [{ Config: 'config.json', RepoTags: [tag], Layers: ['layer.tar'] }]);
+        await execFileAsync('tar', ['-cf', archivePath, '-C', saveRoot, 'config.json', 'manifest.json', 'layer.tar']);
+
+        const scriptCommand = process.platform === 'win32' ? 'powershell.exe' : 'bash';
+        const scriptArgs = process.platform === 'win32'
+          ? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', fixture.powershellPath]
+          : [fixture.bashPath];
+        await execFileAsync(scriptCommand, scriptArgs, { cwd: fixture.externalCwd, timeout: 120_000 });
+        const inspected = await execFileAsync('docker', ['image', 'inspect', tag], { timeout: 10_000 });
+        const image = JSON.parse(inspected.stdout)[0] as { Id: string; RepoTags: string[]; Config: { Labels: Record<string, string> } };
+        expect(image.Id).toBe(`sha256:${configDigest}`);
+        expect(image.RepoTags).toContain(tag);
+        expect(image.Config.Labels['com.depssmuggler.test']).toBe(suffix);
+      } finally {
+        await execFileAsync('docker', ['image', 'rm', tag], { timeout: 10_000 }).catch(() => undefined);
+      }
+    },
+    180_000,
+  );
+});

--- a/src/core/packager/docker-install-script.integration.test.ts
+++ b/src/core/packager/docker-install-script.integration.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process';
 import { createHash } from 'crypto';
+import { realpathSync } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
@@ -105,7 +106,7 @@ describe('Docker install scripts use downloader archive names', () => {
       expect(bashContent).toContain(expectedBasename);
       expect(powershellContent).toContain(`'${expectedBasename}'`);
 
-      const expectedArtifact = await fs.realpath(path.join(fixture.packagesDir, expectedBasename));
+      const expectedArtifact = realpathSync.native(path.join(fixture.packagesDir, expectedBasename));
       const command = process.platform === 'win32' ? 'powershell.exe' : 'bash';
       const commandArgs = process.platform === 'win32'
         ? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', fixture.powershellPath]
@@ -116,7 +117,7 @@ describe('Docker install scripts use downloader archive names', () => {
       if (!recorded) throw new Error('Docker recording shim did not capture argv');
       expect(recorded.args).toHaveLength(3);
       expect(recorded.args.slice(0, 2)).toEqual(['load', '-i']);
-      expect(await fs.realpath(path.resolve(recorded.cwd, recorded.args[2]))).toBe(expectedArtifact);
+      expect(realpathSync.native(path.resolve(recorded.cwd, recorded.args[2]))).toBe(expectedArtifact);
 
     },
     90_000,

--- a/src/core/packager/script-generator.ts
+++ b/src/core/packager/script-generator.ts
@@ -10,6 +10,7 @@ import { buildNpmProjectSetupScript } from './npm-install-runtime';
 import { PackageInfo } from '../../types';
 import logger from '../../utils/logger';
 import { stripLeadingDotSlash, toUnixPath, getWriteOptions } from '../shared/path-utils';
+import { buildDockerArchiveFilename } from '../downloaders/docker-utils';
 
 export interface ScriptOptions {
   includeHeader?: boolean;
@@ -357,10 +358,10 @@ export class ScriptGenerator {
       lines.push('');
 
       for (const pkg of dockerPackages) {
-        const imageName = pkg.name.replace(/\//g, '_');
+        const tarFileName = buildDockerArchiveFilename(pkg.name, pkg.version);
         lines.push(`    # ${pkg.name}:${pkg.version} 로드`);
         lines.push(`    log_info "${pkg.name}:${pkg.version} 로드 중..."`);
-        lines.push(`    docker load -i "$PACKAGE_DIR/${imageName}_${pkg.version}.tar" || {`);
+        lines.push(`    docker load -i "$PACKAGE_DIR"/${this.shellQuote(tarFileName)} || {`);
         lines.push(`        log_warn "${pkg.name}:${pkg.version} 로드 실패"`);
         lines.push('    }');
         lines.push('');
@@ -643,11 +644,10 @@ export class ScriptGenerator {
       lines.push('');
 
       for (const pkg of dockerPackages) {
-        const imageName = pkg.name.replace(/\//g, '_');
-        const tarFileName = `${imageName}_${pkg.version}.tar`;
+        const tarFileName = buildDockerArchiveFilename(pkg.name, pkg.version);
         lines.push(`    # ${pkg.name}:${pkg.version} 로드`);
         lines.push(`    Write-Info "${pkg.name}:${pkg.version} 로드 중..."`);
-        lines.push(`    $ImagePath = Join-Path -Path $PackageDir -ChildPath '${tarFileName}'`);
+        lines.push(`    $ImagePath = Join-Path -Path $PackageDir -ChildPath ${this.powerShellQuote(tarFileName)}`);
         lines.push('    try {');
         lines.push('        docker load -i $ImagePath');
         lines.push('    } catch {');


### PR DESCRIPTION
`busybox:1.36`을 다운로드하면 `busybox-1.36.tar`가 생성되지만, 설치 스크립트는 `busybox_1.36.tar`를 요청해 이미지 반입에 실패했습니다. 다운로더와 Bash·PowerShell 생성기가 하나의 파일명 함수를 사용하도록 수정했습니다. 레지스트리·namespace 분리와 기존 tag 정규화를 그대로 적용하며, 아키텍처와 ZIP·tar.gz 형식이 달라도 같은 내부 파일을 참조합니다.

공백이 있는 경로와 외부 작업 디렉터리에서 생성 스크립트를 실행해 실제 파일 경로를 확인하는 회귀 테스트를 추가했습니다. Ubuntu CI에서는 고유한 임시 이미지 tar를 실제 Docker 엔진에 로드하고 이미지 ID와 태그를 확인하는 별도 테스트도 실행합니다. CLI·packager·Docker 구조·테스트 문서를 갱신했습니다.

검증:

- 수정 전 표준 회귀 테스트 3건에서 기존 잘못된 파일명 재현.
- 실제 source CLI `busybox:1.36 --arch amd64 --format zip`, `--arch arm64 --format tar.gz` 다운로드 성공. 두 아카이브의 `packages/busybox-1.36.tar`, 이미지 config 아키텍처, 원본 Bash의 실제 파일 전달 확인.
- Ubuntu CI에서 고유 이미지 tar의 실제 Docker load 및 이미지 ID·태그 검증을 통과했습니다. 로컬 Docker 대체 명령 검증은 파일·인자 검증입니다. Windows 첫 CI에서 8.3 짧은 이름과 PowerShell의 긴 경로를 테스트가 다르게 비교해 실패했고, 두 경로를 realpathSync.native로 정규화해 비교하도록 수정했습니다.
- 표준 대상 테스트 36 통과·1 건너뜀, 전체 2,654 통과·187 건너뜀. TypeScript 두 설정 통과. 변경 TypeScript lint 오류 없음(기존 테스트 import/order 경고 1건).

일반 설치 실패의 종료 코드 전파는 별도 #86 범위입니다.

Closes #70
