### PR TITLE
fix: Rocky YUM 메타데이터 파싱 실패를 명시적으로 처리

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,6 +217,7 @@ depssmuggler os search bash --distro ubuntu-22.04 --arch amd64
 
 - 배포판 ID와 아키텍처를 기준으로 저장소 메타데이터를 직접 조회합니다.
 - 배포판별 parser는 shared shim(`src/core/shared/{yum,apt,apk}-metadata-parser.ts`)을 통해 사용합니다.
+- YUM 저장소의 메타데이터 조회·파싱에 실패하거나 활성 저장소에 primary 메타데이터가 없으면 저장소 이름과 원인을 표시하고 종료 코드 `1`을 반환합니다. 일부 저장소만 읽은 결과를 정상 검색 목록으로 반환하지 않습니다. 정상적으로 읽은 목록에서 일치하는 패키지가 없는 경우에는 빈 검색 결과로 종료합니다.
 - `-d, --distro`는 필수이고, `-a, --arch` 기본값은 `x86_64`, `-l, --limit` 기본값은 `20`입니다. APT 배포판에는 예시처럼 `amd64` 등 해당 프리셋이 지원하는 아키텍처를 명시해야 합니다.
 
 ### `os download`
@@ -233,6 +234,7 @@ depssmuggler os download bash --distro ubuntu-22.04 --arch amd64 --format reposi
 - `--archive-format zip|tar.gz`로 압축 형식을 선택하며 기본값은 `zip`입니다. `--no-deps`는 의존성 해결을 끕니다.
 - `-d, --distro`는 필수입니다. `--arch` 기본값은 `x86_64`, `-o, --output`은 `./os-packages`, `--concurrency`는 `3`입니다.
 - OS 메타데이터 캐시는 `<cachePath>/os-packages` 아래 persistent JSON 파일로 관리됩니다. 기본 경로는 `~/.depssmuggler/cache/os-packages`이며 CLI 설정의 `cachePath`와 `cacheEnabled`를 따릅니다.
+- YUM의 메타데이터 로딩 실패는 다운로드에서도 원인을 포함한 오류로 전달됩니다. 같은 resolver에서 재시도할 때 실패 직전의 일부 패키지 목록을 완성된 목록으로 재사용하지 않으며, 정상 저장된 저장소별 디스크 캐시는 재사용할 수 있습니다.
 
 ### `os cache`
 

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -485,6 +485,8 @@ const downloadResult = await downloadOSPackages({
 | `searchPackages(query)` | 패키지 검색 |
 | `getPackageVersions(name)` | 버전 목록 조회 |
 
+YUM XML 파서는 표준 엔티티 디코딩을 유지하며 전체 치환 횟수와 DTD 선언·확장 크기에 유한한 제한을 적용합니다. 큰 Rocky primary XML의 정상 파싱과 한도 초과 오류를 함께 검증합니다. 로딩 실패는 resolver에서 검색·다운로드 호출자에게 전달하며, 상세 제한과 캐시 반영 규칙은 [OS 패키지 문서](os-package-downloader.md#메타데이터-파싱-yummetadataparser)를 참고하세요.
+
 ### 타입 정의
 
 | 타입 | 설명 |

--- a/docs/os-package-downloader.md
+++ b/docs/os-package-downloader.md
@@ -300,6 +300,10 @@ console.log(downloadResult.downloadedFiles);
 
 #### 메타데이터 파싱 (YumMetadataParser)
 
+Rocky의 큰 primary XML에 포함된 표준 엔티티를 처리하도록 `fast-xml-parser`의 엔티티 처리를 유지하면서 파서가 집계하는 치환 횟수를 100,000회로 제한합니다. DTD 선언 수 100개, 단일 엔티티 크기 10,000, DTD 치환에 따른 누적 확장 길이 100,000의 기존 제한도 명시적으로 유지합니다. `&amp;` 같은 표준 XML 값은 디코딩되며, 제한을 넘는 입력은 파싱 오류로 보고합니다. 이 값은 전체 XML이나 압축 해제 크기의 상한이 아닙니다.
+
+`YumDependencyResolver`는 모든 활성 저장소의 로딩이 성공한 뒤 패키지·provides 인덱스를 반영합니다. primary 누락이나 조회·파싱 실패를 빈 검색 결과로 숨기지 않으며, 실패한 시도의 일부 목록은 다음 재시도에서 사용하지 않습니다. 정상적으로 저장한 저장소별 디스크 캐시는 재사용합니다.
+
 ```typescript
 interface RepomdInfo {
   revision: string;

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -658,6 +658,8 @@ YUM/APT/APK의 후보 병합은 호출별 `Set`으로 기존 패키지 키의 �
 
 실제 클래스명은 `YumDependencyResolver`이며 `YumResolver`는 호환성 alias입니다. `BaseOSDependencyResolver`를 상속하고 생성자에서 `DependencyResolverOptions`를 받습니다.
 
+메타데이터는 모든 활성 저장소의 조회·파싱이 성공한 뒤 메모리 목록과 이름/provides 인덱스에 반영합니다. primary 누락이나 저장소 오류가 있으면 저장소 이름과 원인을 포함한 오류를 전달하며, 취소 오류는 유지합니다. 실패 시 일부 패키지가 로드 완료 상태로 남지 않아 같은 인스턴스의 재시도가 가능합니다. 파서는 각 저장소를 읽을 때 생성하며 사용하지 않는 인스턴스 맵은 보관하지 않습니다. 비활성 저장소는 조회하지 않으며 정상적인 저장소별 디스크 캐시는 재시도에서 재사용할 수 있습니다.
+
 | 메서드 | 파라미터 | 반환값 | 설명 |
 |--------|----------|--------|------|
 | `searchPackages` | query, matchType? | Promise<OSPackageSearchResult[]> | 이름별 검색 |
@@ -677,7 +679,6 @@ YUM/APT/APK의 후보 병합은 호출별 `Set`으로 기존 패키지 키의 �
 
 | 속성 | 타입 | 설명 |
 |------|------|------|
-| `parsers` | Map<string, YumMetadataParser> | 저장소별 파서 |
 | `allPackages` | OSPackageInfo[] | 호환 아키텍처의 패키지 목록 |
 | `providesMap` | Map<string, OSPackageInfo[]> | capability 제공자 인덱스 |
 | `metadataCache` (상속) | PackageMetadataCache | 이름별 패키지 목록 |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -121,6 +121,18 @@ bash scripts/verify-worktree.sh \
 
 `src/cli/empty-package-file.integration.test.ts`는 빈 파일·공백만 있는 파일·주석만 있는 파일을 별도 Node.js 프로세스에서 실행합니다. 테스트 전용 user directory와 경로에 공백이 있는 출력 디렉터리를 사용하며, 입력 오류가 종료 코드 `1`을 반환하고 archive와 설치 스크립트를 만들지 않는지 확인합니다. 단위 테스트는 parser 결과가 비어 있을 때 resolver, 출력 디렉터리, 다운로드 큐, archive, script generator가 호출되지 않는 순서를 검증합니다.
 
+### YUM 메타데이터와 검색 오류 검증
+
+`src/core/downloaders/os-metadata-parsers.test.ts`는 실제 gzip XML 파서에 1,001개의 표준 엔티티를 전달해 정상 디코딩을 확인하고, 100,000회 한도 초과 및 취소 오류 전달을 검증합니다. `src/core/resolver/os-resolvers.test.ts`는 primary 누락, 비활성 저장소 제외, 뒤쪽 저장소 실패 후 일부 목록이 남지 않는지와 동일 resolver 재시도를 확인합니다.
+
+`src/cli/yum-metadata-failure.integration.test.ts`는 로컬 HTTP 서버의 repomd/primary XML을 실제 자식 CLI로 읽습니다. XML 제한 초과 시 저장소·원인과 종료 코드 `1`이 전달되고 빈 검색 성공으로 바뀌지 않아야 합니다. 이 세 파일은 외부 저장소 없이 기본 테스트에서 실행합니다.
+
+`src/core/downloaders/yum.integration.test.ts`는 현재 OS backend API로 실제 Rocky Linux 9 저장소의 `zlib` 검색(limit 3)과 의존성 없는 RPM ZIP 다운로드를 검증합니다. 오래된 다운로더 API와 조용한 조기 성공 처리를 제거했으며, 아래 명령으로 명시적으로 실행합니다. 외부 네트워크를 사용하고 임시 캐시·출력을 정리합니다. 네이티브 Yum/RPM 설치 트랜잭션을 수행하는 테스트는 아닙니다.
+
+```bash
+INTEGRATION_TEST=true bash scripts/verify-worktree.sh src/core/downloaders/yum.integration.test.ts
+```
+
 ### CLI 다운로드 실패 종료 코드 검증
 
 `src/cli/download-failure-exit.integration.test.ts`는 별도 Node.js 프로세스에서 실제 CLI 엔트리포인트와 Commander 인자를 실행합니다. 부모 프로세스의 로컬 HTTP 서버가 404를 반환하고, 자식의 테스트 전용 설정이 실제 `MavenDownloader`의 저장소 주소만 이 서버로 연결합니다. 실제 다운로드 매니저가 실패 결과를 반환한 뒤 CLI가 종료 코드 `1`과 실패 원인을 남기고, 새 아카이브와 설치 스크립트를 생성하지 않는지 확인합니다. 설정·로그·출력은 임시 디렉터리로 격리하며 외부 레지스트리에 연결하지 않습니다.

--- a/src/cli/yum-metadata-failure.integration.test.ts
+++ b/src/cli/yum-metadata-failure.integration.test.ts
@@ -1,0 +1,204 @@
+import { execFile } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import { gzipSync } from 'node:zlib';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+
+const childHarness = `
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+require(path.join(projectRoot, 'node_modules/ts-node')).register({
+  project: path.join(projectRoot, 'tsconfig.cli.json'),
+});
+
+// Load the repository index first: its module initialization installs the
+// built-in distribution reference before the child replaces it with the
+// loopback fixture below.
+require(path.join(projectRoot, 'src/core/downloaders/os-shared/repos/index.ts'));
+const { setDistributionsRef } = require(
+  path.join(projectRoot, 'src/core/downloaders/os-shared/repos/repository-utils.ts')
+);
+setDistributionsRef([
+  {
+    id: 'fixture-yum',
+    name: 'Fixture YUM',
+    version: '9',
+    packageManager: 'yum',
+    architectures: ['x86_64'],
+    defaultRepos: [{
+      id: 'fixture-yum-repo',
+      name: 'Fixture YUM Repository',
+      baseUrl: process.env.DEPS_SMUGGLER_YUM_REPO_URL,
+      enabled: true,
+      gpgCheck: false,
+      isOfficial: false,
+    }],
+    extendedRepos: [],
+  },
+], []);
+
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  'os',
+  'search',
+  'zlib',
+  '--distro',
+  'fixture-yum',
+  '--arch',
+  'x86_64',
+  '--limit',
+  '3',
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('loopback server did not expose a port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function primaryFixture(): Buffer {
+  const countedEntities = '&quot;'.repeat(100_001);
+  const xml = [
+    '<metadata packages="1">',
+    '  <package type="rpm">',
+    '    <name>zlib</name>',
+    '    <arch>x86_64</arch>',
+    '    <version epoch="0" ver="1.2.11" rel="1.el9" />',
+    '    <checksum type="sha256">fixture-checksum</checksum>',
+    '    <summary>Fixture zlib</summary>',
+    `    <description>${countedEntities}</description>`,
+    '    <size package="1" installed="1" />',
+    '    <location href="Packages/z/zlib-1.2.11-1.el9.x86_64.rpm" />',
+    '    <format />',
+    '  </package>',
+    '</metadata>',
+  ].join('\n');
+  return gzipSync(Buffer.from(xml, 'utf8'));
+}
+
+function repomdFixture(): string {
+  return [
+    '<repomd>',
+    '  <revision>fixture-revision</revision>',
+    '  <data type="primary">',
+    '    <checksum type="sha256">fixture-checksum</checksum>',
+    '    <location href="repodata/primary.xml.gz" />',
+    '  </data>',
+    '</repomd>',
+  ].join('\n');
+}
+
+describe('YUM metadata parser CLI failure propagation', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await fs.remove(tempRoot);
+    tempRoot = undefined;
+  });
+
+  it('returns nonzero instead of empty-success when primary XML exceeds entity limit', async () => {
+    const requests: string[] = [];
+    const primary = primaryFixture();
+    const server = createServer((request, response) => {
+      requests.push(request.url ?? '');
+      if (request.url === '/fixture/repodata/repomd.xml') {
+        response.writeHead(200, { 'content-type': 'application/xml' });
+        response.end(repomdFixture());
+        return;
+      }
+      if (request.url === '/fixture/repodata/primary.xml.gz') {
+        response.writeHead(200, {
+          'content-type': 'application/gzip',
+          'content-length': primary.byteLength,
+        });
+        response.end(primary);
+        return;
+      }
+      response.writeHead(404);
+      response.end('fixture not found');
+    });
+    const port = await listen(server);
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-issue-74-'));
+    const isolatedHome = path.join(tempRoot, 'isolated user directory');
+    const harnessPath = path.join(tempRoot, 'yum-metadata-failure-harness.cjs');
+    await fs.ensureDir(isolatedHome);
+    await fs.writeFile(harnessPath, childHarness);
+
+    try {
+      let child: {
+        code: number;
+        signal: string | null;
+        timedOut: boolean;
+        stdout: string;
+        stderr: string;
+      };
+      try {
+        const result = await execFileAsync(process.execPath, [harnessPath], {
+          cwd: projectRoot,
+          env: {
+            ...process.env,
+            DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+            DEPS_SMUGGLER_YUM_REPO_URL: `http://127.0.0.1:${port}/fixture`,
+            DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+            NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+          },
+          timeout: 180_000,
+        });
+        child = {
+          code: 0,
+          signal: null,
+          timedOut: false,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        };
+      } catch (error) {
+        const failure = error as typeof error & {
+          code?: number;
+          killed?: boolean;
+          signal?: string | null;
+          stdout?: string;
+          stderr?: string;
+        };
+        child = {
+          code: typeof failure.code === 'number' ? failure.code : -1,
+          signal: failure.signal ?? null,
+          timedOut: failure.killed === true,
+          stdout: failure.stdout ?? '',
+          stderr: failure.stderr ?? '',
+        };
+      }
+
+      const outputText = `${child.stdout}\n${child.stderr}`;
+      expect(child.code, outputText).toBe(1);
+      expect(child.signal).toBeNull();
+      expect(child.timedOut).toBe(false);
+      expect(outputText).toContain('Fixture YUM Repository');
+      expect(outputText).toContain('Entity expansion limit exceeded');
+      expect(outputText).not.toContain('검색 결과가 없습니다.');
+      expect(requests).toEqual([
+        '/fixture/repodata/repomd.xml',
+        '/fixture/repodata/primary.xml.gz',
+      ]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }, 240_000);
+});

--- a/src/core/downloaders/os-metadata-parsers.test.ts
+++ b/src/core/downloaders/os-metadata-parsers.test.ts
@@ -16,6 +16,31 @@ describe('OS metadata parsers', () => {
     isOfficial: true,
   };
 
+  const createYumRepomdXml = (): string => [
+    '<repomd>',
+    '  <revision>123</revision>',
+    '  <data type="primary">',
+    '    <checksum type="sha256">deadbeef</checksum>',
+    '    <location href="repodata/primary.xml.gz" />',
+    '  </data>',
+    '</repomd>',
+  ].join('');
+
+  const createYumPrimaryXml = (description: string, summary: string): string => [
+    '<metadata>',
+    '  <package>',
+    '    <name>zlib</name>',
+    '    <arch>x86_64</arch>',
+    '    <version epoch="0" ver="1.2.13" rel="1.el9" />',
+    '    <checksum type="sha256">feedface</checksum>',
+    `    <summary>${summary}</summary>`,
+    `    <description>${description}</description>`,
+    '    <size package="4096" installed="8192" />',
+    '    <location href="Packages/z/zlib.rpm" />',
+    '  </package>',
+    '</metadata>',
+  ].join('');
+
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal('fetch', fetchMock);
@@ -173,7 +198,8 @@ describe('OS metadata parsers', () => {
       .mockResolvedValueOnce(new Response(gzipSync(primaryXml)));
 
     const repomd = await parser.parseRepomd();
-    const packages = await parser.parsePrimary(repomd.primary!.location);
+    expect(repomd.primary).toBeDefined();
+    const packages = await parser.parsePrimary(repomd.primary?.location ?? '');
 
     expect(repomd).toEqual(
       expect.objectContaining({
@@ -211,5 +237,75 @@ describe('OS metadata parsers', () => {
         ],
       }),
     ]);
+  });
+
+  it('YUM parser는 1000개를 초과하는 표준 entity와 amp entity를 보존해 파싱한다', async () => {
+    const parser = new YumMetadataParser(
+      {
+        ...repo,
+        id: 'rocky-9-baseos',
+        baseUrl: 'https://mirror.example.test/$releasever/BaseOS/$basearch/os',
+      },
+      'x86_64'
+    );
+    const expandedDescription = '"'.repeat(1001);
+    fetchMock
+      .mockResolvedValueOnce(new Response(createYumRepomdXml()))
+      .mockResolvedValueOnce(
+        new Response(gzipSync(createYumPrimaryXml('&quot;'.repeat(1001), 'Rocky &amp; BaseOS')))
+      );
+
+    const repomd = await parser.parseRepomd();
+    expect(repomd.primary).toBeDefined();
+    const packages = await parser.parsePrimary(repomd.primary?.location ?? '');
+
+    expect(packages).toEqual([
+      expect.objectContaining({
+        name: 'zlib',
+        summary: 'Rocky & BaseOS',
+        description: expandedDescription,
+      }),
+    ]);
+  });
+
+  it('YUM parser는 유한 entity expansion 한도를 초과하면 실패한다', async () => {
+    const parser = new YumMetadataParser(
+      {
+        ...repo,
+        id: 'rocky-9-baseos',
+        baseUrl: 'https://mirror.example.test/$releasever/BaseOS/$basearch/os',
+      },
+      'x86_64'
+    );
+    fetchMock
+      .mockResolvedValueOnce(new Response(createYumRepomdXml()))
+      .mockResolvedValueOnce(
+        new Response(gzipSync(createYumPrimaryXml('&quot;'.repeat(100001), 'Rocky &amp; BaseOS')))
+      );
+
+    const repomd = await parser.parseRepomd();
+    expect(repomd.primary).toBeDefined();
+
+    await expect(parser.parsePrimary(repomd.primary?.location ?? '')).rejects.toThrow(/100000/);
+  });
+
+  it.each(['repomd', 'primary'] as const)('YUM parser는 %s fetch의 AbortError identity를 보존한다', async (target) => {
+    const parser = new YumMetadataParser(
+      {
+        ...repo,
+        id: 'rocky-9-baseos',
+        baseUrl: 'https://mirror.example.test/$releasever/BaseOS/$basearch/os',
+      },
+      'x86_64'
+    );
+    const abortError = new Error(`cancelled ${target}`);
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValueOnce(abortError);
+
+    const parse = target === 'repomd'
+      ? parser.parseRepomd()
+      : parser.parsePrimary('repodata/primary.xml.gz');
+
+    await expect(parse).rejects.toBe(abortError);
   });
 });

--- a/src/core/downloaders/yum.integration.test.ts
+++ b/src/core/downloaders/yum.integration.test.ts
@@ -1,202 +1,123 @@
 /**
- * YUM/RPM 다운로더 통합 테스트
- *
- * 실제 YUM 리포지토리 API를 호출하여 패키지 조회 및 다운로드 기능을 테스트합니다.
+ * 실제 Rocky Linux YUM metadata/API 통합 테스트
  *
  * 실행 방법:
  *   INTEGRATION_TEST=true npm test -- yum.integration.test.ts
  *
- * 테스트 케이스:
- *   - curl: 의존성 5-6개, ~300KB
- *   - which: 작은 패키지
- *   - 존재하지 않는 패키지 처리
+ * 기본 테스트에서는 네트워크를 사용하지 않도록 전체 suite를 skip한다.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { YumDownloader } from './yum';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import * as yauzl from 'yauzl';
+import { downloadOSPackages, searchOSPackages } from './os-shared/cli-backend';
+import { getDistributionById } from './os-shared/repositories';
 
 const INTEGRATION_TEST = process.env.INTEGRATION_TEST === 'true';
 const describeIntegration = INTEGRATION_TEST ? describe : describe.skip;
 
-describeIntegration('YUM/RPM 통합 테스트', () => {
-  let downloader: YumDownloader;
+function listZipEntries(archivePath: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    yauzl.open(archivePath, { lazyEntries: true }, (error, zipFile) => {
+      if (error || !zipFile) {
+        reject(error ?? new Error('ZIP archive could not be opened'));
+        return;
+      }
+
+      const entries: string[] = [];
+      zipFile.readEntry();
+      zipFile.on('entry', (entry) => {
+        entries.push(entry.fileName);
+        zipFile.readEntry();
+      });
+      zipFile.once('end', () => {
+        zipFile.close();
+        resolve(entries);
+      });
+      zipFile.once('error', (zipError) => {
+        zipFile.close();
+        reject(zipError);
+      });
+    });
+  });
+}
+
+describeIntegration('Rocky Linux 9 YUM metadata and archive integration', () => {
+  const distribution = getDistributionById('rocky-9');
   let tempDir: string;
 
-  // Rocky Linux 9 테스트용 리포지토리
-  const testRepos = [
-    {
-      id: 'baseos',
-      name: 'Rocky Linux 9 - BaseOS',
-      baseUrl: 'https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/'
-    },
-    {
-      id: 'appstream',
-      name: 'Rocky Linux 9 - AppStream',
-      baseUrl: 'https://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/'
+  afterAll(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
     }
-  ];
-
-  beforeAll(() => {
-    downloader = new YumDownloader(testRepos);
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yum-integration-test-'));
   });
 
-  afterAll(() => {
-    if (tempDir && fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
+  it('finds zlib from real metadata with a bounded search result', async () => {
+    if (!distribution) throw new Error('rocky-9 distribution is not configured');
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-yum-integration-'));
+
+    const results = await searchOSPackages({
+      distribution,
+      architecture: 'x86_64',
+      query: 'zlib',
+      limit: 3,
+      cacheDirectory: path.join(tempDir, 'cache'),
+      cacheEnabled: true,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(3);
+    const zlib = results.find((result) => result.name === 'zlib');
+    expect(zlib).toBeDefined();
+    expect(zlib?.latest.name).toBe('zlib');
+    expect(zlib?.latest.architecture).toBe('x86_64');
+    expect(zlib?.latest.version).toBeTruthy();
+    expect(zlib?.latest.release).toBeTruthy();
+    expect(zlib?.latest.checksum.value).toMatch(/^[a-f0-9]+$/i);
+  }, 300_000);
+
+  it('downloads the real zlib RPM into a ZIP without dependency expansion', async () => {
+    if (!distribution) throw new Error('rocky-9 distribution is not configured');
+    if (!tempDir) {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-yum-integration-'));
     }
-    downloader.clearCache();
-  });
+    const outputPath = path.join(tempDir, 'download-output');
 
-  describe('정상 케이스 - which 패키지', () => {
-    it('which 패키지 검색', async () => {
-      const results = await downloader.searchPackages('which');
-
-      expect(results).toBeDefined();
-      expect(results.length).toBeGreaterThan(0);
-
-      const which = results.find(p => p.name === 'which');
-      expect(which).toBeDefined();
-    }, 120000);
-
-    it('which 버전 목록 조회', async () => {
-      const versions = await downloader.getVersions('which');
-
-      expect(versions).toBeDefined();
-      expect(versions.length).toBeGreaterThan(0);
+    const result = await downloadOSPackages({
+      distribution,
+      architecture: 'x86_64',
+      packageNames: ['zlib'],
+      outputPath,
+      outputType: 'archive',
+      archiveFormat: 'zip',
+      resolveDependencies: false,
+      includeScripts: false,
+      concurrency: 1,
+      cacheDirectory: path.join(tempDir, 'cache'),
+      cacheEnabled: true,
     });
 
-    it('which 메타데이터 조회', async () => {
-      const versions = await downloader.getVersions('which');
-      if (versions.length === 0) {
-        console.warn('which 버전을 찾을 수 없습니다');
-        return;
-      }
+    expect(result.requestedPackages).toHaveLength(1);
+    expect(result.requestedPackages[0].name).toBe('zlib');
+    expect(result.requestedPackages[0].architecture).toBe('x86_64');
+    expect(result.requestedPackages[0].version).toBeTruthy();
+    expect(result.requestedPackages[0].release).toBeTruthy();
+    expect(result.requestedPackages[0].checksum.value).toMatch(/^[a-f0-9]+$/i);
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].name).toBe('zlib');
+    expect(result.unresolved).toEqual([]);
+    expect(result.artifacts).toHaveLength(1);
 
-      const metadata = await downloader.getPackageMetadata('which', versions[0]);
-
-      expect(metadata).toBeDefined();
-      expect(metadata.name).toBe('which');
-      expect(metadata.metadata).toBeDefined();
-      expect(metadata.metadata?.downloadUrl).toBeDefined();
-    });
-
-    it('which 패키지 다운로드', async () => {
-      const outputDir = path.join(tempDir, 'which');
-      fs.mkdirSync(outputDir, { recursive: true });
-
-      const versions = await downloader.getVersions('which');
-      if (versions.length === 0) {
-        console.warn('which 버전을 찾을 수 없습니다');
-        return;
-      }
-
-      const metadata = await downloader.getPackageMetadata('which', versions[0]);
-
-      const filePath = await downloader.downloadPackage(
-        {
-          type: 'yum',
-          name: 'which',
-          version: versions[0],
-          metadata: metadata.metadata
-        },
-        outputDir
-      );
-
-      expect(filePath).toBeDefined();
-      expect(fs.existsSync(filePath)).toBe(true);
-
-      // .rpm 파일
-      expect(filePath.endsWith('.rpm')).toBe(true);
-    }, 120000);
-  });
-
-  describe('정상 케이스 - bash 패키지', () => {
-    it('bash 검색', async () => {
-      const results = await downloader.searchPackages('bash');
-
-      expect(results).toBeDefined();
-      expect(results.length).toBeGreaterThan(0);
-
-      const bash = results.find(p => p.name === 'bash');
-      expect(bash).toBeDefined();
-    });
-
-    it('bash 버전 조회', async () => {
-      const versions = await downloader.getVersions('bash');
-
-      expect(versions).toBeDefined();
-      expect(versions.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('존재하지 않는 패키지 처리', () => {
-    it('존재하지 않는 패키지 검색 시 빈 배열 반환', async () => {
-      const results = await downloader.searchPackages('nonexistent-rpm-package-xyz-12345');
-
-      expect(results).toBeDefined();
-      expect(results.length).toBe(0);
-    });
-
-    it('존재하지 않는 패키지 버전 조회', async () => {
-      const versions = await downloader.getVersions('nonexistent-rpm-package-xyz-12345');
-
-      expect(versions).toBeDefined();
-      expect(versions.length).toBe(0);
-    });
-  });
-
-  describe('리포지토리 관리', () => {
-    it('기본 리포지토리 목록 조회', () => {
-      // getDefaultRepos는 Record<string, string>을 반환함
-      const repos = downloader.getDefaultRepos();
-
-      expect(repos).toBeDefined();
-      expect(Object.keys(repos).length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('캐시 관리', () => {
-    it('캐시 초기화', () => {
-      downloader.clearCache();
-      // 에러 없이 완료되면 성공
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('진행 콜백', () => {
-    it('다운로드 진행 콜백 호출', async () => {
-      const outputDir = path.join(tempDir, 'progress-test');
-      fs.mkdirSync(outputDir, { recursive: true });
-
-      const versions = await downloader.getVersions('which');
-      if (versions.length === 0) {
-        console.warn('which 버전을 찾을 수 없습니다');
-        return;
-      }
-
-      const metadata = await downloader.getPackageMetadata('which', versions[0]);
-
-      let progressCalled = false;
-
-      const filePath = await downloader.downloadPackage(
-        {
-          type: 'yum',
-          name: 'which',
-          version: versions[0],
-          metadata: metadata.metadata
-        },
-        outputDir,
-        (progress) => {
-          progressCalled = true;
-        }
-      );
-
-      expect(filePath).toBeDefined();
-      expect(progressCalled).toBe(true);
-    }, 120000);
-  });
+    const archivePath = result.artifacts[0].path;
+    const entries = await listZipEntries(archivePath);
+    const rpmEntries = entries.filter((entry) => entry.toLowerCase().endsWith('.rpm'));
+    expect(rpmEntries).toHaveLength(1);
+    expect(rpmEntries[0]).toContain('zlib-');
+    expect(rpmEntries[0]).toContain(result.packages[0].version);
+    expect(rpmEntries[0]).toContain(result.packages[0].architecture);
+    const archiveStats = await fs.stat(archivePath);
+    expect(archiveStats.isFile()).toBe(true);
+  }, 300_000);
 });

--- a/src/core/downloaders/yum.ts
+++ b/src/core/downloaders/yum.ts
@@ -77,6 +77,14 @@ export class YumMetadataParser {
       textNodeName: '#text',
       parseAttributeValue: true,
       trimValues: true,
+      processEntities: {
+        enabled: true,
+        // Rocky primary XML의 표준 엔티티도 치환 횟수에 포함됩니다.
+        maxTotalExpansions: 100_000,
+        maxEntityCount: 100,
+        maxEntitySize: 10_000,
+        maxExpandedLength: 100_000,
+      },
     });
   }
 
@@ -188,6 +196,9 @@ export class YumMetadataParser {
 
       return result;
     } catch (error) {
+      if ((error as { name?: string })?.name === 'AbortError') {
+        throw error;
+      }
       throw new Error(`Failed to parse repomd.xml from ${repomdUrl}: ${(error as Error).message}`);
     }
   }
@@ -256,6 +267,9 @@ export class YumMetadataParser {
 
       return packages;
     } catch (error) {
+      if ((error as { name?: string })?.name === 'AbortError') {
+        throw error;
+      }
       throw new Error(
         `Failed to parse primary.xml from ${primaryUrl}: ${(error as Error).message}`
       );

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -162,33 +162,72 @@ describe('OS dependency resolvers', () => {
     expect(byCmd[0].architecture).toBe('x86_64');
   });
 
-  it('YUM resolver는 primary 메타데이터가 없는 저장소를 건너뛰고 라이브러리 provides를 찾는다', async () => {
-    const parseRepomd = vi
-      .spyOn(YumMetadataParser.prototype, 'parseRepomd')
-      .mockResolvedValueOnce({
-        revision: '1',
-        primary: null,
-        filelists: null,
-        other: null,
-      })
-      .mockResolvedValueOnce({
-        revision: '2',
-        primary: {
-          location: 'repodata/primary.xml.gz',
-          checksum: { type: 'sha256', value: 'deadbeef' },
-        },
-        filelists: null,
-        other: null,
-      });
-    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary').mockResolvedValue([
+  it('YUM resolver는 primary 메타데이터가 없으면 명시적으로 실패한다', async () => {
+    const parseRepomd = vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockResolvedValue({
+      revision: '1',
+      primary: null,
+      filelists: null,
+      other: null,
+    });
+    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary');
+    const resolver = new YumDependencyResolver({
+      ...createOptions(repo),
+      repositories: [{ ...repo, id: 'empty', name: 'Empty Repo' }],
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+    const testResolver = accessResolverForTest(resolver);
+
+    await expect(testResolver.loadMetadata()).rejects.toThrow(/primary.*Empty Repo|primary metadata/i);
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(parsePrimary).not.toHaveBeenCalled();
+  });
+
+  it('YUM resolver는 저장소 AbortError identity를 보존한다', async () => {
+    const abortError = new Error('metadata load cancelled');
+    abortError.name = 'AbortError';
+    vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockRejectedValue(abortError);
+    const resolver = new YumDependencyResolver({
+      ...createOptions(repo),
+      repositories: [{ ...repo, id: 'cancelled', name: 'Cancelled Repo' }],
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+    const testResolver = accessResolverForTest(resolver);
+
+    await expect(testResolver.loadMetadata()).rejects.toBe(abortError);
+  });
+
+  it('YUM resolver는 모든 저장소 성공 후 provides를 게시한다', async () => {
+    vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockResolvedValue({
+      revision: '2',
+      primary: {
+        location: 'repodata/primary.xml.gz',
+        checksum: { type: 'sha256', value: 'deadbeef' },
+      },
+      filelists: null,
+      other: null,
+    });
+    vi.spyOn(YumMetadataParser.prototype, 'parsePrimary').mockResolvedValue([
       createPackage('openssl-libs', '3.0.0', 'x86_64', ['libcrypto.so.3()(64bit)']),
     ]);
     const resolver = new YumDependencyResolver({
       ...createOptions(repo),
-      repositories: [
-        { ...repo, id: 'empty', name: 'Empty Repo' },
-        { ...repo, id: 'full', name: 'Full Repo' },
-      ],
       distribution: {
         id: 'rocky-9',
         name: 'Rocky Linux 9',
@@ -206,9 +245,112 @@ describe('OS dependency resolvers', () => {
       name: 'libcrypto.so.3()(64bit)',
     });
 
-    expect(parseRepomd).toHaveBeenCalledTimes(2);
-    expect(parsePrimary).toHaveBeenCalledTimes(1);
     expect(byLibrary).toHaveLength(1);
     expect(byLibrary[0].name).toBe('openssl-libs');
+  });
+
+  it('YUM resolver는 실패한 저장소의 부분 상태를 게시하지 않고 같은 resolver 재시도를 허용한다', async () => {
+    const firstRepo = { ...repo, id: 'first', name: 'First Repo' };
+    const secondRepo = { ...repo, id: 'second', name: 'Second Repo' };
+    let repomdCalls = 0;
+    let primaryCalls = 0;
+    const parseRepomd = vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockImplementation(async () => {
+      repomdCalls += 1;
+      if (repomdCalls === 2) {
+        throw new Error('second repository malformed');
+      }
+      return {
+        revision: String(repomdCalls),
+        primary: {
+          location: 'repodata/primary.xml.gz',
+          checksum: { type: 'sha256', value: 'deadbeef' },
+        },
+        filelists: null,
+        other: null,
+      };
+    });
+    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary').mockImplementation(async () => {
+      primaryCalls += 1;
+      return [
+        createPackage(primaryCalls <= 2 ? 'first-repo-package' : 'second-repo-package', '1.0.0', 'x86_64', [
+          primaryCalls <= 2 ? 'first-capability' : 'second-capability',
+        ]),
+      ];
+    });
+    const resolver = new YumDependencyResolver({
+      ...createOptions(repo),
+      repositories: [firstRepo, secondRepo],
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+    const testResolver = accessResolverForTest(resolver);
+    const internals = resolver as unknown as {
+      allPackages: OSPackageInfo[];
+      providesMap: Map<string, OSPackageInfo[]>;
+      metadataCache: { packages: Map<string, OSPackageInfo[]>; provides: Map<string, OSPackageInfo[]> };
+    };
+
+    await expect(testResolver.loadMetadata()).rejects.toThrow(/second repository malformed/);
+    expect(internals.allPackages).toHaveLength(0);
+    expect(internals.metadataCache.packages.size).toBe(0);
+    expect(internals.metadataCache.provides.size).toBe(0);
+    expect(internals.providesMap.size).toBe(0);
+
+    await testResolver.loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledTimes(4);
+    expect(parsePrimary).toHaveBeenCalledTimes(3);
+    expect(internals.allPackages.map((pkg) => pkg.name)).toEqual([
+      'first-repo-package',
+      'second-repo-package',
+    ]);
+    expect(internals.metadataCache.packages.get('first-repo-package')).toHaveLength(1);
+    expect(internals.metadataCache.packages.get('second-repo-package')).toHaveLength(1);
+    expect(internals.providesMap.get('first-capability')).toHaveLength(1);
+    expect(internals.providesMap.get('second-capability')).toHaveLength(1);
+  });
+
+  it('YUM resolver는 disabled 저장소를 로드하지 않는다', async () => {
+    const parseRepomd = vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockResolvedValue({
+      revision: '1',
+      primary: {
+        location: 'repodata/primary.xml.gz',
+        checksum: { type: 'sha256', value: 'deadbeef' },
+      },
+      filelists: null,
+      other: null,
+    });
+    vi.spyOn(YumMetadataParser.prototype, 'parsePrimary').mockResolvedValue([
+      createPackage('enabled-package', '1.0.0'),
+    ]);
+    const resolver = new YumDependencyResolver({
+      ...createOptions(repo),
+      repositories: [
+        { ...repo, id: 'enabled', name: 'Enabled Repo', enabled: true },
+        { ...repo, id: 'disabled', name: 'Disabled Repo', enabled: false },
+      ],
+      distribution: {
+        id: 'rocky-9',
+        name: 'Rocky Linux 9',
+        version: '9',
+        packageManager: 'yum',
+        architectures: ['x86_64'],
+        defaultRepos: [],
+        extendedRepos: [],
+      },
+    });
+    const testResolver = accessResolverForTest(resolver);
+
+    await testResolver.loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(await testResolver.findPackagesForDependency({ name: 'enabled-package' })).toHaveLength(1);
   });
 });

--- a/src/core/resolver/yum-resolver.ts
+++ b/src/core/resolver/yum-resolver.ts
@@ -14,7 +14,6 @@ import type { OSPackageInfo, PackageDependency, OSPackageSearchResult } from '..
  * YUM 의존성 해결기
  */
 export class YumDependencyResolver extends BaseOSDependencyResolver {
-  private parsers: Map<string, YumMetadataParser> = new Map();
   private allPackages: OSPackageInfo[] = [];
   private providesMap: Map<string, OSPackageInfo[]> = new Map();
 
@@ -31,6 +30,9 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
     }
 
     const activeRepos = this.options.repositories.filter((r) => r.enabled);
+    const loadedPackages: OSPackageInfo[] = [];
+    const packageIndex = new Map<string, OSPackageInfo[]>();
+    const providesIndex = new Map<string, OSPackageInfo[]>();
 
     for (const repo of activeRepos) {
       this.throwIfAborted();
@@ -40,7 +42,6 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
           this.options.architecture,
           this.options.abortSignal
         );
-        this.parsers.set(repo.id, parser);
         const cacheKey = OsPackageCache.createKey(
           'yum',
           repo,
@@ -52,8 +53,7 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
         if (!packages) {
           const repomd = await parser.parseRepomd();
           if (!repomd.primary) {
-            console.warn(`No primary metadata found for ${repo.name}`);
-            continue;
+            throw new Error(`No primary metadata found for ${repo.name}`);
           }
 
           packages = await parser.parsePrimary(repomd.primary.location);
@@ -65,17 +65,16 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
           isArchitectureCompatible(pkg.architecture, this.options.architecture)
         );
 
-        this.allPackages.push(...compatiblePackages);
-
         // provides 맵 구축
         for (const pkg of compatiblePackages) {
+          loadedPackages.push(pkg);
           // 패키지 이름으로 등록
-          this.addToPackageCache(pkg.name, pkg);
+          this.addToPackageCache(pkg.name, pkg, packageIndex);
 
           // provides 등록
           if (pkg.provides) {
             for (const provide of pkg.provides) {
-              this.addToProvidesCache(provide, pkg);
+              this.addToProvidesCache(provide, pkg, providesIndex);
             }
           }
         }
@@ -89,36 +88,51 @@ export class YumDependencyResolver extends BaseOSDependencyResolver {
         if ((error as { name?: string })?.name === 'AbortError') {
           throw error;
         }
-        console.error(`Failed to load metadata from ${repo.name}:`, error);
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to load metadata from ${repo.name} (${repo.id}): ${message}`);
       }
     }
+
+    this.throwIfAborted();
+    // 모든 저장소가 성공한 경우에만 완성된 목록과 인덱스를 반영합니다.
+    this.allPackages = loadedPackages;
+    this.metadataCache.packages = packageIndex;
+    this.providesMap = providesIndex;
   }
 
   /**
    * 패키지 캐시에 추가
    */
-  private addToPackageCache(name: string, pkg: OSPackageInfo): void {
-    const existing = this.metadataCache.packages.get(name) || [];
+  private addToPackageCache(
+    name: string,
+    pkg: OSPackageInfo,
+    packageIndex: Map<string, OSPackageInfo[]>
+  ): void {
+    const existing = packageIndex.get(name) || [];
     existing.push(pkg);
-    this.metadataCache.packages.set(name, existing);
+    packageIndex.set(name, existing);
   }
 
   /**
    * provides 캐시에 추가
    */
-  private addToProvidesCache(provide: string, pkg: OSPackageInfo): void {
+  private addToProvidesCache(
+    provide: string,
+    pkg: OSPackageInfo,
+    providesIndex: Map<string, OSPackageInfo[]>
+  ): void {
     // 버전 제거 (예: "libfoo.so.1()(64bit)" -> "libfoo.so.1")
     const baseName = provide.split('(')[0];
 
-    const existing = this.providesMap.get(baseName) || [];
+    const existing = providesIndex.get(baseName) || [];
     existing.push(pkg);
-    this.providesMap.set(baseName, existing);
+    providesIndex.set(baseName, existing);
 
     // 전체 이름으로도 등록
     if (provide !== baseName) {
-      const fullExisting = this.providesMap.get(provide) || [];
+      const fullExisting = providesIndex.get(provide) || [];
       fullExisting.push(pkg);
-      this.providesMap.set(provide, fullExisting);
+      providesIndex.set(provide, fullExisting);
     }
   }
 


### PR DESCRIPTION
## 변경 내용

Rocky YUM/AppStream XML의 정상적인 대규모 entity 확장이 기본 제한에 걸려 검색 결과가 비어 보이던 문제를 수정합니다.

- XML parser 설정을 명시적으로 `processEntities.enabled=true`와 유한한 `maxTotalExpansions=100000`으로 조정했습니다. 기존 기본 총 확장 한도 1000보다 충분히 크지만 DTD/entity count, entity size, expanded length의 유한한 안전 한도는 유지합니다.
- `&amp;` 디코딩과 abort/cancel 동작을 유지하고, 모든 저장소 성공 후에만 YUM catalog를 원자적으로 교체하도록 했습니다.
- 사용하지 않는 parser map을 제거했습니다.
- 실제 Rocky metadata search/download 회귀 경로와 기존 API에 맞춘 opt-in integration test를 추가했습니다.

## 검증

- 전체 로컬: 2684 passed, 178 skipped
- parser/resolver target: 17 passed
- child CLI target: 1 passed
- `INTEGRATION_TEST=true` 실제 Rocky test: 2 passed
- TypeScript: 0 errors
- lint: 0 errors (기존 warnings 3개)
- 실제 CLI search: Rocky 9 / x86_64 `zlib`, limit 3에서 3개 결과
- 실제 CLI download: `zlib` `--no-deps`, ZIP에 RPM 1개 포함, metadata와 SHA-256 일치

실제 CLI 증거는 `cli-fixes-20260909/issue-74/live/GREEN-rocky-zlib-v2`에 보존했습니다. 전체 XML 메모리 파싱 때문에 검색 중 RSS가 약 1.43 GB까지 증가했으며, native RPM 설치는 수행하지 않았습니다.

Closes #74
