### PR TITLE
fix: 빈 패키지 파일 입력을 거부

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,7 +148,7 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
   --target-os linux --arch x86_64 --classifier natives-linux
 ```
 
-참고: `--file`은 현재 XML `pom.xml`이나 `package.json`을 직접 파싱하지 않고, 줄 단위 텍스트 입력만 처리합니다. Maven은 각 줄에 `groupId:artifactId[:version]` 형식으로 적어야 합니다. pip은 패키지명과 버전 제약을 읽지만 extras, 환경 마커, requirements 옵션을 완전하게 파싱하는 입력기는 아닙니다. 그 외 타입의 `name@version` 파서는 단순 `@` 분리이므로 npm scoped 패키지는 `-p @scope/name -V <version>`으로 지정합니다. 빈 줄과 `#`로 시작하는 주석 줄은 제외합니다.
+참고: `--file`은 현재 XML `pom.xml`이나 `package.json`을 직접 파싱하지 않고, 줄 단위 텍스트 입력만 처리합니다. Maven은 각 줄에 `groupId:artifactId[:version]` 형식으로 적어야 합니다. pip은 패키지명과 버전 제약을 읽지만 extras, 환경 마커, requirements 옵션을 완전하게 파싱하는 입력기는 아닙니다. 그 외 타입의 `name@version` 파서는 단순 `@` 분리이므로 npm scoped 패키지는 `-p @scope/name -V <version>`으로 지정합니다. 빈 줄과 `#`로 시작하는 주석 줄은 제외합니다. 파일에서 유효한 패키지가 하나도 남지 않으면 입력 오류로 종료하며 archive나 설치 스크립트를 만들지 않습니다.
 
 ### 현재 동작
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,6 +117,10 @@ bash scripts/verify-worktree.sh \
 
 이 fixture 검증은 실제 Maven Central의 현재 파일 존재 여부나 외부 Maven 실행의 오프라인 성공을 보장하지 않습니다. 외부 저장소 검증에는 아래 통합 테스트를 별도로 사용하고, 실행 명령·대상 좌표·파일 확인 결과를 해당 작업의 검증 기록에 남깁니다.
 
+### 빈 `--file` 입력 검증
+
+`src/cli/empty-package-file.integration.test.ts`는 빈 파일·공백만 있는 파일·주석만 있는 파일을 별도 Node.js 프로세스에서 실행합니다. 테스트 전용 user directory와 경로에 공백이 있는 출력 디렉터리를 사용하며, 입력 오류가 종료 코드 `1`을 반환하고 archive와 설치 스크립트를 만들지 않는지 확인합니다. 단위 테스트는 parser 결과가 비어 있을 때 resolver, 출력 디렉터리, 다운로드 큐, archive, script generator가 호출되지 않는 순서를 검증합니다.
+
 ### CLI 다운로드 실패 종료 코드 검증
 
 `src/cli/download-failure-exit.integration.test.ts`는 별도 Node.js 프로세스에서 실제 CLI 엔트리포인트와 Commander 인자를 실행합니다. 부모 프로세스의 로컬 HTTP 서버가 404를 반환하고, 자식의 테스트 전용 설정이 실제 `MavenDownloader`의 저장소 주소만 이 서버로 연결합니다. 실제 다운로드 매니저가 실패 결과를 반환한 뒤 CLI가 종료 코드 `1`과 실패 원인을 남기고, 새 아카이브와 설치 스크립트를 생성하지 않는지 확인합니다. 설정·로그·출력은 임시 디렉터리로 격리하며 외부 레지스트리에 연결하지 않습니다.

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -1173,4 +1173,35 @@ describe('downloadCommand', () => {
       }),
     ]);
   });
+
+  it.each([
+    ['빈 파일', ''],
+    ['공백만 있는 파일', '\n \n\t'],
+    ['주석만 있는 파일', '# comment only\n\n  # another comment\n'],
+  ])('%s는 resolver와 출력 부수 효과 전에 입력 오류로 거부한다', async (_name, content) => {
+    readFile.mockResolvedValueOnce(content);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+
+    try {
+      await expect(downloadCommand(commandOptions({
+        file: 'empty-packages.txt',
+        package: undefined,
+        deps: false,
+      }))).rejects.toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(resolveAllDependencies).not.toHaveBeenCalled();
+      expect(ensureDir).not.toHaveBeenCalled();
+      expect(addToQueue).not.toHaveBeenCalled();
+      expect(startDownload).not.toHaveBeenCalled();
+      expect(createArchive).not.toHaveBeenCalled();
+      expect(generateAllScripts).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
 });

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -269,6 +269,9 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
     if (options.file) {
       // 파일에서 패키지 목록 읽기
       packages = await parsePackageFile(options.file, options.type);
+      if (packages.length === 0) {
+        throw new Error('--file에 다운로드할 패키지가 없습니다.');
+      }
       console.log(chalk.green(`${packages.length}개 패키지를 파일에서 로드했습니다`));
     } else if (options.package) {
       // 단일 패키지

--- a/src/cli/empty-package-file.integration.test.ts
+++ b/src/cli/empty-package-file.integration.test.ts
@@ -1,0 +1,78 @@
+import { execFile } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as fs from 'fs-extra';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+const childHarness = `
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+require(path.join(projectRoot, 'node_modules/ts-node')).register({ project: path.join(projectRoot, 'tsconfig.cli.json') });
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  'download',
+  '--type', process.env.DEPS_SMUGGLER_TYPE,
+  '--file', process.env.DEPS_SMUGGLER_INPUT,
+  '--output', process.env.DEPS_SMUGGLER_OUTPUT,
+  '--format', 'zip',
+  '--no-deps',
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+describe('empty --file CLI preflight', () => {
+  it.each(
+    ['maven', 'npm', 'pip'].flatMap((type) => [
+      [type, 'empty', ''],
+      [type, 'whitespace', '\n \n\t'],
+      [type, 'comments', '# comment only\n\n  # another comment\n'],
+    ]),
+  )('%s rejects %s input before creating delivery artifacts', async (type, _name, content) => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-issue-73-'));
+    const output = path.join(tempRoot, 'output with spaces');
+    const isolatedHome = path.join(tempRoot, 'isolated user directory');
+    const input = path.join(tempRoot, 'empty packages.txt');
+    const harnessPath = path.join(tempRoot, 'empty-file-harness.cjs');
+    await fs.ensureDir(isolatedHome);
+    await fs.writeFile(input, content);
+    await fs.writeFile(harnessPath, childHarness);
+
+    try {
+      let child: { code: number; stdout: string; stderr: string };
+      try {
+        const result = await execFileAsync(process.execPath, [harnessPath], {
+          cwd: projectRoot,
+          env: {
+            ...process.env,
+            DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+            DEPS_SMUGGLER_TYPE: type,
+            DEPS_SMUGGLER_INPUT: input,
+            DEPS_SMUGGLER_OUTPUT: output,
+            DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+            NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+          },
+          timeout: 120_000,
+        });
+        child = { code: 0, stdout: result.stdout, stderr: result.stderr };
+      } catch (error) {
+        const failure = error as typeof error & { code?: number; stdout?: string; stderr?: string };
+        child = {
+          code: typeof failure.code === 'number' ? failure.code : -1,
+          stdout: failure.stdout ?? '',
+          stderr: failure.stderr ?? '',
+        };
+      }
+
+      expect(child.code).toBe(1);
+      expect(`${child.stdout}\n${child.stderr}`).toContain('다운로드할 패키지가 없습니다');
+      expect(await fs.pathExists(output)).toBe(false);
+    } finally {
+      await fs.remove(tempRoot);
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
## 요약
빈 패키지 목록 파일을 성공적인 빈 bundle로 처리하지 않고 입력 오류로 거부합니다.

Closes #73

## 변경 사항
- `parsePackageFile` 결과가 비어 있으면 resolver, output, queue, archive, script 단계 전에 종료 코드 1로 실패
- 빈 파일·공백-only·주석-only 입력의 ordering unit regression 추가
- Maven/npm/pip × 3 empty-input 형태의 실제 CLI subprocess regression 추가
- `--file` 입력 규칙과 테스트 문서 갱신

## 검증
- Target: 48 passed (39 command tests + 9 subprocess cases)
- Full local baseline before final 3-type matrix expansion: 2,669 passed, 187 skipped
- TypeScript main/electron: PASS
- Changed-file lint: 0 errors
- Node 20 actual CLI: Maven/npm/pip × empty/whitespace/comment all exit 1; output directory and archive/install artifacts absent
- Paths with spaces and isolated `DEPS_SMUGGLER_TEST_USER_DIR` covered
- No native package-manager installation or registry access required
