### PR TITLE
fix: 지원하지 않는 archive 형식 거부

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -162,7 +162,7 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
 - Maven 설치 스크립트는 아카이브의 `packages/` canonical 저장소 경로를 GAV별로 `MAVEN_REPO_LOCAL`에 복사합니다. 기본 대상은 `~/.m2/repository`이며, GUI 출력의 `packages/m2repo/`도 지원합니다. 원본 POM·parent/BOM·POM-only·classifier·checksum은 같은 GAV 디렉터리에서 함께 보존되며 Maven 플러그인이나 네트워크 호출은 필요하지 않습니다.
 - Maven의 기존 `_remote.repositories` 기록은 보존하고, 이번에 복사한 아티팩트에만 로컬 설치 기록을 추가합니다. 파일 복사나 기록 저장에 실패하면 설치 스크립트도 오류로 종료합니다. PowerShell 스크립트는 Windows PowerShell 5에서도 한글을 읽을 수 있도록 UTF-8 BOM으로 저장합니다.
 - `MAVEN_REPO_LOCAL`을 상대 경로로 지정하면 설치 스크립트가 있는 폴더를 기준으로 사용합니다. 사용자 Maven 설정에서 별도의 `localRepository`를 사용하는 경우 이 변수에도 같은 위치를 지정합니다.
-- 출력 형식은 현재 `zip` 또는 `tar.gz`만 지원합니다.
+- 출력 형식은 `zip` 또는 `tar.gz`만 지원합니다. `--format rar`처럼 지원하지 않는 값을 지정하면 허용 형식을 안내하고 종료 코드 `1`을 반환합니다. 입력 파일 읽기·의존성 해결·다운로드·출력 디렉터리 생성 전에 검사하며, 다른 형식의 압축물이나 설치 스크립트를 만들지 않습니다.
 - OS 패키지(`yum`, `apt`, `apk`)는 이 명령이 아니라 `os` 네임스페이스를 사용해야 합니다.
 
 ## `search`

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -21,6 +21,8 @@
 | `getArchiveInfo` | archivePath: string | Promise<{ format, size, fileCount }> | 압축 파일 정보 조회 |
 | `verifyArchive` | archivePath: string | Promise<boolean> | 파일 존재 및 크기 > 0 확인 |
 
+`createArchive()`와 `createArchiveFromDirectory()`는 런타임에도 `options.format`이 `zip` 또는 `tar.gz`인지 검사합니다. 지원하지 않는 값은 입력 파일 조사와 출력 경로 생성 전에 오류로 거부합니다. 공개 함수 `assertArchiveFormat(value)`를 CLI의 사전 검증에서도 재사용하며, 알 수 없는 값을 tar.gz로 대체하지 않습니다.
+
 ### 내부 메서드
 
 | 메서드 | 설명 |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -177,6 +177,8 @@ bash scripts/verify-worktree.sh \
 
 ### CLI 다운로드 실패 종료 코드 검증
 
+`src/cli/download-format.integration.test.ts`는 격리한 실제 CLI 프로세스에 `--format rar`를 전달해 종료 코드 `1`, 거부한 값과 지원 형식 안내, 출력 미생성을 확인합니다. CLI를 불러오기 전에 HTTP·HTTPS 요청을 차단하고 요청 횟수를 기록하므로 네트워크 호출 전에 입력 검증이 끝나는지도 검사합니다. `archive-packager.test.ts`는 두 공개 압축 메서드를 직접 호출해 잘못된 형식의 거부와 기존 ZIP·tar.gz 생성을 검증합니다.
+
 `src/cli/download-failure-exit.integration.test.ts`는 별도 Node.js 프로세스에서 실제 CLI 엔트리포인트와 Commander 인자를 실행합니다. 부모 프로세스의 로컬 HTTP 서버가 404를 반환하고, 자식의 테스트 전용 설정이 실제 `MavenDownloader`의 저장소 주소만 이 서버로 연결합니다. 실제 다운로드 매니저가 실패 결과를 반환한 뒤 CLI가 종료 코드 `1`과 실패 원인을 남기고, 새 아카이브와 설치 스크립트를 생성하지 않는지 확인합니다. 설정·로그·출력은 임시 디렉터리로 격리하며 외부 레지스트리에 연결하지 않습니다.
 
 `src/cli/commands/download.test.ts`는 전체·일부 항목 실패 분기를 빠르게 검증합니다. 다운로드 전 의존성 해결의 기본 건너뛰기 정책은 별도 동작으로 유지합니다. 실제 레지스트리 검증에는 존재하지 않는 Maven classifier와 Docker 태그의 HTTP 404, 정상 패키지 다운로드의 종료 코드와 산출물을 함께 기록합니다.

--- a/src/cli/commands/download-session-integration.test.ts
+++ b/src/cli/commands/download-session-integration.test.ts
@@ -55,9 +55,13 @@ vi.mock('./download-runner', () => ({
   }),
 }));
 
-vi.mock('../../core/packager/archive-packager', () => ({
-  getArchivePackager: vi.fn(() => ({ createArchive })),
-}));
+vi.mock('../../core/packager/archive-packager', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/packager/archive-packager')>();
+  return {
+    ...actual,
+    getArchivePackager: vi.fn(() => ({ createArchive })),
+  };
+});
 
 vi.mock('../../core/packager/script-generator', () => ({
   getScriptGenerator: vi.fn(() => ({ generateAllScripts })),

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -60,11 +60,15 @@ vi.mock('./download-runner', () => ({
   }),
 }));
 
-vi.mock('../../core/packager/archive-packager', () => ({
-  getArchivePackager: vi.fn(() => ({
-    createArchive,
-  })),
-}));
+vi.mock('../../core/packager/archive-packager', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/packager/archive-packager')>();
+  return {
+    ...actual,
+    getArchivePackager: vi.fn(() => ({
+      createArchive,
+    })),
+  };
+});
 
 vi.mock('../../core/packager/script-generator', () => ({
   getScriptGenerator: vi.fn(() => ({
@@ -137,6 +141,32 @@ describe('downloadCommand', () => {
       dependencyTrees: [],
       failedPackages: [],
     });
+  });
+
+  it('지원하지 않는 archive 형식은 resolver와 출력 부수 효과 전에 거부한다', async () => {
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => {
+        throw new Error('process.exit');
+      }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      await expect(downloadCommand(commandOptions({ format: 'rar' }))).rejects.toThrow('process.exit');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('지원하지 않는 압축 형식입니다: rar. 지원 형식: zip, tar.gz'),
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+
+    expect(resolveAllDependencies).not.toHaveBeenCalled();
+    expect(addToQueue).not.toHaveBeenCalled();
+    expect(ensureDir).not.toHaveBeenCalled();
+    expect(startDownload).not.toHaveBeenCalled();
+    expect(createArchive).not.toHaveBeenCalled();
   });
 
   it('완료된 Maven 항목의 모든 파일을 중복 없이 아카이브하고 실패 항목은 제외한다', async () => {

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -8,7 +8,11 @@ import {
   type CliDownloadEnvironmentOptions,
 } from './download-environment';
 import { DownloadManager, OverallProgress } from './download-runner';
-import { getArchivePackager, ArchiveFormat } from '../../core/packager/archive-packager';
+import {
+  assertArchiveFormat,
+  getArchivePackager,
+  ArchiveFormat,
+} from '../../core/packager/archive-packager';
 import { getScriptGenerator } from '../../core/packager/script-generator';
 import { DownloadPackage, resolveAllDependencies } from '../../core/shared';
 import { PackageInfo, PackageType, Architecture } from '../../types';
@@ -260,6 +264,7 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
   console.log(chalk.cyan('다운로드 준비 중...'));
 
   try {
+    assertArchiveFormat(options.format);
     validateDownloadEnvironmentOptions(options);
     const maxDepth = parseMaxDepth(options.maxDepth ?? '5');
 

--- a/src/cli/download-format.integration.test.ts
+++ b/src/cli/download-format.integration.test.ts
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as fs from 'fs-extra';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+
+const childHarness = `
+const fs = require('node:fs');
+const http = require('node:http');
+const https = require('node:https');
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+const requestMarker = process.env.DEPS_SMUGGLER_REQUEST_MARKER;
+let requestCount = 0;
+const rejectNetwork = () => {
+  requestCount += 1;
+  throw new Error('Unexpected network request');
+};
+http.request = rejectNetwork;
+http.get = rejectNetwork;
+https.request = rejectNetwork;
+https.get = rejectNetwork;
+process.on('exit', () => {
+  fs.writeFileSync(requestMarker, String(requestCount));
+});
+
+require(path.join(projectRoot, 'node_modules/ts-node')).register({
+  project: path.join(projectRoot, 'tsconfig.cli.json'),
+});
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  ...JSON.parse(process.env.DEPS_SMUGGLER_ARGS),
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+interface ChildResult {
+  status: number;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+}
+
+async function runChild(
+  harnessPath: string,
+  isolatedHome: string,
+  markerPath: string,
+  args: string[],
+): Promise<ChildResult> {
+  try {
+    const result = await execFileAsync(process.execPath, [harnessPath], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+        DEPS_SMUGGLER_ARGS: JSON.stringify(args),
+        DEPS_SMUGGLER_REQUEST_MARKER: markerPath,
+        DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+        NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+      },
+      maxBuffer: 2 * 1024 * 1024,
+      timeout: 180_000,
+    });
+    return { status: 0, signal: null, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const failure = error as typeof error & {
+      code?: number;
+      killed?: boolean;
+      signal?: string | null;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (
+      failure.killed === true ||
+      (failure.signal !== undefined && failure.signal !== null) ||
+      typeof failure.code !== 'number'
+    ) {
+      throw error;
+    }
+    return {
+      status: failure.code,
+      signal: failure.signal ?? null,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? '',
+    };
+  }
+}
+
+describe('CLI archive format validation integration', () => {
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await fs.remove(tempRoot);
+    tempRoot = undefined;
+  });
+
+  it('rejects unsupported formats before network or delivery output', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-format-'));
+    const harnessPath = path.join(tempRoot, 'cli harness.cjs');
+    const isolatedHome = path.join(tempRoot, 'isolated user directory');
+    const output = path.join(tempRoot, 'output directory with spaces');
+    const requestMarker = path.join(tempRoot, 'request-count.txt');
+    await fs.writeFile(harnessPath, childHarness);
+
+    const child = await runChild(
+      harnessPath,
+      isolatedHome,
+      requestMarker,
+      [
+        'download',
+        '--type', 'pip',
+        '--package', 'colorama',
+        '--pkg-version', '0.4.6',
+        '--no-deps',
+        '--format', 'rar',
+        '--output', output,
+      ],
+    );
+
+    const outputText = `${child.stdout}\n${child.stderr}`;
+    expect(child.status, outputText).toBe(1);
+    expect(child.signal).toBeNull();
+    expect(outputText).toContain('rar');
+    expect(outputText).toContain('zip');
+    expect(outputText).toContain('tar.gz');
+    expect(await fs.readFile(requestMarker, 'utf8')).toBe('0');
+    expect(await fs.pathExists(output)).toBe(false);
+  }, 180_000);
+});

--- a/src/core/packager/archive-packager.test.ts
+++ b/src/core/packager/archive-packager.test.ts
@@ -42,6 +42,43 @@ describe('ArchivePackager', () => {
   });
 
   describe('createArchive', () => {
+    it('지원하지 않는 형식은 파일을 읽거나 출력 부모를 만들기 전에 거부한다', async () => {
+      const sourcePath = path.join(tempDir, 'source.txt');
+      const outputParent = path.join(tempDir, 'missing-parent');
+      const outputPath = path.join(outputParent, 'archive.zip');
+      await fs.writeFile(sourcePath, 'content');
+
+      await expect(
+        packager.createArchive(
+          [sourcePath],
+          outputPath,
+          [],
+          { format: 'rar' as ArchiveFormat },
+        ),
+      ).rejects.toThrow('지원하지 않는 압축 형식입니다: rar');
+      expect(await fs.pathExists(outputPath)).toBe(false);
+      expect(await fs.pathExists(outputParent)).toBe(false);
+    });
+
+    it('디렉터리 입력도 지원하지 않는 형식을 읽기 전에 거부한다', async () => {
+      const sourceDir = path.join(tempDir, 'source-dir');
+      const outputParent = path.join(tempDir, 'missing-dir-parent');
+      const outputPath = path.join(outputParent, 'archive.tar.gz');
+      await fs.ensureDir(sourceDir);
+      await fs.writeFile(path.join(sourceDir, 'source.txt'), 'content');
+
+      await expect(
+        packager.createArchiveFromDirectory(
+          sourceDir,
+          outputPath,
+          [],
+          { format: 'rar' as ArchiveFormat },
+        ),
+      ).rejects.toThrow('지원하지 않는 압축 형식입니다: rar');
+      expect(await fs.pathExists(outputPath)).toBe(false);
+      expect(await fs.pathExists(outputParent)).toBe(false);
+    });
+
     it('출력 디렉터리 아래의 중첩 아티팩트 경로를 보존한다', async () => {
       const firstFile = path.join(
         tempDir,
@@ -353,4 +390,5 @@ describe('ArchiveFormat 타입', () => {
     expect(formats).toContain('zip');
     expect(formats).toContain('tar.gz');
   });
+
 });

--- a/src/core/packager/archive-packager.ts
+++ b/src/core/packager/archive-packager.ts
@@ -15,6 +15,17 @@ export type {
 // 압축 형식 타입
 export type ArchiveFormat = ArchiveType;
 
+/**
+ * Validate archive format values received from CLI and other runtime callers.
+ */
+export function assertArchiveFormat(value: unknown): asserts value is ArchiveFormat {
+  if (value !== 'zip' && value !== 'tar.gz') {
+    throw new Error(
+      `지원하지 않는 압축 형식입니다: ${String(value)}. 지원 형식: zip, tar.gz`,
+    );
+  }
+}
+
 // 압축 옵션
 export interface ArchiveOptions {
   format: ArchiveFormat;
@@ -43,6 +54,7 @@ export class ArchivePackager {
     packages: PackageInfo[],
     options: ArchiveOptions
   ): Promise<string> {
+    assertArchiveFormat(options.format);
     const archiveBasePath = path.dirname(resolvePath(outputPath));
     const fileEntries = files.map((file) => {
       const sourcePath = resolvePath(file);
@@ -78,6 +90,7 @@ export class ArchivePackager {
     packages: PackageInfo[],
     options: ArchiveOptions
   ): Promise<string> {
+    assertArchiveFormat(options.format);
     const sourceFiles = await this.collectFiles(sourceDir);
     const { totalBytes, totalFiles } = await this.reportPreparationProgress(sourceFiles, options.onProgress);
     const metadataEntries = this.buildMetadataEntries(


### PR DESCRIPTION
## 변경 내용

지원하지 않는 archive 형식이 입력되면 다운로드가 성공한 것처럼 `.tar.gz`를 생성하던 문제를 수정했습니다. 이제 `zip`과 `tar.gz`만 허용하고, 잘못된 형식은 명확한 오류와 exit 1로 거부합니다.

- archive format 입력 검증 및 packager 오류 전파
- CLI format 회귀 테스트와 archive 구조 테스트 추가
- `Closes #81`

## 검증

- full: 2764 passed / 162 skipped
- targeted: 62 passed
- TypeScript 두 설정 PASS
- lint: 0 errors, 7 existing warnings
- 실제 Node 20 CLI: `colorama@0.4.6 --no-deps`의 `rar`는 exit 1·output 없음; `zip`과 `tar.gz`는 exit 0
- zip/tar.gz 내부에는 manifest, README, wheel이 포함되며 generated `install.sh`/`install.ps1`는 archive 옆 output에 생성됨
- native install, global install, release 작업은 수행하지 않음
