### PR TITLE
fix: Conda defaults 채널 URL 정규화

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,6 +110,7 @@ Maven의 `-V latest`는 POM을 조회하기 전에 `maven-metadata.xml`의 `late
 - 기본값인 `--target-os any`와 `--conda-channel conda-forge`는 적용 대상이 아닌 타입에서 기존 동작을 유지합니다. 그러나 다른 OS나 채널을 명시하면 적용 타입을 검사합니다.
 - pip에서 대상 OS가 `any`이면 특정 OS wheel을 임의로 선택하지 않고 범용 wheel 또는 `Requires-Python` 조건을 만족하는 소스 배포본을 선택합니다. `--python-version`도 생략하면 특정 CPython ABI wheel 대신 Python 버전 독립 wheel 또는 소스 배포본만 선택합니다.
 - pip 의존성의 PEP 508 환경 마커는 지정한 OS, 아키텍처, Python 버전과 extra를 기준으로 평가합니다. `--python-version`은 `major.minor`만 받으므로 `python_full_version`처럼 patch 버전이 필요한 조건은 결과를 확정할 수 없을 때 제외합니다. 필요한 대상 값이 없거나 마커를 해석할 수 없으면 해당 조건부 의존성을 임의로 포함하지 않습니다.
+- `--conda-channel defaults`는 `https://repo.anaconda.com/pkgs/main`에서 메타데이터와 패키지를 받습니다. 대상 플랫폼과 `noarch` 선택 규칙은 동일하며, 명시적 `main`과 `conda-forge` 같은 일반 채널은 `https://conda.anaconda.org/<채널>`을 사용합니다.
 - Conda에서 대상 OS가 `any`이면 특정 플랫폼을 임의로 가정하지 않고 `noarch` 빌드만 조회합니다. 플랫폼별 빌드가 필요하면 `--target-os`를 명시해야 합니다.
 - Conda에서 지정한 OS, 아키텍처, Python/CUDA 조건과 일치하는 대상 subdir 또는 `noarch` 빌드를 찾지 못하면 다른 플랫폼으로 재조회하지 않고 다운로드 전에 실패합니다.
 - pip와 Conda에서 필수 전이 의존성의 호환 버전이나 아티팩트를 찾지 못하면 해당 직접 루트의 해결이 실패합니다. 기본 모드는 그 직접 루트만 건너뛰고, `--strict`는 명령 전체를 실패 처리합니다. Conda의 OpenSSL, zlib 같은 런타임 라이브러리도 성공한 루트의 오프라인 묶음에 포함됩니다.

--- a/docs/conda-dependency-resolution.md
+++ b/docs/conda-dependency-resolution.md
@@ -8,7 +8,7 @@
 - `PackageCandidate`는 `conda-repodata-processor.ts`에 정의되며 `build`, `buildNumber`, `isPythonMatch`, `size`, `filename`, `subdir`, `depends`를 포함합니다. 아래 축약 예시는 전체 인터페이스 선언을 대체하지 않습니다.
 - 대상 플랫폼에 후보가 없거나 Python이 맞지 않을 때 noarch를 조회합니다. noarch도 Python/Python ABI 제약을 검증하며 무조건 호환으로 처리하지 않습니다. 호환 파일을 찾지 못하면 실패합니다.
 - Python·Python ABI와 `__` 가상 패키지는 외부 환경 조건으로 취급합니다. OpenSSL·zlib·libgcc 같은 실제 런타임 패키지는 수집 대상입니다.
-- 6절의 `defaults`/`main` URL 분기는 채널 URL 설계 참고 예시입니다. 현재 resolver는 `https://conda.anaconda.org/{channel}/{subdir}/{filename}`을 구성하며 `defaults`를 `repo.anaconda.com/pkgs/main`으로 자동 변환하지 않습니다.
+- `defaults`는 공유 채널 헬퍼를 통해 `https://repo.anaconda.com/pkgs/main`으로 변환합니다. 명시적 `main`과 다른 일반 채널은 `https://conda.anaconda.org/{channel}`을 유지하며, 그 뒤에 선택한 subdir와 파일명을 붙입니다.
 
 ## 1. 전체 아키텍처
 
@@ -482,25 +482,14 @@ function parseVersion(version: string): VersionPart[] {
 ## 6. 다운로드 URL 구성
 
 ```typescript
-function getPackageUrl(
-  channel: string,
-  subdir: string,
-  filename: string
-): string {
-  // conda-forge 채널
-  if (channel === 'conda-forge') {
-    return `https://conda.anaconda.org/conda-forge/${subdir}/${filename}`;
-  }
+import { getCondaRepositoryBase } from '../shared/conda-channel';
 
-  // Anaconda 기본 채널
-  if (channel === 'defaults' || channel === 'main') {
-    return `https://repo.anaconda.com/pkgs/main/${subdir}/${filename}`;
-  }
-
-  // 기타 채널
-  return `https://conda.anaconda.org/${channel}/${subdir}/${filename}`;
+function getPackageUrl(channel: string, subdir: string, filename: string): string {
+  return `${getCondaRepositoryBase(channel)}/${subdir}/${filename}`;
 }
 ```
+
+`defaults`의 변환은 기본 저장소 origin에만 적용합니다. 사용자 지정 base URL과 Anaconda API 소유자 매핑은 [공유 Conda 유틸리티](shared-conda.md#채널-url-conda-channelts)를 참고하세요.
 
 ## 7. DepsSmuggler 구현 세부사항
 

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -139,6 +139,8 @@ await downloader.searchPackages('numpy', 'conda-forge');
 await downloader.searchPackages('numpy', 'all'); // 검색에서만 채널 필터 생략
 ```
 
+`defaults`의 repodata와 패키지 파일은 `https://repo.anaconda.com/pkgs/main/<subdir>/`에서 조회합니다. 버전·파일 목록 API에서는 공식 `main` 소유자를 사용하며, 선택한 채널은 패키지 메타데이터의 `defaults/<name>`으로 유지합니다. API 파일명이 `noarch/six-….conda`처럼 subdir를 포함해도 다운로드 URL에 subdir를 한 번만 붙입니다. 명시적인 `main`은 기존 `https://conda.anaconda.org/main` 채널로 유지하고, 다른 채널도 기존 주소를 사용합니다. URL 규칙은 [공유 Conda 유틸리티](shared-conda.md#채널-url-conda-channelts)를 참고하세요.
+
 ### Subdir 매핑
 
 | OS + 아키텍처 | Subdir |

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -287,6 +287,8 @@ torch-2.1.0+cu121-cp311-cp311-linux_x86_64.whl
 - 캐시: `src/core/shared/conda-cache.ts` 모듈 사용 (repodata 디스크 캐시와 processor의 요청 중 메모리 캐시)
 - **알고리즘**: BFS 큐 기반 (call stack overflow 방지)
 
+`defaults` 채널은 `https://repo.anaconda.com/pkgs/main`을 기준으로 대상 subdir와 `noarch`의 repodata를 조회하고 다운로드 URL을 생성합니다. `metadata.repository`에는 요청한 `defaults/<name>`을 유지합니다. 명시적인 `main` 등 일반 채널은 `https://conda.anaconda.org/<채널>`을 사용합니다. 채널 URL 변환은 [공유 헬퍼](shared-conda.md#채널-url-conda-channelts)에 모으며, 버전·빌드 선택은 계속 repodata에 한정합니다.
+
 ### 모듈 구조
 
 ```

--- a/docs/shared-conda.md
+++ b/docs/shared-conda.md
@@ -11,11 +11,29 @@
 ```
 src/core/shared/
 ├── conda-types.ts         # Conda 타입 정의 (shared-types.md 참조)
+├── conda-channel.ts       # 논리 채널 → 저장소 URL / API 소유자
 ├── conda-utils.ts         # Conda 패키지 URL 조회
 ├── conda-cache.ts         # repodata 캐싱 시스템
 ├── conda-matchspec.ts     # MatchSpec 파싱/매칭
 └── conda-validator.ts     # Conda 채널 검증
 ```
+
+---
+
+## 채널 URL (`conda-channel.ts`)
+
+`getCondaRepositoryBase(channel, baseUrl?)`와 `getCondaApiOwner(channel)`는 `shared/index.ts`에서도 내보냅니다. resolver, downloader, URL 조회, 채널 검증 및 Electron의 파일명 기반 다운로드 경로가 이 규칙을 함께 사용합니다.
+
+| 논리 채널 | 기본 저장소 URL | Anaconda API 소유자 |
+| --- | --- | --- |
+| `defaults` | `https://repo.anaconda.com/pkgs/main` | `main` |
+| `main` | `https://conda.anaconda.org/main` | `main` |
+| `conda-forge` | `https://conda.anaconda.org/conda-forge` | `conda-forge` |
+| 기타 채널 | `https://conda.anaconda.org/<채널>` | 입력 채널 |
+
+저장소 URL 뒤에 `<subdir>/<파일명>`을 붙입니다. API 파일명에 포함된 subdir는 중복해서 붙이지 않습니다. `defaults` 변환은 기본 origin인 `https://conda.anaconda.org`에만 적용하며 끝의 `/`는 제거합니다. 사용자 지정 `baseUrl`은 기존 `<baseUrl>/<channel>` 규칙을 유지합니다. 예를 들어 `https://mirror.example/conda`와 `defaults`를 주면 저장소는 `https://mirror.example/conda/defaults`입니다.
+
+패키지 메타데이터와 디스크 캐시 디렉터리는 논리 채널명을 유지합니다. 캐시 메타데이터의 URL은 실제 요청한 저장소 주소이며, 진행 중인 요청의 중복 제거 키에는 기존처럼 입력 `baseUrl`도 포함합니다. 이 앱의 `defaults`는 `pkgs/main`을 뜻하며 Conda 자체의 `.condarc`나 여러 기본 채널 설정을 읽어 확장하지 않습니다.
 
 ---
 
@@ -167,7 +185,7 @@ interface RepodataCacheMeta {
 
 ```typescript
 interface FetchRepodataOptions {
-  baseUrl?: string;        // Conda 기본 URL (기본: https://conda.anaconda.org)
+  baseUrl?: string;        // 채널명 앞에 붙일 URL (기본: https://conda.anaconda.org)
   cacheDir?: string;       // 캐시 디렉토리
   useCache?: boolean;      // 캐시 사용 여부 (기본: true)
   forceRefresh?: boolean;  // 강제 새로고침 (기본: false)
@@ -262,7 +280,7 @@ const matches = matchesSpec(pkg, spec); // true
 
 ## Conda 채널 검증 (`conda-validator.ts`)
 
-Conda 채널의 원격 repodata에 HEAD 요청을 보내 접근 가능 여부를 확인하는 비동기 유틸리티입니다. 두 함수 모두 `Promise<boolean>`을 반환합니다.
+Conda 채널의 원격 repodata에 HEAD 요청을 보내 접근 가능 여부를 확인하는 비동기 유틸리티입니다. 두 함수 모두 `Promise<boolean>`을 반환합니다. `defaults`도 위 채널 URL 규칙에 따라 `repo.anaconda.com/pkgs/main`의 repodata를 확인합니다.
 
 ### 주요 함수
 

--- a/docs/shared-utilities.md
+++ b/docs/shared-utilities.md
@@ -18,6 +18,7 @@ src/core/shared/
 ├── maven-types.ts                # Maven 관련 타입 정의
 ├── version-utils.ts              # 버전 비교/호환성 유틸리티
 ├── pypi-utils.ts                 # PyPI 다운로드 URL 조회
+├── conda-channel.ts              # 채널별 저장소 URL / API 소유자
 ├── conda-utils.ts                # Conda 패키지 URL 조회
 ├── dependency-resolver.ts        # 의존성 해결 유틸리티
 ├── dependency-tree-utils.ts      # 의존성 트리 유틸리티
@@ -138,6 +139,7 @@ export { getPyPIDownloadUrl } from './pypi-utils';
 
 // Conda 유틸리티
 export { getCondaDownloadUrl, getCondaSubdir } from './conda-utils';
+export { getCondaApiOwner, getCondaRepositoryBase } from './conda-channel';
 
 // 파일 유틸리티
 export { downloadFile, createZipArchive, createTarGzArchive } from './file-utils';

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -93,6 +93,14 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 
 커버리지는 `npm run test:coverage`로 확인합니다. 현재 커버리지 집계 대상은 `src/core/**/*.ts`이며 테스트 파일과 index barrel은 제외합니다. 따라서 CLI, Electron, 렌더러, E2E 테스트의 검증 범위와 구분해야 합니다. text 보고서는 콘솔에, JSON/HTML 보고서는 `coverage/`에 생성되며 커버리지 최소 비율은 설정되어 있지 않습니다. 외부 레지스트리 실제 연동 및 OS별 파일시스템 동작 전체를 mock 테스트가 보장하지는 않습니다.
 
+### Conda defaults 채널 검증
+
+- `conda-channel.test.ts`, `conda-cache.test.ts`, `conda-utils.test.ts`: 기본 `defaults`의 공식 URL, 명시적 `main`과 사용자 지정 origin 유지, repodata 요청 및 API 파일 URL 구성을 검증합니다.
+- `conda.test.ts`, `conda-resolver-target.test.ts`: downloader/resolver의 메타데이터·후보 조회 경계를 모킹해 대상 subdir와 `noarch`의 다운로드 URL을 검증합니다. downloader의 API 응답 모킹으로 `main` 소유자 매핑과 논리 채널 유지, 중복 subdir 방지도 확인합니다.
+- `conda-validator.test.ts`, `download-package-router.test.ts`: 채널 HEAD 검증과 Electron의 파일명 기반 URL 생성에도 같은 규칙이 적용되는지 확인합니다.
+
+실제 네트워크 smoke는 격리한 사용자 디렉터리에서 `download -t conda -p six -V latest --no-deps --conda-channel defaults`를 실행하고 종료 코드, 요청 URL, 아카이브와 manifest를 검사합니다. `--target-os linux --arch x86_64` 및 일반 `conda-forge` 채널도 대조합니다. 이 검증은 패키지 다운로드 범위이며 생성된 스크립트로 Conda 환경을 설치하는 검증은 별도입니다.
+
 ### Maven 모델 POM 검증
 
 `src/core/resolver/maven-resolver.test.ts`는 `latest` 메타데이터의 실제 버전으로 루트 POM과 파일명을 만드는지, release fallback·빈 버전 실패·classifier/type 보존·명시 버전의 조회 생략을 검증합니다. `src/cli/commands/download.test.ts`는 기본 Maven `--no-deps`에서 `latest`만 깊이 0의 루트 해결을 거쳐 다운로드 큐로 전달되는지 확인합니다. 실제 저장소 검증에서는 같은 좌표의 의존성 포함/제외 CLI를 실행하고 메타데이터 버전과 아카이브·manifest를 비교합니다.

--- a/electron/services/download-package-router.test.ts
+++ b/electron/services/download-package-router.test.ts
@@ -4,11 +4,13 @@ import path from 'node:path';
 const {
   copyMock,
   downloadMavenPackageMock,
+  downloadFileMock,
   ensureDirMock,
   pathExistsMock,
 } = vi.hoisted(() => ({
   copyMock: vi.fn(),
   downloadMavenPackageMock: vi.fn(),
+  downloadFileMock: vi.fn(),
   ensureDirMock: vi.fn(),
   pathExistsMock: vi.fn(),
 }));
@@ -27,7 +29,7 @@ vi.mock('../../src/core', () => ({
 }));
 
 vi.mock('../../src/core/shared', () => ({
-  downloadFile: vi.fn(),
+  downloadFile: downloadFileMock,
   getPyPIDownloadUrl: vi.fn(),
 }));
 
@@ -70,6 +72,33 @@ describe('createDownloadPackageRouter Maven 처리', () => {
     ensureDirMock.mockResolvedValue(undefined);
     pathExistsMock.mockResolvedValue(true);
     copyMock.mockResolvedValue(undefined);
+    downloadFileMock.mockResolvedValue(undefined);
+  });
+
+  it('uses the canonical defaults repository in the metadata fallback', async () => {
+    const router = createDownloadPackageRouter();
+    const pkg = {
+      id: 'conda-six',
+      type: 'conda' as const,
+      name: 'six',
+      version: '1.16.0',
+      metadata: {
+        repository: 'defaults/six',
+        subdir: 'noarch',
+        filename: 'six-1.16.0-pyhd3eb1b0_1.conda',
+      },
+    };
+
+    const result = await router.downloadPackage(pkg, createContext() as never);
+
+    expect(result.success).toBe(true);
+    expect(downloadFileMock).toHaveBeenCalledWith(
+      'https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.conda',
+      expect.any(String),
+      expect.any(Function),
+      expect.any(Object)
+    );
+    expect(downloadFileMock.mock.calls[0][0]).not.toContain('conda.anaconda.org/defaults');
   });
 
   it('같은 GAV는 복사까지 직렬화하고 다른 GAV는 동시에 다운로드한다', async () => {

--- a/electron/services/download-package-router.ts
+++ b/electron/services/download-package-router.ts
@@ -1,20 +1,21 @@
 import * as path from 'path';
 import * as fse from 'fs-extra';
-import { createScopedLogger } from '../utils/logger';
-import { getPyPIDownloadUrl, downloadFile } from '../../src/core/shared';
-import type {
-  Architecture,
-  DownloadOptions,
-  DownloadPackage,
-  DownloadPackageResult,
-} from '../../src/core/shared';
 import {
   getCondaDownloader,
   getDockerDownloader,
   getMavenDownloader,
   getNpmDownloader,
 } from '../../src/core';
+import { getPyPIDownloadUrl, downloadFile } from '../../src/core/shared';
+import { getCondaRepositoryBase } from '../../src/core/shared/conda-channel';
+import { createScopedLogger } from '../utils/logger';
 import type { DownloadProgressEmitter } from './download-progress';
+import type {
+  Architecture,
+  DownloadOptions,
+  DownloadPackage,
+  DownloadPackageResult,
+} from '../../src/core/shared';
 
 const log = createScopedLogger('DownloadPackageRouter');
 
@@ -221,7 +222,8 @@ async function resolveDownloadTarget(
       const subdir = pkg.metadata?.subdir as string | undefined;
       const filename = pkg.metadata?.filename as string | undefined;
       if (subdir && filename) {
-        condaDownloadUrl = `https://conda.anaconda.org/${channel}/${subdir}/${filename}`;
+        const artifactFilename = filename.split('/').pop() || filename;
+        condaDownloadUrl = `${getCondaRepositoryBase(channel)}/${subdir}/${artifactFilename}`;
       } else {
         const arch = (pkg.architecture || architecture || 'x86_64') as Architecture;
         const metadata = await condaDownloader.getPackageMetadata(

--- a/src/core/downloaders/conda.test.ts
+++ b/src/core/downloaders/conda.test.ts
@@ -1,6 +1,25 @@
 import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
 import { getCondaDownloader } from './conda';
 
+function repodataPackage(subdir: string) {
+  return {
+    packages: {
+      'six-1.16.0-pyhd3eb1b0_1.conda': {
+        name: 'six',
+        version: '1.16.0',
+        build: 'pyhd3eb1b0_1',
+        build_number: 1,
+        depends: [],
+        subdir,
+        size: 123,
+        md5: 'fixture-md5',
+      },
+    },
+    'packages.conda': {},
+    info: { subdir },
+  };
+}
+
 describe('conda downloader', () => {
   let downloader: ReturnType<typeof getCondaDownloader>;
 
@@ -77,6 +96,88 @@ describe('conda downloader', () => {
           downloadUrl: 'https://conda.example/numpy.conda',
         }),
         undefined,
+      );
+    });
+  });
+
+  describe('defaults repository URLs', () => {
+    it.each([
+      ['x86_64', 'linux-64', 'https://repo.anaconda.com/pkgs/main/linux-64/'],
+      ['noarch', 'noarch', 'https://repo.anaconda.com/pkgs/main/noarch/'],
+    ] as const)('uses the canonical %s repository endpoint', async (arch, subdir, base) => {
+      const getRepoData = vi
+        .spyOn(downloader as any, 'getRepoData')
+        .mockImplementation(async (_channel: string, requestedSubdir: string) =>
+          requestedSubdir === subdir ? repodataPackage(subdir) : null
+        );
+
+      const result = await downloader.getPackageMetadata('six', '1.16.0', 'defaults', arch);
+
+      expect(result.metadata).toMatchObject({
+        repository: 'defaults/six',
+        subdir,
+        filename: 'six-1.16.0-pyhd3eb1b0_1.conda',
+        downloadUrl: `${base}six-1.16.0-pyhd3eb1b0_1.conda`,
+      });
+      expect(result.metadata?.downloadUrl).not.toContain('conda.anaconda.org/defaults');
+      expect(getRepoData).toHaveBeenCalledWith('defaults', subdir);
+    });
+
+    it('keeps explicit main on the ordinary Anaconda.org endpoint', async () => {
+      vi.spyOn(downloader as any, 'getRepoData').mockResolvedValue(repodataPackage('noarch'));
+      const result = await downloader.getPackageMetadata('six', '1.16.0', 'main', 'noarch');
+
+      expect(result.metadata?.downloadUrl).toBe(
+        'https://conda.anaconda.org/main/noarch/six-1.16.0-pyhd3eb1b0_1.conda'
+      );
+    });
+
+    it('maps defaults to the main API owner without duplicating the subdir', async () => {
+      vi.spyOn(downloader as any, 'getRepoData').mockResolvedValue(null);
+      const apiGet = vi.spyOn((downloader as any).client, 'get').mockResolvedValue({
+        data: {
+          name: 'six',
+          summary: 'six',
+          description: 'six',
+          owner: 'main',
+          license: 'MIT',
+          home: 'https://example.test/six',
+          files: [
+            {
+              basename: 'noarch/six-1.16.0-pyhd3eb1b0_1.conda',
+              version: '1.16.0',
+              size: 123,
+              attrs: { subdir: 'noarch', build: 'pyhd3eb1b0_1', build_number: 1 },
+            },
+          ],
+          versions: ['1.16.0'],
+        },
+      });
+
+      const result = await downloader.getPackageMetadata('six', '1.16.0', 'defaults', 'noarch');
+
+      expect(apiGet).toHaveBeenCalledWith('https://api.anaconda.org/package/main/six');
+      expect(result.metadata).toMatchObject({
+        repository: 'defaults/six',
+        downloadUrl: 'https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.conda',
+      });
+      expect(result.metadata?.downloadUrl).not.toContain('/noarch/noarch/');
+    });
+
+    it('keeps defaults as the logical repository after API search owner mapping', async () => {
+      const apiGet = vi.spyOn((downloader as any).client, 'get').mockResolvedValue({
+        data: [{ owner: 'main', name: 'six', full_name: 'main/six', summary: 'six' }],
+      });
+
+      await expect(downloader.searchPackages('six', 'defaults')).resolves.toEqual([
+        expect.objectContaining({
+          name: 'six',
+          metadata: { description: 'six', repository: 'defaults/six' },
+        }),
+      ]);
+      expect(apiGet).toHaveBeenCalledWith(
+        'https://api.anaconda.org/search',
+        expect.objectContaining({ params: { name: 'six' } })
       );
     });
   });

--- a/src/core/downloaders/conda.ts
+++ b/src/core/downloaders/conda.ts
@@ -16,6 +16,7 @@ import {
   CondaPackageFile,
 } from '../shared/conda-types';
 import { BaseLanguageDownloader } from './lang-shared/base-language-downloader';
+import { getCondaApiOwner, getCondaRepositoryBase } from '../shared/conda-channel';
 import { verifyFileChecksum } from '../shared/integrity/checksum';
 
 // CondaPackageInfo는 downloader 전용 (files, versions 등 추가 필드 포함)
@@ -143,7 +144,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
 
         // 채널 필터링
         const filtered = response.data.filter(
-          (pkg) => pkg.owner === channel || channel === 'all'
+          (pkg) => pkg.owner === getCondaApiOwner(channel) || channel === 'all'
         );
 
         return filtered.slice(0, 50).map((pkg) => ({
@@ -152,7 +153,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
           version: 'latest',
           metadata: {
             description: pkg.summary,
-            repository: pkg.full_name,
+            repository: channel === 'defaults' ? `defaults/${pkg.name}` : pkg.full_name,
           },
         }));
       } catch (error) {
@@ -184,7 +185,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
   ): Promise<string[]> {
     try {
       const response = await this.client.get<CondaPackageInfo>(
-        `${this.apiUrl}/package/${channel}/${packageName}`
+        `${this.apiUrl}/package/${getCondaApiOwner(channel)}/${packageName}`
       );
 
       // 버전 정렬 (최신순)
@@ -218,7 +219,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
         const found = this.findPackageInRepoData(repodata, name, version, subdir);
         if (found) {
           const { filename, pkg } = found;
-          const downloadUrl = `${this.condaUrl}/${channel}/${subdir}/${filename}`;
+          const downloadUrl = `${getCondaRepositoryBase(channel, this.condaUrl)}/${subdir}/${filename}`;
 
           return {
             type: 'conda',
@@ -248,7 +249,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
         const found = this.findPackageInRepoData(noarchRepodata, name, version, 'noarch');
         if (found) {
           const { filename, pkg } = found;
-          const downloadUrl = `${this.condaUrl}/${channel}/noarch/${filename}`;
+          const downloadUrl = `${getCondaRepositoryBase(channel, this.condaUrl)}/noarch/${filename}`;
 
           return {
             type: 'conda',
@@ -290,13 +291,18 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
   ): Promise<PackageInfo> {
     try {
       const response = await this.client.get<CondaPackageInfo>(
-        `${this.apiUrl}/package/${channel}/${name}`
+        `${this.apiUrl}/package/${getCondaApiOwner(channel)}/${name}`
       );
       const pkgInfo = response.data;
 
       // 버전과 아키텍처에 맞는 파일 찾기
       const file = this.selectBestFile(pkgInfo.files, version, arch);
 
+      const basenameParts = file?.basename.split('/') || [];
+      const fileSubdir = basenameParts.length > 1
+        ? basenameParts[basenameParts.length - 2]
+        : file?.attrs.subdir || 'noarch';
+      const fileName = basenameParts[basenameParts.length - 1];
       const metadata: PackageMetadata = {
         description: pkgInfo.summary || pkgInfo.description,
         license: pkgInfo.license,
@@ -309,8 +315,8 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
               sha256: file.sha256,
             }
           : undefined,
-        downloadUrl: file
-          ? `${this.condaUrl}/${channel}/${file.attrs.subdir || 'noarch'}/${file.basename}`
+        downloadUrl: file && fileName
+          ? `${getCondaRepositoryBase(channel, this.condaUrl)}/${fileSubdir}/${fileName}`
           : undefined,
       };
 
@@ -493,7 +499,7 @@ export class CondaDownloader extends BaseLanguageDownloader implements IDownload
     channel: CondaChannel = 'conda-forge'
   ): Promise<CondaPackageFile[]> {
     const response = await this.client.get<CondaPackageInfo>(
-      `${this.apiUrl}/package/${channel}/${name}`
+      `${this.apiUrl}/package/${getCondaApiOwner(channel)}/${name}`
     );
     return response.data.files;
   }

--- a/src/core/resolver/conda-resolver-target.test.ts
+++ b/src/core/resolver/conda-resolver-target.test.ts
@@ -674,6 +674,41 @@ describe('CondaRepoDataProcessor Python 호환성', () => {
 });
 
 describe('CondaResolver 대상 아티팩트 선택', () => {
+  it.each([
+    ['linux-64', { system: 'Linux', machine: 'x86_64' }, 'https://repo.anaconda.com/pkgs/main/linux-64/'],
+    ['noarch', { machine: 'x86_64' }, 'https://repo.anaconda.com/pkgs/main/noarch/'],
+  ] as const)('defaults %s artifact URL uses the canonical repository base', async (subdir, targetPlatform, base) => {
+    const resolver = new CondaResolver();
+    const processor = (resolver as any).repoDataProcessor;
+    vi.spyOn(processor, 'getRepoData').mockResolvedValue({ packages: {}, 'packages.conda': {}, info: { subdir } });
+    vi.spyOn(processor, 'findPackageCandidates').mockReturnValue([
+      {
+        filename: `demo-1.0.0-${subdir}.conda`,
+        name: 'demo',
+        version: '1.0.0',
+        build: '0',
+        buildNumber: 0,
+        depends: [],
+        subdir,
+        size: 1,
+        isPythonMatch: true,
+      },
+    ]);
+
+    const result = await resolver.resolveDependencies('demo', '1.0.0', {
+      maxDepth: 0,
+      channel: 'defaults',
+      targetPlatform,
+    });
+
+    expect(result.root.package.metadata).toMatchObject({
+      repository: 'defaults/demo',
+      subdir,
+      downloadUrl: `${base}demo-1.0.0-${subdir}.conda`,
+    });
+    expect(result.root.package.metadata.downloadUrl).not.toContain('conda.anaconda.org/defaults');
+  });
+
   it('대상 OS가 없으면 linux-64 대신 noarch만 조회한다', async () => {
     const resolver = new CondaResolver();
     const processor = (

--- a/src/core/resolver/conda-resolver.ts
+++ b/src/core/resolver/conda-resolver.ts
@@ -16,6 +16,7 @@ import {
 import {
   CondaRepoDataProcessor,
 } from './conda-repodata-processor';
+import { getCondaRepositoryBase } from '../shared/conda-channel';
 import type { ResolutionSession } from '../shared/internal/resolution-session';
 import {
   attachResolutionSession,
@@ -352,7 +353,7 @@ export class CondaResolver implements IResolver {
 
     // 다운로드 URL 생성
     const downloadUrl =
-      `${this.condaUrl}/${channel}/${resolvedSubdir}/${resolvedFilename}`;
+      `${getCondaRepositoryBase(channel, this.condaUrl)}/${resolvedSubdir}/${resolvedFilename}`;
 
     const packageInfo: PackageInfo = {
       type: 'conda',

--- a/src/core/shared/conda-cache.test.ts
+++ b/src/core/shared/conda-cache.test.ts
@@ -158,4 +158,27 @@ describe('conda-cache', () => {
     expect(second?.data.info.subdir).toBe(subdir);
     expect(mockedAxiosGet).toHaveBeenCalledTimes(2);
   });
+
+  it('defaults는 공식 repository URL을 사용하면서 논리 채널 캐시 경로를 유지해야 함', async () => {
+    const data: RepoData = {
+      info: { subdir: 'noarch' },
+      packages: { 'defaults-package-1.0-0.tar.bz2': {} as never },
+      'packages.conda': {},
+    };
+    mockedAxiosGet.mockImplementation(async (url: string) => {
+      if (url.endsWith('repodata.json.zst')) throw new Error('zstd unavailable');
+      return { status: 200, data, headers: {} } as never;
+    });
+
+    const result = await fetchRepodata('defaults', 'noarch', { cacheDir });
+    const { metaPath } = getCachePaths(cacheDir, 'defaults', 'noarch');
+    const meta = await fs.readJson(metaPath);
+
+    expect(result?.data).toEqual(data);
+    expect(meta.url).toBe('https://repo.anaconda.com/pkgs/main/noarch/current_repodata.json');
+    expect(mockedAxiosGet.mock.calls.map(([url]) => url)).toEqual([
+      'https://repo.anaconda.com/pkgs/main/noarch/repodata.json.zst',
+      'https://repo.anaconda.com/pkgs/main/noarch/current_repodata.json',
+    ]);
+  });
 });

--- a/src/core/shared/conda-cache.ts
+++ b/src/core/shared/conda-cache.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import axios, { AxiosResponse } from 'axios';
 import * as fzstd from 'fzstd';
 import { createMemoryCache } from './cache/cache-store';
+import { CONDA_STANDARD_ORIGIN, getCondaRepositoryBase } from './conda-channel';
 import { RepoData } from './conda-types';
 import logger from '../../utils/logger';
 
@@ -205,7 +206,7 @@ export async function fetchRepodata(
   options: FetchRepodataOptions = {}
 ): Promise<CacheResult | null> {
   const {
-    baseUrl = 'https://conda.anaconda.org',
+    baseUrl = CONDA_STANDARD_ORIGIN,
     cacheDir = getDefaultCacheDir(),
     useCache = true,
     forceRefresh = false,
@@ -240,10 +241,11 @@ export async function fetchRepodata(
   const requestKey = getRequestKey(baseUrl, cacheDir, channel, subdir, useCache, forceRefresh);
   const result = await repodataRequestCache.dedupeFetch(requestKey, async () => {
     // 2. HTTP 요청 준비
+    const repositoryBase = getCondaRepositoryBase(channel, baseUrl);
     const urls = [
-      { url: `${baseUrl}/${channel}/${subdir}/repodata.json.zst`, compressed: true },
-      { url: `${baseUrl}/${channel}/${subdir}/current_repodata.json`, compressed: false },
-      { url: `${baseUrl}/${channel}/${subdir}/repodata.json`, compressed: false },
+      { url: `${repositoryBase}/${subdir}/repodata.json.zst`, compressed: true },
+      { url: `${repositoryBase}/${subdir}/current_repodata.json`, compressed: false },
+      { url: `${repositoryBase}/${subdir}/repodata.json`, compressed: false },
     ];
 
     // 기존 캐시 메타데이터 (조건부 요청용)

--- a/src/core/shared/conda-channel.test.ts
+++ b/src/core/shared/conda-channel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getCondaApiOwner, getCondaRepositoryBase } from './conda-channel';
+
+describe('Conda channel URL boundaries', () => {
+  it.each([
+    ['defaults', 'https://repo.anaconda.com/pkgs/main'],
+    ['main', 'https://conda.anaconda.org/main'],
+    ['conda-forge', 'https://conda.anaconda.org/conda-forge'],
+    ['anaconda', 'https://conda.anaconda.org/anaconda'],
+    ['custom-channel', 'https://conda.anaconda.org/custom-channel'],
+  ])('maps the standard %s channel to %s', (channel, expected) => {
+    expect(getCondaRepositoryBase(channel)).toBe(expected);
+  });
+
+  it('keeps defaults on a custom origin instead of applying the official alias', () => {
+    expect(getCondaRepositoryBase('defaults', 'https://mirror.example/conda/')).toBe(
+      'https://mirror.example/conda/defaults'
+    );
+    expect(getCondaRepositoryBase('main', 'https://mirror.example/conda/')).toBe(
+      'https://mirror.example/conda/main'
+    );
+  });
+
+  it.each([
+    ['defaults', 'main'],
+    ['main', 'main'],
+    ['conda-forge', 'conda-forge'],
+  ])('uses %s as the Anaconda API owner %s', (channel, expected) => {
+    expect(getCondaApiOwner(channel)).toBe(expected);
+  });
+});

--- a/src/core/shared/conda-channel.ts
+++ b/src/core/shared/conda-channel.ts
@@ -1,0 +1,18 @@
+export const CONDA_STANDARD_ORIGIN = 'https://conda.anaconda.org';
+
+/** Return the repository root for a logical Conda channel. */
+export function getCondaRepositoryBase(
+  channel: string,
+  baseUrl: string = CONDA_STANDARD_ORIGIN
+): string {
+  const origin = baseUrl.replace(/\/+$/, '');
+  if (channel === 'defaults' && origin === CONDA_STANDARD_ORIGIN) {
+    return 'https://repo.anaconda.com/pkgs/main';
+  }
+  return `${origin}/${channel}`;
+}
+
+/** Return the Anaconda API owner corresponding to a logical channel. */
+export function getCondaApiOwner(channel: string): string {
+  return channel === 'defaults' ? 'main' : channel;
+}

--- a/src/core/shared/conda-utils.test.ts
+++ b/src/core/shared/conda-utils.test.ts
@@ -354,6 +354,26 @@ describe('Conda Anaconda API fallback and errors', () => {
     });
   });
 
+  it('uses the official defaults repository and main API owner for fallback files', async () => {
+    serveIndexes({}, [
+      apiFile({
+        basename: 'noarch/defaults-package.conda',
+        attrs: { subdir: 'noarch', build: 'pyhd8ed1ab_0', build_number: 0 },
+      }),
+    ]);
+
+    await expect(
+      getCondaDownloadUrl('numpy', '2.0.0', undefined, undefined, 'defaults')
+    ).resolves.toEqual({
+      url: 'https://repo.anaconda.com/pkgs/main/noarch/defaults-package.conda',
+      filename: 'defaults-package.conda',
+      size: 8192,
+    });
+    expect(mocks.get.mock.calls.map(([url]) => url)).toContain(
+      'https://api.anaconda.org/package/main/numpy/files'
+    );
+  });
+
   it.each<{ files: AnacondaFileInfo[] }>([
     { files: [] },
     { files: [apiFile({ version: '1.0.0' })] },

--- a/src/core/shared/conda-utils.ts
+++ b/src/core/shared/conda-utils.ts
@@ -1,14 +1,19 @@
 // Conda 관련 유틸리티 함수 (repodata.json 기반 패키지 URL 조회)
 import axios from 'axios';
 import * as fzstd from 'fzstd';
-import type { DownloadUrlResult } from './types';
-import type { RepoData, RepoDataPackage, AnacondaFileInfo } from './conda-types';
+import {
+  CONDA_STANDARD_ORIGIN,
+  getCondaApiOwner,
+  getCondaRepositoryBase,
+} from './conda-channel';
 import logger from '../../utils/logger';
+import type { RepoData, RepoDataPackage, AnacondaFileInfo } from './conda-types';
+import type { DownloadUrlResult } from './types';
 
 // repodata 캐시 (channel/subdir -> RepoData)
 const repodataCache = new Map<string, RepoData>();
 
-const CONDA_URL = 'https://conda.anaconda.org';
+const CONDA_URL = CONDA_STANDARD_ORIGIN;
 const ANACONDA_API_URL = 'https://api.anaconda.org';
 
 /**
@@ -44,10 +49,11 @@ async function getRepoData(channel: string, subdir: string): Promise<RepoData | 
   }
 
   // 우선순위: zstd 압축 > current_repodata.json > repodata.json
+  const repositoryBase = getCondaRepositoryBase(channel, CONDA_URL);
   const urls = [
-    { url: `${CONDA_URL}/${channel}/${subdir}/repodata.json.zst`, compressed: true },
-    { url: `${CONDA_URL}/${channel}/${subdir}/current_repodata.json`, compressed: false },
-    { url: `${CONDA_URL}/${channel}/${subdir}/repodata.json`, compressed: false },
+    { url: `${repositoryBase}/${subdir}/repodata.json.zst`, compressed: true },
+    { url: `${repositoryBase}/${subdir}/current_repodata.json`, compressed: false },
+    { url: `${repositoryBase}/${subdir}/repodata.json`, compressed: false },
   ];
 
   for (const { url, compressed } of urls) {
@@ -194,7 +200,7 @@ async function getPackageFromAnacondaApi(
     logger.debug('[conda-utils] Anaconda API fallback', { packageName, version, subdir });
 
     const response = await axios.get<AnacondaFileInfo[]>(
-      `${ANACONDA_API_URL}/package/${channel}/${packageName}/files`,
+      `${ANACONDA_API_URL}/package/${getCondaApiOwner(channel)}/${packageName}/files`,
       {
         headers: { 'User-Agent': 'DepsSmuggler/1.0' },
         timeout: 30000,
@@ -222,7 +228,7 @@ async function getPackageFromAnacondaApi(
         const filename = selected.basename.split('/').pop() || selected.basename;
         logger.debug('[conda-utils] API에서 noarch 패키지 찾음', { filename });
         return {
-          url: `${CONDA_URL}/${channel}/noarch/${filename}`,
+          url: `${getCondaRepositoryBase(channel, CONDA_URL)}/noarch/${filename}`,
           filename,
           size: selected.size || 0,
         };
@@ -258,7 +264,7 @@ async function getPackageFromAnacondaApi(
     logger.debug('[conda-utils] API에서 찾음', { filename, build: selected.attrs.build });
 
     return {
-      url: `${CONDA_URL}/${channel}/${subdir}/${filename}`,
+      url: `${getCondaRepositoryBase(channel, CONDA_URL)}/${subdir}/${filename}`,
       filename,
       size: selected.size || 0,
     };
@@ -289,7 +295,7 @@ export async function getCondaDownloadUrl(
     const found = findPackageInRepoData(repodata, packageName, version, pythonVersion);
     if (found) {
       const { filename, pkg } = found;
-      const downloadUrl = `${CONDA_URL}/${channel}/${subdir}/${filename}`;
+      const downloadUrl = `${getCondaRepositoryBase(channel, CONDA_URL)}/${subdir}/${filename}`;
       logger.debug('[conda-utils] 찾음', { filename, build: pkg.build });
       return {
         url: downloadUrl,
@@ -305,7 +311,7 @@ export async function getCondaDownloadUrl(
     const found = findPackageInRepoData(noarchRepodata, packageName, version);
     if (found) {
       const { filename, pkg } = found;
-      const downloadUrl = `${CONDA_URL}/${channel}/noarch/${filename}`;
+      const downloadUrl = `${getCondaRepositoryBase(channel, CONDA_URL)}/noarch/${filename}`;
       logger.debug('[conda-utils] noarch에서 찾음', { filename });
       return {
         url: downloadUrl,

--- a/src/core/shared/conda-validator.test.ts
+++ b/src/core/shared/conda-validator.test.ts
@@ -23,6 +23,20 @@ describe('Conda 채널 검증', () => {
     expect(validate(403)).toBe(false);
   });
 
+  it('defaults는 공식 main repository의 noarch endpoint를 검증한다', async () => {
+    vi.mocked(axios.head).mockResolvedValue({ status: 200 });
+
+    await expect(validateCondaChannel('defaults')).resolves.toBe(true);
+    expect(axios.head).toHaveBeenCalledWith(
+      'https://repo.anaconda.com/pkgs/main/noarch/repodata.json',
+      expect.objectContaining({ timeout: 5000 })
+    );
+    expect(axios.head).not.toHaveBeenCalledWith(
+      'https://conda.anaconda.org/defaults/noarch/repodata.json',
+      expect.anything()
+    );
+  });
+
   it('200 이외의 응답은 유효하지 않다', async () => {
     vi.mocked(axios.head).mockResolvedValue({ status: 204 });
     await expect(validateCondaChannel('empty-channel')).resolves.toBe(false);

--- a/src/core/shared/conda-validator.ts
+++ b/src/core/shared/conda-validator.ts
@@ -5,6 +5,7 @@
  */
 
 import axios from 'axios';
+import { getCondaRepositoryBase } from './conda-channel';
 
 /**
  * Conda 채널 유효성 검증 (단순 버전)
@@ -14,9 +15,8 @@ import axios from 'axios';
  */
 export async function validateCondaChannel(channel: string): Promise<boolean> {
   try {
-    // anaconda.org API를 통해 채널 존재 여부 확인
-    // https://conda.anaconda.org/{channel}/noarch/repodata.json
-    const baseUrl = `https://conda.anaconda.org/${channel}/noarch/repodata.json`;
+    // 논리 채널에 대응하는 repository endpoint를 통해 채널 존재 여부 확인
+    const baseUrl = `${getCondaRepositoryBase(channel)}/noarch/repodata.json`;
 
     const response = await axios.head(baseUrl, {
       timeout: 5000,
@@ -45,10 +45,10 @@ export async function validateCondaChannelStrict(
   subdirs: string[] = ['noarch', 'linux-64', 'win-64', 'osx-64']
 ): Promise<boolean> {
   try {
-    // 최소 하나의 subdir에서 repodata.json 접근 가능해야 함
+    // 최소 하나의 subdir에서 대응 repository의 repodata.json 접근 가능해야 함
     const results = await Promise.allSettled(
       subdirs.map((subdir) =>
-        axios.head(`https://conda.anaconda.org/${channel}/${subdir}/repodata.json`, {
+        axios.head(`${getCondaRepositoryBase(channel)}/${subdir}/repodata.json`, {
           timeout: 3000,
         })
       )

--- a/src/core/shared/index.ts
+++ b/src/core/shared/index.ts
@@ -23,6 +23,7 @@ export { AptMetadataParser } from './apt-metadata-parser';
 
 // Conda 유틸리티
 export { getCondaDownloadUrl, getCondaSubdir } from './conda-utils';
+export { getCondaApiOwner, getCondaRepositoryBase } from './conda-channel';
 
 // Conda MatchSpec 파서
 export {


### PR DESCRIPTION
## 변경 내용

Conda `defaults` 채널이 `conda.anaconda.org/defaults/...`로 조립되어 실제 Anaconda defaults 저장소를 찾지 못하던 문제를 수정합니다.

- 공식 defaults 저장소를 `https://repo.anaconda.com/pkgs/main`으로 정규화하고 resolver, downloader, 공용 캐시, Electron 경로, 검증 경로가 같은 채널 변환기를 사용합니다.
- 채널 API의 소유 기본값은 `defaults`로 유지하고, 내부 공용 API의 기본 원점은 `main`으로 명확히 분리했습니다.
- `noarch`와 대상 하위 디렉터리(`linux-64` 등)는 한 번씩만 조립합니다.
- 검색 결과의 `repository` 표기는 선택한 `defaults` 채널 의미를 유지합니다.
- 명시적 `main`과 사용자 지정 원점 채널의 기존 URL 조립은 유지합니다.

## 검증

- 전체 테스트: 2723 passed, 162 skipped
- 집중 테스트: 98 passed, 2 skipped
- resolver 별도: 45 passed
- router 별도: 6 passed
- TypeScript 두 설정: 통과
- 변경 파일 lint: 오류 0개 (기존 경고 19개)
- 실제 CLI `defaults` noarch: `repo.anaconda.com/pkgs/main/noarch`, `six-1.16.0`
- 실제 CLI `defaults` Linux x86_64: `repo.anaconda.com/pkgs/main/linux-64`, `six-1.17.0`
- conda-forge 확인: 기존 `conda.anaconda.org/conda-forge/noarch` 유지

실제 artifact의 `info/index.json`, manifest, 파일명, URL을 서로 대조했고 채널 또는 하위 디렉터리 중복이 없음을 확인했습니다. Native Conda 설치는 수행하지 않았습니다.

Closes #77
