### PR TITLE
fix: Maven latest 버전을 실제 릴리스로 해석

### DIFF
--- a/docs/cli-download-environment-options-design.md
+++ b/docs/cli-download-environment-options-design.md
@@ -89,7 +89,7 @@ DownloadManager queue
 | 타입 | 깊이 0 루트 해결 조건 |
 |------|----------------------|
 | pip, Conda | 환경 옵션이 모두 기본값이어도 항상 수행 |
-| Maven | `hasExplicitTargetEnvironment(options)`가 참일 때 수행. 유효한 명령에서는 classifier를 명시한 경우가 해당하며, 비기본 OS·아키텍처에도 classifier가 필요함 |
+| Maven | 요청 목록에 `latest`가 있거나 `hasExplicitTargetEnvironment(options)`가 참일 때 수행. 유효한 환경 지정 명령에서는 classifier를 명시한 경우가 해당하며, 비기본 OS·아키텍처에도 classifier가 필요함 |
 | npm, Docker 및 일반 `download`의 OS 타입 | resolver를 호출하지 않고 입력 패키지를 반환 |
 
 `hasExplicitTargetEnvironment()`는 비기본 `arch`, `targetOS`, `condaChannel` 또는 지정된 `pythonVersion`, `cudaVersion`, `classifier`를 검사한다. 타입에 맞지 않는 환경 옵션은 이 단계 전에 검증 오류로 거부된다. 이 판별 함수와 별개로 pip·Conda는 항상 루트 아티팩트를 해결하므로, 기본 환경의 `--no-deps`도 호환 파일 선택과 해결 실패 검사를 거친다.
@@ -125,7 +125,7 @@ DownloadManager queue
 
 1. CLI command 테스트에서 각 환경 옵션이 `resolveAllDependencies`로 전달되는지 확인한다.
 2. 잘못된 OS, 아키텍처, Python/CUDA 버전과 패키지 타입별 잘못된 조합이 다운로드 시작 전에 거부되는지 확인한다.
-3. pip·Conda의 `--no-deps`는 기본 환경과 명시한 환경 모두에서 깊이 0 루트 해결만 수행하고 의존성을 큐에 추가하지 않는지 확인한다. Maven의 환경 지정 여부와 나머지 타입의 resolver 생략 조건도 구분한다.
+3. pip·Conda의 `--no-deps`는 기본 환경과 명시한 환경 모두에서 깊이 0 루트 해결만 수행하고 의존성을 큐에 추가하지 않는지 확인한다. Maven은 환경 지정 여부와 `latest` 요청 포함 여부를 검사하며, 나머지 타입의 resolver 생략 조건도 구분한다.
 4. 공용 dependency resolver 테스트에서 기존 루트 패키지에 resolver의 URL, 파일명, classifier 메타데이터가 병합되는지 확인한다.
 5. pip resolver에서 downloader까지 이어지는 테스트로 PyPI JSON과 Simple API에서 선택한 URL·체크섬을 재조회 없이 사용하는지 확인하고, ARM64 별칭·`abi3` 최소 버전·`Requires-Python` 제약을 검증한다.
 6. 파일 입력과 `--no-deps`에도 비기본 아키텍처가 적용되고, pip/Conda의 미지원 아키텍처와 classifier 없는 Maven 대상 OS/아키텍처가 부수 효과 전에 거부되는지 확인한다.

--- a/docs/cli-download-environment-options-plan.md
+++ b/docs/cli-download-environment-options-plan.md
@@ -4,7 +4,7 @@
 >
 > 구현 결과는 `src/cli/commands/download-environment.ts`, `download.ts`, `download-runner.ts`, `src/core/shared/dependency-resolver.ts` 및 pip/Conda/Maven resolver·downloader에 반영되어 있습니다. 후속 수정으로 pip 호환 wheel/sdist 선택, Conda noarch의 Python 제약, Maven 명시적 type 보존도 보강되었습니다. 아래 초안의 메서드·타입을 현재 API로 복사하지 말고 해당 소스와 테스트를 기준으로 삼습니다.
 >
-> 특히 Task 2의 Step 2·9에 남아 있는 “새 환경 옵션이 없는 `--no-deps`는 resolver를 호출하지 않는다”는 초기 조건은 pip·Conda에 더 이상 적용되지 않습니다. 현재 두 타입은 기본 환경에서도 `maxDepth: 0`, `resolveRootArtifactsOnly: true`로 루트 파일을 검증합니다. Maven은 명시한 대상 환경이 있을 때만 루트를 해결하며, 나머지 타입의 일반 `download --no-deps`는 resolver를 생략합니다.
+> 특히 Task 2의 Step 2·9에 남아 있는 “새 환경 옵션이 없는 `--no-deps`는 resolver를 호출하지 않는다”는 초기 조건은 pip·Conda에 더 이상 적용되지 않습니다. 현재 두 타입은 기본 환경에서도 `maxDepth: 0`, `resolveRootArtifactsOnly: true`로 루트 파일을 검증합니다. Maven은 명시한 대상 환경이 있거나 요청 목록에 `latest`가 있을 때 루트를 해결하며, 나머지 타입의 일반 `download --no-deps`는 resolver를 생략합니다.
 
 **Goal:** `depssmuggler download`에서 대상 OS, 아키텍처, Python/CUDA 버전, Conda 채널과 Maven classifier를 검증하고 의존성 해결부터 실제 아티팩트 다운로드까지 일관되게 적용한다.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,8 @@ depssmuggler download [옵션]
 
 Maven ZIP/TAR.GZ에는 선택된 각 아티팩트의 부속 POM과 다운로드에 성공한 `.sha1` 체크섬도 포함됩니다. `--no-deps`나 `--max-depth`로 의존성 탐색 범위를 줄여도 선택된 JAR 자체의 POM은 함께 전달됩니다. 파일은 `packages/` 아래 Maven 저장소 디렉터리 구조를 유지하며, 같은 POM을 여러 항목에서 참조해도 한 번만 포함합니다.
 
+Maven의 `-V latest`는 POM을 조회하기 전에 `maven-metadata.xml`의 `latest` 값으로 해석하며, 그 값이 없으면 `release`를 사용합니다. 해석된 실제 버전이 다운로드 경로·파일명과 manifest에 기록됩니다. `--no-deps`에서도 이 버전 조회는 수행하며 전이 라이브러리를 확장하지 않습니다. 사용 가능한 버전 정보가 없으면 해당 루트의 해결 실패로 처리합니다.
+
 `pip`에서 `--python-version`을 지정하면 해당 버전의 `python_version` 환경 마커를 평가하고, `--target-os` 및 `--arch`와 호환되는 wheel 태그를 선택합니다. Python 버전은 `major.minor` 형식만 허용합니다. 따라서 `python_full_version`과 `implementation_version`처럼 patch가 필요한 marker는 값을 알 수 없는 조건으로 처리합니다. wheel은 대상 버전의 CPython 태그와 범용 `py3`/`py2.py3` 태그, 또는 대상보다 같거나 낮은 CPython 버전의 `abi3` 태그만 선택합니다. PyPI의 패키지·파일 `requires_python`과 Simple API 파일의 `requiresPython`도 PEP 440 specifier set으로 확인하므로, 대상 Python보다 높은 버전만 지원하는 wheel과 source distribution은 선택하지 않습니다. `latest`와 버전 범위는 PyPI 또는 Simple API에서 대상 Python과 호환되는 산출물이 있는 가장 높은 안정 버전을 선택하고, 철회(yanked) 릴리스는 wildcard가 없는 정확한 버전 고정 외에는 제외합니다. 프리릴리스는 버전 제약이 명시적으로 포함하거나 안정 후보가 없을 때만 선택합니다. 지원하지 않는 marker 문법이나 값이 없는 `platform_release`/`platform_version`은 의존성을 포함하지 않는 것으로 처리합니다.
 
 대상 환경 옵션은 다운로드 전에 검증됩니다.
@@ -114,7 +116,7 @@ Maven ZIP/TAR.GZ에는 선택된 각 아티팩트의 부속 POM과 다운로드�
 - 깊이 경계 도달은 위 규칙에 따른 정상적인 bounded traversal이며 직접 루트 실패가 아닙니다. 반대로 호환되는 필수 의존성 버전을 찾지 못한 경우, 의존성 메타데이터 조회가 실패한 경우, 네트워크 오류가 발생한 경우처럼 실제 필수 의존성 해결 오류는 직접 루트 실패로 처리됩니다.
 - pip 하위 의존성은 버전 제약과 대상 환경에 호환되는 아티팩트를 함께 만족하는 최신 릴리스를 선택하며, 같은 패키지에 여러 경로로 요청된 기본/extra 컨텍스트는 합쳐서 평가합니다. Conda 하위 의존성은 버전뿐 아니라 build MatchSpec도 실제 파일 선택까지 유지하고, 같은 버전의 서로 다른 build가 필요하면 각 아티팩트를 모두 보존합니다.
 - Maven classifier 형식은 라이브러리마다 다르므로 OS와 아키텍처만으로 자동 생성하지 않습니다. Maven에 `--target-os` 또는 기본값이 아닌 `--arch`를 지정할 때는 실제 네이티브 아티팩트를 선택할 `--classifier`를 함께 지정해야 합니다.
-- pip·Conda의 `--no-deps`는 환경 옵션을 생략해도 깊이 0 resolver로 호환되는 루트 아티팩트를 선택·검증하며, 전이 의존성은 다운로드하지 않습니다. 기본값이 아닌 `--arch`를 비롯해 지정한 환경 옵션도 이 파일 선택에 반영됩니다. Maven은 classifier 등 대상 환경을 명시한 경우에만 깊이 0으로 루트를 해결합니다. 기본 환경의 Maven과 npm·Docker는 `--no-deps`에서 resolver를 생략합니다.
+- pip·Conda의 `--no-deps`는 환경 옵션을 생략해도 깊이 0 resolver로 호환되는 루트 아티팩트를 선택·검증하며, 전이 의존성은 다운로드하지 않습니다. 기본값이 아닌 `--arch`를 비롯해 지정한 환경 옵션도 이 파일 선택에 반영됩니다. Maven은 classifier 등 대상 환경을 명시하거나 요청 목록에 `latest`가 있으면 깊이 0으로 루트를 해결합니다. 명시적 버전만 지정한 기본 환경의 Maven과 npm·Docker는 `--no-deps`에서 resolver를 생략합니다.
 - pip은 PyPI JSON API와 Simple API 모두에서 호환 wheel을 우선하고, 없으면 `Requires-Python` 조건을 만족하는 source distribution(`.tar.gz`, `.zip`, `.tar.bz2`, `.tar.xz`)을 선택합니다. source distribution은 대상 환경에서 빌드하지 않고 그대로 반입합니다. 호환 wheel과 source distribution이 모두 없으면 다른 아키텍처 wheel로 바꾸지 않으며, 요청한 정확 버전·`latest`·범위 spec과 대상 Python/OS/아키텍처를 포함한 오류를 반환합니다.
 - Simple API의 source distribution은 `--no-deps`에서 artifact hash가 있으면 Core Metadata 없이도 반입할 수 있습니다. wheel과 의존성 확장 모드는 검증된 Core Metadata를 계속 요구합니다.
 

--- a/docs/maven-dependency-resolution.md
+++ b/docs/maven-dependency-resolution.md
@@ -5,6 +5,7 @@
 ## 현재 구현 요약
 
 - `MavenResolver`는 BF 탐색을 `MavenQueueProcessor`와 조합하고, `MavenBomProcessor`, `DependencyResolutionSkipper` 및 Maven 공용 캐시를 사용합니다. Maven JVM 라이브러리를 직접 실행하지 않습니다.
+- 루트의 `latest`는 저장소 메타데이터의 `latest` 또는 `release` 실제 버전으로 바꾼 뒤 POM을 조회합니다. 두 값이 모두 없으면 실패합니다. CLI의 `--no-deps`에서도 버전 확인은 수행하며 자식 라이브러리 의존성은 펼치지 않습니다.
 - 루트의 명시적 `metadata.type`은 `artifactType`으로 전달되며 원격 POM packaging이 이를 덮어쓰지 않습니다. 아티팩트 키는 type을 포함합니다. classifier는 사용자가 선택하며 OS/아키텍처만으로 자동 생성하지 않습니다.
 - `dependencyManagement`와 BOM은 버전 관리에 사용하고, 그 목록 전체를 실제 다운로드 의존성으로 펼치지 않습니다. `MavenQueueProcessor`가 `src/core/shared/maven-pom-utils.ts`의 `extractDependencies()`를 호출합니다.
 - 선택된 패키지의 모델 해석에 필요한 Parent POM과 import BOM은 전체 GAV로 중복 제거하여 `metadata.type: 'pom'`인 다운로드 항목으로 포함합니다. Parent/BOM 탐색과 그래프 평탄화는 반복 처리하며, 필수 모델의 누락이나 순환 참조는 해당 루트의 해결 실패로 보고합니다.

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -549,6 +549,8 @@ maven-queue-processor.ts
 | `parseFromText` | content: string | Promise<PackageInfo[]> | pom.xml 파싱 |
 | `flattenDependencies` (private) | node: DependencyNode | PackageInfo[] | 트리를 플랫 리스트로 변환 |
 
+루트 버전이 `latest`이면 POM 조회 전에 설정된 저장소의 `maven-metadata.xml`에서 `latest`, 없으면 `release`를 선택합니다. 둘 다 비어 있으면 버전 조회 실패로 처리합니다. 해결 결과의 루트·플랫 목록·파일명에는 실제 버전이 들어가며 classifier와 artifact type은 유지합니다. 명시한 버전은 메타데이터 조회 없이 사용합니다. CLI의 기본 `--no-deps`도 `latest` 요청이면 깊이 0으로 이 과정을 실행합니다.
+
 ### 내부 메서드
 
 | 메서드 | 설명 |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,6 +95,8 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 
 ### Maven 모델 POM 검증
 
+`src/core/resolver/maven-resolver.test.ts`는 `latest` 메타데이터의 실제 버전으로 루트 POM과 파일명을 만드는지, release fallback·빈 버전 실패·classifier/type 보존·명시 버전의 조회 생략을 검증합니다. `src/cli/commands/download.test.ts`는 기본 Maven `--no-deps`에서 `latest`만 깊이 0의 루트 해결을 거쳐 다운로드 큐로 전달되는지 확인합니다. 실제 저장소 검증에서는 같은 좌표의 의존성 포함/제외 CLI를 실행하고 메타데이터 버전과 아카이브·manifest를 비교합니다.
+
 Parent POM과 import BOM이 조회 캐시에만 남아 오프라인 출력에서 누락되는 문제는 다음 기본 회귀 세트로 검증합니다. `INTEGRATION_TEST` 설정 없이 실행하며 외부 Maven Central에 접속하지 않습니다.
 
 | 테스트 | 검증 범위 |

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -97,6 +97,7 @@ function commandOptions(
 describe('downloadCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveAllDependencies).mockReset();
 
     ensureDir.mockResolvedValue(undefined);
     startDownload.mockResolvedValue({
@@ -933,6 +934,83 @@ describe('downloadCommand', () => {
         metadata: expect.objectContaining({
           filename: 'numpy-2.0.0-py312_0.conda',
         }),
+      }),
+    ]);
+  });
+
+  it('기본 Maven --no-deps의 latest는 concrete root artifact를 resolver로 검증한다', async () => {
+    const concreteRoot = {
+      id: 'maven-org.example:demo-3.0.2',
+      type: 'maven' as const,
+      name: 'org.example:demo',
+      version: '3.0.2',
+      architecture: 'x86_64' as const,
+      metadata: {
+        groupId: 'org.example',
+        artifactId: 'demo',
+        type: 'jar',
+        filename: 'demo-3.0.2.jar',
+      },
+    };
+    vi.mocked(resolveAllDependencies).mockResolvedValueOnce({
+      originalPackages: [
+        {
+          id: 'maven-org.example:demo-latest',
+          type: 'maven',
+          name: 'org.example:demo',
+          version: 'latest',
+          architecture: 'x86_64',
+        },
+      ],
+      allPackages: [concreteRoot],
+      successfulPackages: [concreteRoot],
+      dependencyTrees: [],
+      failedPackages: [],
+    });
+
+    await downloadCommand(commandOptions({
+      type: 'maven',
+      package: 'org.example:demo',
+      pkgVersion: 'latest',
+      deps: false,
+    }));
+
+    expect(resolveAllDependencies).toHaveBeenCalledWith(
+      [expect.objectContaining({
+        type: 'maven',
+        name: 'org.example:demo',
+        version: 'latest',
+      })],
+      expect.objectContaining({
+        includeDependencies: true,
+        maxDepth: 0,
+        resolveRootArtifactsOnly: true,
+      }),
+    );
+    expect(addToQueue).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'maven',
+        name: 'org.example:demo',
+        version: '3.0.2',
+        metadata: expect.objectContaining({ filename: 'demo-3.0.2.jar' }),
+      }),
+    ]);
+  });
+
+  it('기본 Maven --no-deps의 명시 버전은 latest resolver 조회를 추가하지 않는다', async () => {
+    await downloadCommand(commandOptions({
+      type: 'maven',
+      package: 'org.example:demo',
+      pkgVersion: '3.0.1',
+      deps: false,
+    }));
+
+    expect(resolveAllDependencies).not.toHaveBeenCalled();
+    expect(addToQueue).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'maven',
+        name: 'org.example:demo',
+        version: '3.0.1',
       }),
     ]);
   });

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -161,6 +161,7 @@ async function preparePackagesForDownload(
   const shouldResolveTargetedRoots =
     !options.deps &&
     (CLI_ROOT_ARTIFACT_RESOLUTION_TYPES.has(options.type) ||
+      (options.type === 'maven' && packages.some((pkg) => pkg.version === 'latest')) ||
       (CLI_TARGET_ENVIRONMENT_TYPES.has(options.type) &&
         hasExplicitTargetEnvironment(options)));
 

--- a/src/core/resolver/maven-resolver.test.ts
+++ b/src/core/resolver/maven-resolver.test.ts
@@ -264,6 +264,144 @@ describe('MavenResolver 단위 테스트', () => {
     });
   });
 
+  describe('latest root version resolution', () => {
+    it('latest는 metadata의 concrete version으로 root POM과 artifact metadata를 조회한다', async () => {
+      const metadataGet = vi.fn().mockResolvedValue({
+        data: '<metadata><versioning><latest>3.0.2</latest><release>3.0.1</release></versioning></metadata>',
+      });
+      const head = vi.fn().mockResolvedValue({ headers: { 'content-length': '10' } });
+      (resolver as any).axiosInstance.get = metadataGet;
+      (resolver as any).axiosInstance.head = head;
+      fetchPomFromCacheMock.mockResolvedValue({
+        groupId: 'org.example',
+        artifactId: 'demo',
+        version: '3.0.2',
+        packaging: 'jar',
+      });
+
+      const result = await resolver.resolveDependencies('org.example:demo', 'latest', {
+        maxDepth: 0,
+        classifier: 'sources',
+        artifactType: 'jar',
+      });
+
+      expect(metadataGet).toHaveBeenCalledWith(
+        'https://repo1.maven.org/maven2/org/example/demo/maven-metadata.xml',
+      );
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groupId: 'org.example',
+          artifactId: 'demo',
+          version: '3.0.2',
+          classifier: 'sources',
+          type: 'jar',
+        }),
+        expect.any(Object),
+      );
+      expect(result.root.package.version).toBe('3.0.2');
+      expect(result.root.package.metadata).toMatchObject({
+        classifier: 'sources',
+        type: 'jar',
+        filename: 'demo-3.0.2-sources.jar',
+      });
+      expect(result.flatList).toHaveLength(1);
+      expect(head).toHaveBeenCalled();
+    });
+
+    it('latest의 concrete root로 전체 의존성 그래프를 해결한다', async () => {
+      const metadataGet = vi.fn().mockResolvedValue({
+        data: '<metadata><versioning><latest>3.0.2</latest></versioning></metadata>',
+      });
+      const head = vi.fn().mockResolvedValue({ headers: { 'content-length': '10' } });
+      (resolver as any).axiosInstance.get = metadataGet;
+      (resolver as any).axiosInstance.head = head;
+      fetchPomFromCacheMock.mockImplementation(async (coordinate) => {
+        if (coordinate.artifactId === 'demo' && coordinate.version === '3.0.2') {
+          return {
+            groupId: 'org.example',
+            artifactId: 'demo',
+            version: '3.0.2',
+            dependencies: {
+              dependency: {
+                groupId: 'org.example',
+                artifactId: 'child',
+                version: '1.0.0',
+              },
+            },
+          };
+        }
+        if (coordinate.artifactId === 'child' && coordinate.version === '1.0.0') {
+          return {
+            groupId: 'org.example',
+            artifactId: 'child',
+            version: '1.0.0',
+          };
+        }
+        throw new Error(`Unexpected POM: ${coordinate.groupId}:${coordinate.artifactId}:${coordinate.version}`);
+      });
+
+      const result = await resolver.resolveDependencies('org.example:demo', 'latest');
+
+      expect(result.flatList.map((pkg) => `${pkg.name}@${pkg.version}`).sort()).toEqual([
+        'org.example:child@1.0.0',
+        'org.example:demo@3.0.2',
+      ]);
+      expect(fetchPomFromCacheMock.mock.calls.map(([coordinate]) => coordinate.version)).not.toContain('latest');
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        expect.objectContaining({ artifactId: 'child', version: '1.0.0' }),
+        expect.any(Object),
+      );
+    });
+
+    it('latest가 없으면 release를 사용하고 metadata가 둘 다 비어 있으면 실패한다', async () => {
+      const metadataGet = vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: '<metadata><versioning><release>2.4.1</release></versioning></metadata>',
+        })
+        .mockResolvedValueOnce({
+          data: '<metadata><versioning><latest></latest><release></release></versioning></metadata>',
+        });
+      (resolver as any).axiosInstance.get = metadataGet;
+
+      await expect(resolver.getLatestVersion('org.example', 'release-only'))
+        .resolves.toBe('2.4.1');
+      await expect(resolver.getLatestVersion('org.example', 'empty-metadata'))
+        .rejects.toThrow('org.example:empty-metadata');
+      expect(metadataGet).toHaveBeenNthCalledWith(
+        1,
+        'https://repo1.maven.org/maven2/org/example/release-only/maven-metadata.xml',
+      );
+      expect(metadataGet).toHaveBeenNthCalledWith(
+        2,
+        'https://repo1.maven.org/maven2/org/example/empty-metadata/maven-metadata.xml',
+      );
+    });
+
+    it('명시 버전은 latest metadata를 조회하지 않는다', async () => {
+      const metadataGet = vi.fn();
+      const head = vi.fn().mockResolvedValue({ headers: { 'content-length': '10' } });
+      (resolver as any).axiosInstance.get = metadataGet;
+      (resolver as any).axiosInstance.head = head;
+      fetchPomFromCacheMock.mockResolvedValue({
+        groupId: 'org.example',
+        artifactId: 'demo',
+        version: '3.0.1',
+      });
+
+      const result = await resolver.resolveDependencies('org.example:demo', '3.0.1', {
+        maxDepth: 0,
+      });
+
+      expect(metadataGet).not.toHaveBeenCalled();
+      expect(result.root.package.version).toBe('3.0.1');
+      expect(fetchPomFromCacheMock).toHaveBeenCalledWith(
+        expect.objectContaining({ version: '3.0.1' }),
+        expect.any(Object),
+      );
+    });
+  });
+
   describe('resolveProperty (유틸리티 함수)', () => {
     it('빈 값은 그대로 반환', () => {
       expect(resolveProperty('')).toBe('');

--- a/src/core/resolver/maven-resolver.ts
+++ b/src/core/resolver/maven-resolver.ts
@@ -181,7 +181,7 @@ export class MavenResolver implements IResolver {
     const rootCoordinate: MavenCoordinate = {
       groupId,
       artifactId,
-      version,
+      version: version === 'latest' ? await this.getLatestVersion(groupId, artifactId) : version,
       // 사용자가 UI에서 선택한 classifier 사용
       classifier: opts.classifier,
       type: opts.artifactType,
@@ -205,7 +205,7 @@ export class MavenResolver implements IResolver {
     try {
       logger.info('Maven 의존성 해결 시작', {
         package: packageName,
-        version,
+        version: rootCoordinate.version,
         algorithm: opts.algorithm,
       });
 
@@ -450,9 +450,14 @@ export class MavenResolver implements IResolver {
     try {
       const response = await this.axiosInstance.get<string>(url);
       const parsed = this.parser.parse(response.data);
-      return (
-        parsed.metadata?.versioning?.latest || parsed.metadata?.versioning?.release || ''
-      );
+      const version = [
+        parsed.metadata?.versioning?.latest,
+        parsed.metadata?.versioning?.release,
+      ].find((candidate) => typeof candidate === 'string' && candidate.trim());
+      if (!version) {
+        throw new Error('Maven 메타데이터에 latest 또는 release 버전이 없습니다.');
+      }
+      return version.trim();
     } catch {
       throw new Error(`버전 조회 실패: ${groupId}:${artifactId}`);
     }


### PR DESCRIPTION
## 요약
Maven CLI의 `latest` 선택자가 literal POM/JAR 경로로 전달되던 문제를 수정했습니다.

Closes #72

## 변경 사항
- Maven root coordinate에서 `latest`를 `maven-metadata.xml`의 concrete latest/release 버전으로 해석
- 기본 Maven `--no-deps`도 latest root resolution 경로를 거치도록 조정
- latest/release가 모두 비어 있는 metadata를 명확한 resolution error로 거부
- 명시적 버전, classifier, max-depth 0 semantics는 유지
- 관련 CLI/resolver 테스트와 Maven 문서 업데이트

## 검증
- Target tests: 94 passed
- Full suite: 2,663 passed, 187 skipped
- TypeScript main/electron: PASS
- Lint: 0 errors, 2 pre-existing warnings
- 실제 CLI omitted-version full-deps: exit 0, `org.slf4j:slf4j-api` resolved to `2.1.0-alpha1`
- 실제 CLI `-V latest --no-deps`: exit 0, same concrete version
- Both archives: 1 root JAR, root POM plus parent/BOM POMs, 4 SHA-1 files, manifest 3 package records / 8 files; no literal `latest`
- Native Maven installation/build was not performed

Live evidence: `/Users/jonggeun/IdeaProjects/DepsSmuggler-audits/cli-fixes-20260909/issue-72/live/GREEN-summary.md`
