### PR TITLE
fix: npm manifest에 실제 resolved version 기록

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,6 +157,7 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
 - 다운로드 성공 시 출력 디렉터리에 `packages-<timestamp>.zip` 또는 `.tar.gz`를 만든 뒤, 같은 디렉터리에 설치 스크립트를 생성합니다. 이 호출 순서에서는 별도로 생성한 설치 스크립트가 앞서 만든 아카이브에 포함되지 않습니다.
 - Docker는 압축을 풀어 생긴 `packages/`와 설치 스크립트를 같은 폴더에 두고 실행합니다. Bash·PowerShell 모두 실제 이미지 파일명(예: `packages/busybox-1.36.tar`)을 `docker load -i`에 전달합니다. `amd64`·`arm64`와 ZIP·tar.gz 출력에서 같은 이름 규칙을 사용하며, 대상 환경에는 실행 중인 Docker가 필요합니다.
 - npm은 압축을 풀어 생긴 `packages/` 폴더와 설치 스크립트를 같은 폴더에 두고 실행합니다. Node.js와 npm이 설치된 환경에서 전달된 `.tgz`를 `npm install --offline`으로 설치하며, 결과는 스크립트 폴더의 `npm-project/node_modules`에 생깁니다. 이 전용 프로젝트에 설치용 `package.json`을 생성하며 상위 폴더의 사용자 manifest는 변경하지 않습니다.
+- npm 다운로드가 성공하면 아카이브의 `manifest.json`에는 실제로 받은 버전을 기록합니다. `--no-deps`에서 버전을 생략하거나 `latest`를 지정한 경우도 tarball 내부 `package.json`과 같은 버전을 표시합니다.
 - npm 설치 스크립트는 tarball 내부 이름·버전과 전달 경로를 기록합니다. 직접 요청한 패키지만 최상위 의존성으로 등록하고, 선택한 버전과 전이 의존성의 여러 버전을 필요한 하위 경로에 설치합니다. scoped 패키지도 지원합니다. 같은 이름의 서로 다른 버전을 직접 루트로 함께 지정하면 모호한 설치 결과를 만들지 않고 스크립트 생성에 실패합니다. 기존 `npm-project`에 사용자 프로젝트가 있으면 다른 폴더에 압축을 풀어 실행해야 합니다.
 - `--no-deps` 출력에 필요한 npm 의존성이 빠져 있으면 오프라인 설치가 실패할 수 있으며, 이 경우 스크립트도 오류로 종료합니다. 설치 대상 환경의 Node.js·OS·아키텍처에 맞는 패키지를 전달해야 하며, npm의 일반 설치 lifecycle은 그대로 실행됩니다.
 - Maven 설치 스크립트는 아카이브의 `packages/` canonical 저장소 경로를 GAV별로 `MAVEN_REPO_LOCAL`에 복사합니다. 기본 대상은 `~/.m2/repository`이며, GUI 출력의 `packages/m2repo/`도 지원합니다. 원본 POM·parent/BOM·POM-only·classifier·checksum은 같은 GAV 디렉터리에서 함께 보존되며 Maven 플러그인이나 네트워크 호출은 필요하지 않습니다.

--- a/docs/downloaders.md
+++ b/docs/downloaders.md
@@ -626,6 +626,7 @@ const versions = results[0]?.versions ?? [];
 - 위치: `src/core/downloaders/npm.ts`
 - 버전 스펙 해석과 packument 조회는 `src/core/shared/npm-version-resolver.ts`를 재사용한다.
 - tarball 저장과 진행률 이벤트 생성은 `BaseLanguageDownloader`가 담당하고, `NpmDownloader`는 packument 해석과 integrity/sha1 검증 기준을 제공한다.
+- `downloadPackage()`는 파일 저장과 제공된 무결성 검증이 성공한 뒤 전달받은 `PackageInfo`의 `version`을 실제 선택한 버전으로 갱신하고 조회한 메타데이터를 병합한다. 기존 객체·이름·타입·아키텍처와 별도 호출자 메타데이터는 유지하며, 다운로드 URL과 체크섬은 실제 받은 패키지 기준으로 반영한다. 다운로드나 무결성 검증에 실패하면 입력 정보는 갱신하지 않는다.
 
 ### 클래스 구조
 

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -65,6 +65,8 @@ interface ArchivePackageManifest {
 archive 전용 canonical 정의는 `src/types/manifest/package-manifest.ts`의 `ArchivePackageManifest`에 두고, `archive-packager.ts`는 해당 타입을 재사용합니다.
 `src/types`의 공개 `PackageManifest`는 기존 packaging contract를 유지하는 compatibility surface입니다.
 
+manifest는 완료된 다운로드 항목의 `PackageInfo`를 기록합니다. npm의 `latest` 같은 버전 선택자는 다운로드 성공 시 실제 버전으로 갱신되므로, CLI `--no-deps` 아카이브에도 tarball과 일치하는 버전이 들어갑니다.
+
 ### 사용 예시
 ```typescript
 import { getArchivePackager } from './core/packager/archive-packager';

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -206,6 +206,8 @@ DEPS_SMUGGLER_NATIVE_DOCKER=1 bash scripts/verify-worktree.sh \
 
 ### npm 설치 스크립트 오프라인 검증
 
+`src/cli/npm-manifest.integration.test.ts`는 로컬 레지스트리와 실제 tarball을 제공하고 별도 CLI 프로세스에서 `--no-deps` 다운로드를 실행합니다. `latest`와 고정 버전 요청 모두 ZIP의 manifest 버전이 tarball 내부 `package/package.json`의 버전과 일치하는지 확인합니다. 이 검증은 npm 설치를 실행하지 않습니다. npm 다운로더 단위 테스트는 성공 후 버전·메타데이터 갱신과 기존 입력 정보 보존, 실패 시 입력 미변경을 검증합니다.
+
 `src/core/packager/npm-install-script.integration.test.ts`는 레지스트리에 연결하지 않고 로컬 tarball fixture로 생성 스크립트를 실제 실행합니다. macOS·Linux에서는 Bash, Windows에서는 `powershell.exe`와 해당 환경의 npm을 사용합니다. 빈 npm 캐시와 별도 설정·설치 경로를 사용하며, 공백이 포함된 경로와 scoped 전이 의존성을 설치한 뒤 Node.js에서 실제 모듈을 불러와 검사합니다. 같은 패키지의 1.x·2.x를 요구하는 두 루트가 각각 올바른 버전을 불러오는지, 명시적으로 선택한 직접 버전이 유지되는지도 검증합니다. 서로 다른 peer 버전을 요구하는 전이 플러그인과 순환 의존성도 실제 npm 설치 및 모듈 로딩으로 확인합니다. 설치 대상은 `npm-project/node_modules`이며 상위 사용자 manifest 보존과 기존 사용자 프로젝트 덮어쓰기 방지를 확인합니다. 패키지 파일 또는 필요한 의존성이 없거나 tarball이 손상된 경우에는 오류 종료와 성공 문구 부재를 확인합니다. macOS 임시 디렉터리의 `/var`→`/private/var` 경로 차이에서도 여러 버전을 설치할 수 있어야 합니다. Windows의 `NODE_OPTIONS` preload 경로는 `JSON.stringify`로 인코딩해 역슬래시가 손실되지 않도록 합니다.
 
 ### Maven 설치 스크립트 canonical 저장소 검증

--- a/src/cli/npm-manifest.integration.test.ts
+++ b/src/cli/npm-manifest.integration.test.ts
@@ -1,0 +1,299 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+import { createRequire } from 'node:module';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import * as fs from 'fs-extra';
+import * as tar from 'tar';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const yauzl = require('yauzl') as {
+  open: (
+    filePath: string,
+    options: { lazyEntries: boolean },
+    callback: (
+      error: Error | null,
+      zipFile?: {
+        readEntry: () => void;
+        on: (event: string, listener: (...args: any[]) => void) => void;
+        openReadStream: (
+          entry: any,
+          callback: (error: Error | null, stream?: NodeJS.ReadableStream) => void
+        ) => void;
+        close: () => void;
+      }
+    ) => void
+  ) => void;
+};
+
+const execFileAsync = promisify(execFile);
+const projectRoot = process.cwd();
+const isolateHomeScript = path.join(projectRoot, 'tests/fixtures/isolate-home.cjs');
+
+const childHarness = `
+const path = require('node:path');
+const projectRoot = process.env.DEPS_SMUGGLER_PROJECT_ROOT;
+require(path.join(projectRoot, 'node_modules/ts-node')).register({
+  project: path.join(projectRoot, 'tsconfig.cli.json'),
+});
+
+const { NPM_CONSTANTS } = require(path.join(projectRoot, 'src/core/constants/npm.ts'));
+NPM_CONSTANTS.DEFAULT_REGISTRY_URL = process.env.DEPS_SMUGGLER_NPM_REGISTRY_URL;
+
+process.argv = [
+  process.execPath,
+  path.join(projectRoot, 'src/cli/index.ts'),
+  ...JSON.parse(process.env.DEPS_SMUGGLER_NPM_ARGS),
+];
+require(path.join(projectRoot, 'src/cli/index.ts'));
+`;
+
+interface ChildResult {
+  code: number;
+  signal: string | null;
+  killed: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('fixture server did not expose a port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function runChild(
+  harnessPath: string,
+  isolatedHome: string,
+  registryUrl: string,
+  output: string,
+  version: string
+): Promise<ChildResult> {
+  try {
+    const result = await execFileAsync(process.execPath, [harnessPath], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        DEPS_SMUGGLER_PROJECT_ROOT: projectRoot,
+        DEPS_SMUGGLER_NPM_REGISTRY_URL: registryUrl,
+        DEPS_SMUGGLER_NPM_ARGS: JSON.stringify([
+          'download',
+          '--type',
+          'npm',
+          '--package',
+          'fixture-package',
+          '--pkg-version',
+          version,
+          '--output',
+          output,
+          '--format',
+          'zip',
+          '--no-deps',
+          '--concurrency',
+          '1',
+        ]),
+        DEPS_SMUGGLER_TEST_USER_DIR: isolatedHome,
+        NODE_OPTIONS: `--require ${JSON.stringify(isolateHomeScript)}`,
+      },
+      maxBuffer: 2 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    return { code: 0, signal: null, killed: false, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const failure = error as typeof error & {
+      code?: number;
+      killed?: boolean;
+      signal?: string | null;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (
+      failure.killed === true ||
+      (failure.signal !== undefined && failure.signal !== null) ||
+      typeof failure.code !== 'number'
+    ) {
+      throw error;
+    }
+    return {
+      code: failure.code,
+      signal: failure.signal ?? null,
+      killed: false,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? '',
+    };
+  }
+}
+
+async function createPackageTarball(
+  root: string
+): Promise<{ path: string; bytes: Buffer; sha1: string }> {
+  const packageDirectory = path.join(root, 'package');
+  const archivePath = path.join(root, 'fixture-package-3.0.1.tgz');
+  await fs.ensureDir(packageDirectory);
+  await fs.writeJson(path.join(packageDirectory, 'package.json'), {
+    name: 'fixture-package',
+    version: '3.0.1',
+    description: 'local npm fixture',
+  });
+  await tar.create({ cwd: root, file: archivePath, gzip: true }, ['package']);
+  const bytes = await fs.readFile(archivePath);
+  return {
+    path: archivePath,
+    bytes,
+    sha1: createHash('sha1').update(bytes).digest('hex'),
+  };
+}
+
+async function readZipEntries(filePath: string): Promise<Map<string, Buffer>> {
+  return new Promise((resolve, reject) => {
+    yauzl.open(filePath, { lazyEntries: true }, (error, zipFile) => {
+      if (error || !zipFile) {
+        reject(error ?? new Error('ZIP 열기 실패'));
+        return;
+      }
+      const entries = new Map<string, Buffer>();
+      zipFile.on('error', reject);
+      zipFile.on('end', () => resolve(entries));
+      zipFile.on('entry', (entry: { fileName: string }) => {
+        zipFile.openReadStream(entry, (streamError, stream) => {
+          if (streamError || !stream) {
+            reject(streamError ?? new Error(`ZIP entry 열기 실패: ${entry.fileName}`));
+            zipFile.close();
+            return;
+          }
+          const chunks: Buffer[] = [];
+          stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+          stream.on('error', reject);
+          stream.on('end', () => {
+            entries.set(entry.fileName, Buffer.concat(chunks));
+            zipFile.readEntry();
+          });
+        });
+      });
+      zipFile.readEntry();
+    });
+  });
+}
+
+async function readNestedManifest(
+  tgzBytes: Buffer,
+  root: string
+): Promise<Record<string, unknown>> {
+  const extractionRoot = await fs.mkdtemp(path.join(root, 'nested-tarball-'));
+  const tgzPath = path.join(extractionRoot, 'archive-package.tgz');
+  await fs.writeFile(tgzPath, tgzBytes);
+  await tar.extract({ file: tgzPath, cwd: extractionRoot, strip: 0 });
+  return fs.readJson(path.join(extractionRoot, 'package/package.json'));
+}
+
+describe('npm CLI manifest version integration', () => {
+  let tempRoot: string | undefined;
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    const activeServer = server;
+    if (activeServer?.listening) {
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+    }
+    server = undefined;
+    if (tempRoot) await fs.remove(tempRoot);
+    tempRoot = undefined;
+  });
+
+  it('uses the resolved npm version in the ZIP manifest and downloaded tarball', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-npm-manifest-'));
+    const tarball = await createPackageTarball(tempRoot);
+    const requests: string[] = [];
+    const fixtureServer = createServer((request, response) => {
+      const requestPath = request.url ?? '';
+      requests.push(requestPath);
+      if (requestPath === '/fixture-package') {
+        const port = (fixtureServer.address() as { port: number }).port;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(
+          JSON.stringify({
+            name: 'fixture-package',
+            'dist-tags': { latest: '3.0.1' },
+            versions: {
+              '3.0.1': {
+                name: 'fixture-package',
+                version: '3.0.1',
+                dist: {
+                  tarball: `http://127.0.0.1:${port}/fixture-package/-/fixture-package-3.0.1.tgz`,
+                  shasum: tarball.sha1,
+                },
+              },
+            },
+          })
+        );
+        return;
+      }
+      if (requestPath === '/fixture-package/-/fixture-package-3.0.1.tgz') {
+        response.writeHead(200, { 'content-type': 'application/octet-stream' });
+        response.end(tarball.bytes);
+        return;
+      }
+      response.writeHead(404);
+      response.end('fixture not found');
+    });
+    server = fixtureServer;
+    const port = await listen(fixtureServer);
+    const registryUrl = `http://127.0.0.1:${port}`;
+    const harnessPath = path.join(tempRoot, 'npm-cli-harness.cjs');
+    const isolatedHome = path.join(tempRoot, 'isolated user');
+    const latestOutput = path.join(tempRoot, 'output latest');
+    const fixedOutput = path.join(tempRoot, 'output fixed');
+    await fs.writeFile(harnessPath, childHarness);
+    await fs.ensureDir(isolatedHome);
+
+    const latest = await runChild(harnessPath, isolatedHome, registryUrl, latestOutput, 'latest');
+    const fixed = await runChild(harnessPath, isolatedHome, registryUrl, fixedOutput, '3.0.1');
+
+    for (const result of [latest, fixed]) {
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.killed).toBe(false);
+      expect(result.stdout).toContain('압축 파일 생성 완료');
+    }
+
+    expect(requests.filter((requestPath) => requestPath === '/fixture-package')).toHaveLength(2);
+    expect(
+      requests.filter(
+        (requestPath) => requestPath === '/fixture-package/-/fixture-package-3.0.1.tgz'
+      )
+    ).toHaveLength(2);
+    expect(requests).toHaveLength(4);
+
+    for (const output of [latestOutput, fixedOutput]) {
+      const archives = (await fs.readdir(output)).filter((name) => /^packages-.*\.zip$/.test(name));
+      expect(archives).toHaveLength(1);
+      const archiveName = archives[0];
+      if (!archiveName) throw new Error('ZIP archive was not created');
+      const entries = await readZipEntries(path.join(output, archiveName));
+      expect(entries.has('manifest.json')).toBe(true);
+      const manifestEntry = entries.get('manifest.json');
+      if (!manifestEntry) throw new Error('ZIP manifest.json was not created');
+      const manifest = JSON.parse(manifestEntry.toString('utf8')) as {
+        packages: Array<{ name: string; version: string }>;
+      };
+      expect(manifest.packages).toHaveLength(1);
+      expect(manifest.packages[0]).toMatchObject({ name: 'fixture-package', version: '3.0.1' });
+      const tarballEntry = entries.get('packages/fixture-package-3.0.1.tgz');
+      if (!tarballEntry) throw new Error('ZIP npm tarball was not created');
+      if (!tempRoot) throw new Error('fixture root was removed before inspection');
+      const nestedManifest = await readNestedManifest(tarballEntry, tempRoot);
+      expect(nestedManifest).toMatchObject({ name: 'fixture-package', version: '3.0.1' });
+    }
+  }, 240_000);
+});

--- a/src/core/downloaders/npm-download.test.ts
+++ b/src/core/downloaders/npm-download.test.ts
@@ -58,6 +58,90 @@ describe('NpmDownloader downloadPackage 테스트', () => {
   });
 
   describe('downloadPackage', () => {
+    it('성공한 다운로드 후 resolve된 버전과 메타데이터를 원본 PackageInfo에 반영한다', async () => {
+      const mockGetPackageMetadata = vi.fn().mockResolvedValue({
+        name: 'test-pkg',
+        version: '3.0.1',
+        type: 'npm',
+        metadata: {
+          downloadUrl: 'https://registry.npmjs.org/test-pkg/-/test-pkg-3.0.1.tgz',
+          checksum: { sha1: 'resolved-sha1' },
+          description: 'resolved metadata',
+        },
+      });
+      (downloader as any).getPackageMetadata = mockGetPackageMetadata;
+
+      const mockStream = new EventEmitter();
+      (mockStream as any).pipe = vi.fn().mockReturnValue(mockStream);
+      mockAxiosDefault.mockResolvedValue({
+        data: mockStream,
+        headers: { 'content-length': '1000' },
+      });
+      const mockWriter = new EventEmitter();
+      (fs.createWriteStream as any).mockReturnValue(mockWriter);
+      (downloader as any).verifyShasum = vi.fn().mockResolvedValue(true);
+
+      const info = {
+        type: 'npm' as const,
+        name: 'test-pkg',
+        version: 'latest',
+        arch: 'x86_64' as const,
+        metadata: {
+          requestedVersion: 'latest',
+          checksum: { sha512: 'caller-sha512' },
+          callerFlag: true,
+        },
+      };
+      const downloadPromise = downloader.downloadPackage(info, '/tmp/test');
+
+      setTimeout(() => {
+        mockStream.emit('data', Buffer.from('test data'));
+        mockWriter.emit('finish');
+      }, 10);
+
+      await downloadPromise;
+
+      expect(info).toEqual({
+        type: 'npm',
+        name: 'test-pkg',
+        version: '3.0.1',
+        arch: 'x86_64',
+        metadata: {
+          requestedVersion: 'latest',
+          checksum: { sha1: 'resolved-sha1' },
+          callerFlag: true,
+          downloadUrl: 'https://registry.npmjs.org/test-pkg/-/test-pkg-3.0.1.tgz',
+          description: 'resolved metadata',
+        },
+      });
+    });
+
+    it('전송에 실패하면 원본 PackageInfo를 변경하지 않는다', async () => {
+      const mockGetPackageMetadata = vi.fn().mockResolvedValue({
+        name: 'test-pkg',
+        version: '3.0.1',
+        type: 'npm',
+        metadata: {
+          downloadUrl: 'https://registry.npmjs.org/test-pkg/-/test-pkg-3.0.1.tgz',
+        },
+      });
+      (downloader as any).getPackageMetadata = mockGetPackageMetadata;
+      (downloader as any).downloadArtifactFile = vi.fn().mockRejectedValue(new Error('transfer failed'));
+
+      const info = {
+        type: 'npm' as const,
+        name: 'test-pkg',
+        version: 'latest',
+        arch: 'x86_64' as const,
+        metadata: { requestedVersion: 'latest', callerFlag: true },
+      };
+      const before = structuredClone(info);
+
+      await expect(downloader.downloadPackage(info, '/tmp/test')).rejects.toThrow('transfer failed');
+
+      expect(info).toEqual(before);
+    });
+
     it('다운로드 성공 (체크섬 없음)', async () => {
       // getPackageMetadata 모킹
       const mockGetPackageMetadata = vi.fn().mockResolvedValue({
@@ -166,7 +250,13 @@ describe('NpmDownloader downloadPackage 테스트', () => {
       const mockVerifyIntegrity = vi.fn().mockResolvedValue(false);
       (downloader as any).verifyIntegrity = mockVerifyIntegrity;
 
-      const info = { type: 'npm' as const, name: 'test-pkg', version: '1.0.0' };
+      const info = {
+        type: 'npm' as const,
+        name: 'test-pkg',
+        version: 'latest',
+        metadata: { callerFlag: true },
+      };
+      const before = structuredClone(info);
       const downloadPromise = downloader.downloadPackage(info, '/tmp/test');
 
       setTimeout(() => {
@@ -175,6 +265,7 @@ describe('NpmDownloader downloadPackage 테스트', () => {
       }, 10);
 
       await expect(downloadPromise).rejects.toThrow('무결성 검증 실패');
+      expect(info).toEqual(before);
     });
 
     it('sha1 체크섬 검증 성공', async () => {

--- a/src/core/downloaders/npm.ts
+++ b/src/core/downloaders/npm.ts
@@ -160,6 +160,12 @@ export class NpmDownloader extends BaseLanguageDownloader implements IDownloader
         onProgress
       );
 
+      info.version = packageInfo.version;
+      info.metadata = {
+        ...info.metadata,
+        ...packageInfo.metadata,
+      };
+
       logger.info('npm 패키지 다운로드 완료', {
         name: info.name,
         version: info.version,


### PR DESCRIPTION
## 변경 내용

npm 버전을 생략하거나 `latest`로 요청할 때 실제 tarball의 버전과 archive manifest가 서로 달라지던 문제를 수정했습니다. npm downloader가 성공적으로 해석한 실제 package metadata를 전달해 manifest가 실제 tarball 버전을 기록하도록 했습니다.

- omitted/latest npm 요청의 resolved version metadata 반영
- pinned version 동작 유지
- 실제 archive와 nested tarball manifest 회귀 테스트 추가
- `Closes #82`

## 검증

- 실제 Node 20 CLI: `is-odd --no-deps` 버전 생략 및 `-V 3.0.1` 모두 exit 0
- 두 archive manifest와 nested `package/package.json` 모두 `is-odd@3.0.1`
- archive members: `manifest.json`, `README.txt`, `packages/is-odd-3.0.1.tgz`
- native npm install, global install, release 작업은 수행하지 않음
