### PR TITLE
fix: 캐시 목록에서 파일 항목 건너뛰기

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -293,14 +293,13 @@ depssmuggler cache list
 
 - `size`: 캐시 디렉터리 용량 출력
 - `clear`: 캐시 삭제, `--force` 없으면 확인 프롬프트 표시
-- `list`: 캐시 루트 엔트리를 표로 출력하고, 엔트리가 디렉터리이며 `manifest.json`이 있으면 메타데이터를 채웁니다.
+- `list`: 캐시 루트의 디렉터리 항목을 표로 출력하고, `manifest.json`이 있으면 메타데이터를 채웁니다. 일반 파일과 심볼릭 링크는 목록과 패키지 개수에서 제외합니다. 디렉터리가 없으면 캐시된 패키지가 없다고 안내합니다.
 
 ## 현재 한계
 
 - CLI는 GUI보다 지원 범위가 좁습니다.
 - OS 패키지 CLI는 `list-distros`, `search`, `download`, `cache`를 독립적으로 수행하며 Electron GUI에 의존하지 않습니다.
 - 일반 패키지 `search`는 `pip`, `conda`, `maven`, `npm`, `docker`에 연결되어 있지만, GUI 전용 위자드/시각화 흐름은 CLI에 없습니다.
-- `cache list`는 현재 캐시 루트가 디렉터리 위주라는 가정을 두고 있어, `cache-manifest.json` 같은 일반 파일이 섞인 경우 실패할 수 있습니다.
 - `cache size/clear/list`는 내부 조회·삭제 오류를 출력한 뒤 반환하는 경로가 있으므로, 캐시 자동화에서 종료 코드만으로 모든 파일 작업의 성공을 판정할 수는 없습니다.
 - CLI에는 SMTP 발송, 전달용 자동 분할, GUI 히스토리 저장 명령이 없습니다. 해당 기능은 Electron 일반 다운로드 전달 파이프라인에서 사용합니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,6 +95,8 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 
 ### CLI 캐시 설정 검증
 
+`src/cli/cache-commands.integration.test.ts`는 실제 파일·디렉터리가 섞인 캐시에서 별도 CLI 프로세스로 `cache list`를 실행합니다. 정상 디렉터리의 패키지 정보와 개수가 표시되고 일반 파일은 목록에서 제외되는지 확인합니다. `commands/cache.test.ts`는 심볼릭 링크 제외, 디렉터리가 없는 경우, manifest 유무에 따른 표시를 검증합니다.
+
 `src/cli/cache-settings.integration.test.ts`는 격리한 사용자 디렉터리와 별도 CLI 프로세스로 설정 저장·조회가 연결되는지 확인합니다. 로컬 HTTP APK 저장소를 이용해 캐시 비활성화 시 재요청과 파일 미생성, 활성화 시 저장·재사용, 설정한 크기 한도에 따른 캐시 저장 생략도 검사합니다. 잘못된 입력의 종료 코드와 설정 파일 보존은 실제 CLI 경계에서 확인합니다.
 
 `src/core/config.test.ts`는 저장 키와 이전 별칭의 우선순위, 비동기 API와의 호환성, 불리언·양의 안전 정수 검증을 담당합니다. OS backend 테스트는 옵션 전달을 확인하고, `cache-manager.test.ts`는 실제 임시 디렉터리에서 LRU와 한도 초과 항목의 저장 생략을 검증합니다. 저장 순서와 조회 순서를 다르게 만든 뒤 작은 용량으로 다시 열어도 최근 조회한 항목이 남는지 확인합니다. 이 테스트에는 native apt/yum/apk 실행 파일이 필요하지 않습니다.

--- a/src/cli/cache-commands.integration.test.ts
+++ b/src/cli/cache-commands.integration.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+
+const childHarness = `
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+require(path.join(projectRoot, 'node_modules/ts-node')).register({
+  project: path.join(projectRoot, 'tsconfig.cli.json'),
+});
+
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  ...JSON.parse(process.env.DEPS_SMUGGLER_ARGS),
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+interface ChildResult {
+  status: number;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runChild(
+  harnessPath: string,
+  isolatedHome: string,
+  args: string[],
+): Promise<ChildResult> {
+  try {
+    const result = await execFileAsync(process.execPath, [harnessPath], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+        DEPS_SMUGGLER_ARGS: JSON.stringify(args),
+        DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+        NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+      },
+      maxBuffer: 2 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    return { status: 0, signal: null, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const failure = error as typeof error & {
+      code?: number;
+      killed?: boolean;
+      signal?: string | null;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (
+      failure.killed === true ||
+      (failure.signal !== undefined && failure.signal !== null) ||
+      typeof failure.code !== 'number'
+    ) {
+      throw error;
+    }
+    return {
+      status: failure.code,
+      signal: failure.signal ?? null,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? '',
+    };
+  }
+}
+
+describe('CLI cache commands integration', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await fs.remove(tempRoot);
+    tempRoot = undefined;
+  });
+
+  it('lists valid cache directories when the root also contains a loose file', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-cache-list-'));
+    const harnessPath = path.join(tempRoot, 'cli-harness.cjs');
+    const isolatedHome = path.join(tempRoot, 'isolated user');
+    const cacheRoot = path.join(tempRoot, 'cache root');
+    const validCache = path.join(cacheRoot, 'valid-cache');
+    await fs.writeFile(harnessPath, childHarness);
+    await fs.ensureDir(validCache);
+    await fs.writeJson(path.join(validCache, 'manifest.json'), {
+      name: 'fixture-package',
+      version: '1.2.3',
+      type: 'apk',
+    });
+    await fs.writeFile(path.join(validCache, 'payload.apk'), 'fixture payload');
+    await fs.writeFile(path.join(cacheRoot, 'loose-cache-entry.json'), '{"loose":true}\n');
+
+    const configured = await runChild(
+      harnessPath,
+      isolatedHome,
+      ['config', 'set', 'cachePath', cacheRoot],
+    );
+    expect(configured.status, `${configured.stdout}\n${configured.stderr}`).toBe(0);
+    expect(configured.signal).toBeNull();
+
+    const listed = await runChild(harnessPath, isolatedHome, ['cache', 'list']);
+    expect(listed.status, `${listed.stdout}\n${listed.stderr}`).toBe(0);
+    expect(listed.signal).toBeNull();
+    expect(listed.stderr).not.toContain('ENOTDIR');
+    expect(listed.stdout.match(/fixture-package/g)).toHaveLength(1);
+    expect(listed.stdout.match(/1\.2\.3/g)).toHaveLength(1);
+    expect(listed.stdout).toContain('총 1개 패키지');
+  }, 120_000);
+});

--- a/src/cli/commands/cache.test.ts
+++ b/src/cli/commands/cache.test.ts
@@ -23,6 +23,10 @@ const fileStat = (size: number, directory = false) => ({
   isDirectory: () => directory,
   mtime: new Date('2026-01-01T00:00:00Z'),
 });
+const dirent = (name: string, directory: boolean) => ({
+  name,
+  isDirectory: () => directory,
+});
 const output = () => vi.mocked(console.log).mock.calls.flat().join('\n');
 const errors = () => vi.mocked(console.error).mock.calls.flat().join('\n');
 
@@ -133,7 +137,11 @@ describe('CLI 캐시 명령', () => {
 
   it('매니페스트가 있는 항목과 손상된 항목을 함께 표시한다', async () => {
     vi.mocked(fs.readdir).mockImplementation(
-      async (dir) => (String(dir) === 'test-cache' ? ['valid', 'broken'] : []) as never
+      async (dir) => (
+        String(dir) === 'test-cache'
+          ? [dirent('valid', true), dirent('broken', true)]
+          : []
+      ) as never
     );
     vi.mocked(fs.stat).mockResolvedValue(fileStat(0, true) as never);
     vi.mocked(fs.readJson).mockImplementation(async (target) => {
@@ -150,7 +158,11 @@ describe('CLI 캐시 명령', () => {
 
   it('빈 매니페스트의 이름과 버전은 대체값을 표시한다', async () => {
     vi.mocked(fs.readdir).mockImplementation(
-      async (dir) => (String(dir) === 'test-cache' ? ['unnamed-cache'] : []) as never
+      async (dir) => (
+        String(dir) === 'test-cache'
+          ? [dirent('unnamed-cache', true)]
+          : []
+      ) as never
     );
     vi.mocked(fs.readJson).mockResolvedValue({});
     vi.mocked(fs.stat).mockResolvedValue(fileStat(0, true) as never);
@@ -158,6 +170,47 @@ describe('CLI 캐시 명령', () => {
     expect(output()).toContain('unnamed-cache');
     expect(output()).toContain('0 B');
     expect(output()).toContain('총 1개 패키지');
+  });
+
+  it('root regular file과 symlink를 건너뛰고 유효한 디렉터리만 표시한다', async () => {
+    vi.mocked(fs.readdir).mockImplementation(
+      async (dir) => {
+        if (String(dir) === 'test-cache') {
+          return [
+            dirent('valid', true),
+            dirent('loose-cache-entry.json', false),
+            dirent('linked-cache', false),
+          ] as never;
+        }
+        return [] as never;
+      }
+    );
+    vi.mocked(fs.readJson).mockResolvedValue({ name: 'requests', version: '2.32.0', type: 'pip' });
+    vi.mocked(fs.stat).mockResolvedValue(fileStat(0, true) as never);
+
+    await cacheList();
+
+    expect(output()).toContain('requests');
+    expect(output()).toContain('총 1개 패키지');
+    expect(output()).not.toContain('loose-cache-entry.json');
+    expect(output()).not.toContain('linked-cache');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('root에 파일과 symlink만 있으면 캐시 없음으로 안내한다', async () => {
+    vi.mocked(fs.readdir).mockImplementation(
+      async (dir) => (
+        String(dir) === 'test-cache'
+          ? [dirent('cache-manifest.json', false), dirent('linked-cache', false)]
+          : []
+      ) as never
+    );
+
+    await cacheList();
+
+    expect(output()).toContain('캐시된 패키지가 없습니다');
+    expect(fs.readJson).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   it('목록 읽기 권한이 없으면 오류만 표시한다', async () => {

--- a/src/cli/commands/cache.ts
+++ b/src/cli/commands/cache.ts
@@ -73,7 +73,10 @@ export async function cacheList(): Promise<void> {
       return;
     }
 
-    const dirs = await fs.readdir(cachePath);
+    const entries = await fs.readdir(cachePath, { withFileTypes: true });
+    const dirs = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
     if (dirs.length === 0) {
       console.log(chalk.yellow('캐시된 패키지가 없습니다'));
       return;


### PR DESCRIPTION
## 문제

`cache list`가 캐시 루트의 모든 항목을 디렉터리로 가정해 regular file이나 symlink가 함께 있으면 `ENOTDIR`로 실패했습니다.

## 변경

- 실제 디렉터리인 캐시 항목만 읽고 regular file과 symlink는 건너뜁니다.
- 유효한 캐시 디렉터리는 한 번만 표시하고, 파일과 symlink만 있는 루트는 빈 캐시 메시지를 표시합니다.
- 캐시 명령과 CLI 테스트 문서를 갱신했습니다.

## 검증

- 실제 Node 20 CLI 혼합 루트: 디렉터리 1개, 파일 1개, symlink 1개에서 exit 0, 유효 패키지 1개를 한 번 표시
- 실제 Node 20 CLI 파일/symlink 전용 루트: exit 0, `캐시된 패키지가 없습니다`
- 전체 테스트 및 최종 CI 결과는 전달 시 갱신합니다.

Native OS 설치는 수행하지 않았습니다.

Closes #79
