### PR TITLE
fix: CLI 다운로드 실패를 종료 코드에 반영

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,6 +150,7 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
 
 ### 현재 동작
 
+- 실제 파일 다운로드 항목이 하나라도 실패하면 실패 목록을 출력하고 종료 코드 `1`로 끝납니다. 이 경우 이번 실행의 아카이브와 설치 스크립트를 생성하지 않습니다. 성공한 다운로드의 종료 코드는 `0`이며, 다운로드 전 의존성 해결 단계의 기본 건너뛰기 정책과 `--strict`는 위 설명을 따릅니다.
 - 다운로드 성공 시 출력 디렉터리에 `packages-<timestamp>.zip` 또는 `.tar.gz`를 만든 뒤, 같은 디렉터리에 설치 스크립트를 생성합니다. 이 호출 순서에서는 별도로 생성한 설치 스크립트가 앞서 만든 아카이브에 포함되지 않습니다.
 - Docker는 압축을 풀어 생긴 `packages/`와 설치 스크립트를 같은 폴더에 두고 실행합니다. Bash·PowerShell 모두 실제 이미지 파일명(예: `packages/busybox-1.36.tar`)을 `docker load -i`에 전달합니다. `amd64`·`arm64`와 ZIP·tar.gz 출력에서 같은 이름 규칙을 사용하며, 대상 환경에는 실행 중인 Docker가 필요합니다.
 - npm은 압축을 풀어 생긴 `packages/` 폴더와 설치 스크립트를 같은 폴더에 두고 실행합니다. Node.js와 npm이 설치된 환경에서 전달된 `.tgz`를 `npm install --offline`으로 설치하며, 결과는 스크립트 폴더의 `npm-project/node_modules`에 생깁니다. 이 전용 프로젝트에 설치용 `package.json`을 생성하며 상위 폴더의 사용자 manifest는 변경하지 않습니다.
@@ -285,7 +286,7 @@ depssmuggler cache list
 - OS 패키지 CLI는 `list-distros`, `search`, `download`, `cache`를 독립적으로 수행하며 Electron GUI에 의존하지 않습니다.
 - 일반 패키지 `search`는 `pip`, `conda`, `maven`, `npm`, `docker`에 연결되어 있지만, GUI 전용 위자드/시각화 흐름은 CLI에 없습니다.
 - `cache list`는 현재 캐시 루트가 디렉터리 위주라는 가정을 두고 있어, `cache-manifest.json` 같은 일반 파일이 섞인 경우 실패할 수 있습니다.
-- 일반 `download`에서 실제 파일 다운로드가 일부 실패하면 실패 목록을 출력하고 아카이브/설치 스크립트 생성을 건너뛰지만, 이 분기 자체는 종료 코드를 `1`로 바꾸지 않습니다. `cache size/clear/list`도 내부 조회·삭제 오류를 출력한 뒤 반환하는 경로가 있으므로, 자동화에서 종료 코드만으로 모든 파일 작업의 성공을 판정할 수는 없습니다.
+- `cache size/clear/list`는 내부 조회·삭제 오류를 출력한 뒤 반환하는 경로가 있으므로, 캐시 자동화에서 종료 코드만으로 모든 파일 작업의 성공을 판정할 수는 없습니다.
 - CLI에는 SMTP 발송, 전달용 자동 분할, GUI 히스토리 저장 명령이 없습니다. 해당 기능은 Electron 일반 다운로드 전달 파이프라인에서 사용합니다.
 
 ## 관련 문서

--- a/docs/downloader-factory.md
+++ b/docs/downloader-factory.md
@@ -103,7 +103,7 @@ const versions = await mavenDownloader.getVersions('org.springframework:spring-c
 ```typescript
 import { setTestDownloader, clearAllTestDownloaders } from './downloaders/factory';
 
-describe('DownloadManager', () => {
+describe('Downloader factory', () => {
   beforeEach(() => {
     // 모킹된 다운로더 설정
     const mockPipDownloader = {
@@ -130,6 +130,8 @@ describe('DownloadManager', () => {
   });
 });
 ```
+
+위 `setTestDownloader()`는 factory의 `getDownloader()`를 사용하는 호출에 적용됩니다. CLI의 `DownloadManager`는 `registry.ts`의 `createRegisteredDownloader()`를 직접 사용하므로 이 factory override로 교체되지 않습니다. CLI 프로세스의 다운로드·종료 상태 검증은 [테스트 문서](./testing.md)를 참고합니다.
 
 ### 비동기 초기화 보장
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -115,6 +115,18 @@ bash scripts/verify-worktree.sh \
 
 이 fixture 검증은 실제 Maven Central의 현재 파일 존재 여부나 외부 Maven 실행의 오프라인 성공을 보장하지 않습니다. 외부 저장소 검증에는 아래 통합 테스트를 별도로 사용하고, 실행 명령·대상 좌표·파일 확인 결과를 해당 작업의 검증 기록에 남깁니다.
 
+### CLI 다운로드 실패 종료 코드 검증
+
+`src/cli/download-failure-exit.integration.test.ts`는 별도 Node.js 프로세스에서 실제 CLI 엔트리포인트와 Commander 인자를 실행합니다. 부모 프로세스의 로컬 HTTP 서버가 404를 반환하고, 자식의 테스트 전용 설정이 실제 `MavenDownloader`의 저장소 주소만 이 서버로 연결합니다. 실제 다운로드 매니저가 실패 결과를 반환한 뒤 CLI가 종료 코드 `1`과 실패 원인을 남기고, 새 아카이브와 설치 스크립트를 생성하지 않는지 확인합니다. 설정·로그·출력은 임시 디렉터리로 격리하며 외부 레지스트리에 연결하지 않습니다.
+
+`src/cli/commands/download.test.ts`는 전체·일부 항목 실패 분기를 빠르게 검증합니다. 다운로드 전 의존성 해결의 기본 건너뛰기 정책은 별도 동작으로 유지합니다. 실제 레지스트리 검증에는 존재하지 않는 Maven classifier와 Docker 태그의 HTTP 404, 정상 패키지 다운로드의 종료 코드와 산출물을 함께 기록합니다.
+
+```bash
+bash scripts/verify-worktree.sh \
+  src/cli/download-failure-exit.integration.test.ts \
+  src/cli/commands/download.test.ts
+```
+
 ### Docker 설치 스크립트 파일명과 실제 로드 검증
 
 `src/core/downloaders/docker-download.test.ts`는 이미지 이름·태그 정규화와 아키텍처별 실제 반환 파일명을 확인합니다. `src/core/packager/docker-install-script.integration.test.ts`는 같은 파일명 fixture를 준비하고, 공백이 있는 폴더와 외부 작업 디렉터리에서 생성 스크립트를 실행합니다. macOS·Linux에서는 Bash, Windows에서는 PowerShell을 사용하며 Docker 기록용 대체 명령이 받은 `load -i` 인자와 실제 파일 경로를 검사합니다. 이 검증은 Docker 엔진의 이미지 로드를 대신하지 않습니다.

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -190,6 +190,53 @@ describe('downloadCommand', () => {
     );
   });
 
+  it.each([
+    ['partial failure', [
+      {
+        id: 'pip-completed-2.28.0',
+        package: { type: 'pip', name: 'requests', version: '2.28.0' },
+        status: 'completed',
+        progress: 100,
+        filePath: '/tmp/output/requests.whl',
+      },
+      {
+        id: 'pip-failed-2.28.0',
+        package: { type: 'pip', name: 'missing', version: '2.28.0' },
+        status: 'failed',
+        progress: 0,
+        error: '404 Not Found',
+      },
+    ]],
+    ['full failure', [
+      {
+        id: 'pip-failed-2.28.0',
+        package: { type: 'pip', name: 'missing', version: '2.28.0' },
+        status: 'failed',
+        progress: 0,
+        error: '404 Not Found',
+      },
+    ]],
+  ] as const)('%s sets a nonzero exit code without creating delivery files', async (_label, items) => {
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    startDownload.mockResolvedValueOnce({
+      success: false,
+      totalSize: 0,
+      duration: 100,
+      items,
+    });
+
+    try {
+      await downloadCommand(commandOptions());
+
+      expect(process.exitCode).toBe(1);
+      expect(createArchive).not.toHaveBeenCalled();
+      expect(generateAllScripts).not.toHaveBeenCalled();
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it('deps가 true면 의존성을 해결한 패키지 목록을 큐에 추가한다', async () => {
     await downloadCommand(commandOptions());
 

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -435,6 +435,7 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
           console.log(chalk.red(`  - ${item.package.name}@${item.package.version}: ${item.error}`));
         }
       }
+      process.exitCode = 1;
     }
   } catch (error) {
     console.log(chalk.red('✗ 다운로드 실패'));

--- a/src/cli/download-failure-exit.integration.test.ts
+++ b/src/cli/download-failure-exit.integration.test.ts
@@ -1,0 +1,116 @@
+import { execFile } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+const childHarness = `
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+require(path.join(projectRoot, 'node_modules/ts-node')).register({ project: path.join(projectRoot, 'tsconfig.cli.json') });
+
+const registry = require(path.join(projectRoot, 'src/core/downloaders/registry.ts'));
+const { MavenDownloader } = require(path.join(projectRoot, 'src/core/downloaders/maven.ts'));
+const originalCreate = registry.createRegisteredDownloader;
+const downloader = new MavenDownloader();
+downloader.repoUrl = process.env.DEPS_SMUGGLER_MAVEN_REPO_URL;
+registry.createRegisteredDownloader = (type) => type === 'maven' ? downloader : originalCreate(type);
+
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  'download',
+  '--type', 'maven',
+  '--package', 'com.example:missing',
+  '--pkg-version', '1.0.0',
+  '--output', process.env.DEPS_SMUGGLER_OUTPUT,
+  '--format', 'zip',
+  '--no-deps',
+  '--concurrency', '1',
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('loopback server did not expose a port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+describe('download CLI failure exit status', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await fs.remove(tempRoot);
+    tempRoot = undefined;
+  });
+
+  it('returns nonzero after real Maven HTTP failure and creates no delivery artifacts', async () => {
+    const requests: string[] = [];
+    const server = createServer((_request, response) => {
+      requests.push(_request.url ?? '');
+      response.writeHead(404, { 'content-type': 'text/plain' });
+      response.end('fixture not found');
+    });
+    const port = await listen(server);
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-issue-71-'));
+    const output = path.join(tempRoot, 'output with spaces');
+    const isolatedHome = path.join(tempRoot, 'isolated user directory');
+    const harnessPath = path.join(tempRoot, 'download-failure-harness.cjs');
+    await fs.ensureDir(output);
+    await fs.ensureDir(isolatedHome);
+    await fs.writeFile(harnessPath, childHarness);
+
+    try {
+      let child: { code: number; stdout: string; stderr: string };
+      try {
+        const result = await execFileAsync(process.execPath, [harnessPath], {
+          cwd: projectRoot,
+          env: {
+            ...process.env,
+            DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+            DEPS_SMUGGLER_MAVEN_REPO_URL: `http://127.0.0.1:${port}/maven2`,
+            DEPS_SMUGGLER_OUTPUT: output,
+            DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+            NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+          },
+          timeout: 120_000,
+        });
+        child = { code: 0, stdout: result.stdout, stderr: result.stderr };
+      } catch (error) {
+        const failure = error as typeof error & { code?: number; stdout?: string; stderr?: string };
+        child = {
+          code: typeof failure.code === 'number' ? failure.code : -1,
+          stdout: failure.stdout ?? '',
+          stderr: failure.stderr ?? '',
+        };
+      }
+
+      expect(child.code).toBe(1);
+      const outputText = `${child.stdout}\n${child.stderr}`;
+      expect(outputText).toContain('다운로드 완료 (일부 실패)');
+      expect(outputText).toContain('com.example:missing@1.0.0');
+      expect(outputText).toContain('404');
+      expect(requests).toContain('/maven2/com/example/missing/1.0.0/missing-1.0.0.jar');
+      const deliveredArtifacts = (await fs.readdir(output)).filter((name) =>
+        /^packages-.*\.(zip|tar\.gz)$/.test(name) || /^install\.(sh|ps1)$/.test(name)
+      );
+      expect(deliveredArtifacts).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
일반 `download`에서 실제 파일 다운로드가 실패하면 실패 목록을 출력하고도 종료 코드 0으로 끝나 자동화가 성공으로 오인했습니다. 이제 다운로드 매니저가 실패 결과를 반환하면 실패 내역을 출력한 뒤 종료 코드 1로 마무리합니다. 해당 실행의 아카이브·설치 스크립트 생성을 건너뛰는 기존 동작과 다운로드 전 의존성 해결의 기본 건너뛰기 정책은 유지합니다.

실제 CLI 엔트리포인트를 별도 프로세스로 실행하고, 실제 Maven 다운로더가 로컬 HTTP 서버의 404를 받는 회귀 테스트를 추가했습니다. 테스트는 요청 URL, 실패 원인, 종료 코드와 전달 산출물 미생성을 확인합니다. CLI 동작·검증 문서를 갱신하고 factory 테스트 override와 CLI registry의 적용 범위도 명확히 했습니다.

검증:

- 수정 전 실제 Maven classifier 및 Docker 태그 404는 종료 코드 0, 산출물 없음. 정상 busybox 다운로드는 종료 코드 0과 아카이브·설치 스크립트 생성.
- 표준 CLI subprocess 회귀는 수정 전 종료 코드 0으로 실패하고 수정 후 1로 통과.
- 전체 표준 테스트 2,657 통과·187 건너뜀, TypeScript 두 설정과 변경 파일 lint 통과. 전체·일부 다운로드 실패의 단위 회귀도 확인했습니다.
- 수정 후 실제 Maven classifier 및 Docker 태그 404 모두 종료 코드 1, 새 아카이브·스크립트 없음. 정상 busybox 다운로드는 종료 코드 0과 산출물 생성을 유지했습니다.

Closes #71
