### PR TITLE
fix: Conda 오프라인 설치 스크립트 생성

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,12 @@ jobs:
           DEPS_SMUGGLER_NATIVE_APT: '1'
         run: bash scripts/verify-worktree.sh src/core/downloaders/apt-native-consumer.integration.test.ts
 
+      - name: Test generated Conda installer with native Conda
+        if: runner.os == 'Linux'
+        env:
+          DEPS_SMUGGLER_NATIVE_CONDA: '1'
+        run: bash scripts/verify-worktree.sh src/core/packager/conda-native-consumer.integration.test.ts
+
       - name: Build project
         run: npm run build
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,9 @@ depssmuggler download -t maven -p org.lwjgl:lwjgl -V 3.3.6 \
 
 - 실제 파일 다운로드 항목이 하나라도 실패하면 실패 목록을 출력하고 종료 코드 `1`로 끝납니다. 이 경우 이번 실행의 아카이브와 설치 스크립트를 생성하지 않습니다. 성공한 다운로드의 종료 코드는 `0`이며, 다운로드 전 의존성 해결 단계의 기본 건너뛰기 정책과 `--strict`는 위 설명을 따릅니다.
 - 다운로드 성공 시 출력 디렉터리에 `packages-<timestamp>.zip` 또는 `.tar.gz`를 만든 뒤, 같은 디렉터리에 설치 스크립트를 생성합니다. 이 호출 순서에서는 별도로 생성한 설치 스크립트가 앞서 만든 아카이브에 포함되지 않습니다.
+- Conda는 압축을 풀어 생긴 `packages/`와 설치 스크립트를 같은 폴더에 두고 실행합니다. 설치된 Conda를 사용해 전달된 `.conda`·`.tar.bz2` 파일만 `--offline`으로 설치하며, pip 패키지는 별도 pip 분기로 처리합니다. 기본 대상은 스크립트 폴더의 `conda-env`이고 새 환경에 사용자 설정의 기본 패키지를 추가하지 않습니다. 기존 Conda 환경이면 재생성하지 않고 설치 명령을 실행하며, 같은 위치에 일반 파일·디렉터리가 있으면 오류로 종료합니다.
+- 기존 Python 환경에 설치하려면 스크립트 실행 전에 `DEPS_SMUGGLER_CONDA_PREFIX`에 해당 Conda 환경 경로를 지정합니다. 상대 경로는 스크립트 폴더를 기준으로 해석합니다. 예를 들어 Bash에서는 `DEPS_SMUGGLER_CONDA_PREFIX=/path/to/env bash install.sh`, PowerShell에서는 `$env:DEPS_SMUGGLER_CONDA_PREFIX = 'C:\path\to\env'; .\install.ps1`로 실행합니다. 설치 후 `conda activate <환경 경로>`로 사용할 수 있습니다.
+- Conda 설치 스크립트는 전달된 파일 집합을 그대로 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. `--no-deps`로 받은 `six` 같은 Python 패키지만으로는 새 환경에 Python 런타임이 생기지 않으므로 호환되는 기존 환경을 지정하거나 필요한 런타임과 의존성도 함께 전달해야 합니다. Conda 부재·파일 누락·설치 실패는 스크립트의 오류 종료로 이어지고 완료 메시지를 출력하지 않습니다.
 - Docker는 압축을 풀어 생긴 `packages/`와 설치 스크립트를 같은 폴더에 두고 실행합니다. Bash·PowerShell 모두 실제 이미지 파일명(예: `packages/busybox-1.36.tar`)을 `docker load -i`에 전달합니다. `amd64`·`arm64`와 ZIP·tar.gz 출력에서 같은 이름 규칙을 사용하며, 대상 환경에는 실행 중인 Docker가 필요합니다.
 - npm은 압축을 풀어 생긴 `packages/` 폴더와 설치 스크립트를 같은 폴더에 두고 실행합니다. Node.js와 npm이 설치된 환경에서 전달된 `.tgz`를 `npm install --offline`으로 설치하며, 결과는 스크립트 폴더의 `npm-project/node_modules`에 생깁니다. 이 전용 프로젝트에 설치용 `package.json`을 생성하며 상위 폴더의 사용자 manifest는 변경하지 않습니다.
 - npm 다운로드가 성공하면 아카이브의 `manifest.json`에는 실제로 받은 버전을 기록합니다. `--no-deps`에서 버전을 생략하거나 `latest`를 지정한 경우도 tarball 내부 `package.json`과 같은 버전을 표시합니다.

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -141,6 +141,7 @@ interface ScriptOptions {
   packageDir?: string;            // 기본 './packages'
   npmPackageFiles?: { filePath: string; relativePath: string }[];
   npmRootPackages?: PackageInfo[]; // 직접 요청한 npm 패키지의 해결된 버전
+  condaPackageFiles?: { relativePath: string }[]; // packages/ 안의 실제 Conda 파일 경로
 }
 
 interface GeneratedScript {
@@ -178,7 +179,7 @@ Get-ChildItem -Path $PackageDir -Directory -Recurse | ForEach-Object {
 pip install --no-index @FindLinkArgs requests==2.31.0
 ```
 
-실제 파일은 헤더, 패키지 디렉터리와 실행 도구 확인, 로그 함수와 타입별 설치 함수를 포함합니다. Python은 하위 디렉터리마다 `--find-links`를 추가합니다. Maven은 패키지 메타데이터의 GAV 좌표로 canonical 저장소 경로를 선택해 `packages/<group>/<artifact>/<version>/`를 `MAVEN_REPO_LOCAL` 또는 기본 `~/.m2/repository`에 그대로 복사합니다. GUI 출력의 `packages/m2repo/` 구조도 지원하며, 같은 GAV 디렉터리의 원본 POM, parent/BOM POM, POM-only 항목, classifier와 checksum을 보존합니다. Bash와 PowerShell 모두 Maven 플러그인이나 네트워크를 호출하지 않고, 좌표 디렉터리가 없거나 복사에 실패하면 오류로 종료합니다. Bash는 pip/conda·npm·Maven·YUM·Docker 블록을, PowerShell은 pip/conda·npm·Maven·Docker 블록을 생성하며 YUM 설치 블록은 없습니다.
+실제 파일은 헤더, 패키지 디렉터리와 실행 도구 확인, 로그 함수와 타입별 설치 함수를 포함합니다. pip은 하위 디렉터리마다 `--find-links`를 추가합니다. Maven은 패키지 메타데이터의 GAV 좌표로 canonical 저장소 경로를 선택해 `packages/<group>/<artifact>/<version>/`를 `MAVEN_REPO_LOCAL` 또는 기본 `~/.m2/repository`에 그대로 복사합니다. GUI 출력의 `packages/m2repo/` 구조도 지원하며, 같은 GAV 디렉터리의 원본 POM, parent/BOM POM, POM-only 항목, classifier와 checksum을 보존합니다. Bash와 PowerShell 모두 Maven 플러그인이나 네트워크를 호출하지 않고, 좌표 디렉터리가 없거나 복사에 실패하면 오류로 종료합니다. Bash는 pip·Conda·npm·Maven·YUM·Docker 블록을, PowerShell은 pip·Conda·npm·Maven·Docker 블록을 생성하며 YUM 설치 블록은 없습니다.
 
 Maven의 `_remote.repositories`는 대상 저장소의 기존 내용을 보존하며 복사한 아티팩트에만 `파일명>=` 로컬 설치 기록을 추가합니다. `.demo`처럼 점으로 시작하는 아티팩트의 POM·JAR·체크섬도 복사합니다. 체크섬과 대상에만 존재하는 파일은 등록하지 않고, 원본에 있는 추적 파일로 대상 기록을 덮어쓰지도 않습니다. 재실행해도 로컬 기록은 중복되지 않습니다. 기록 저장에 실패하거나 좌표 디렉터리에 아티팩트가 없으면 오류로 종료합니다. 생성된 PowerShell 파일은 Windows PowerShell 5의 한글 해석을 위해 UTF-8 BOM을 포함합니다.
 
@@ -194,7 +195,13 @@ CLI는 `npmRootPackages`에 실제 직접 요청 목록과 해결된 버전을 �
 
 상위 폴더의 사용자 `package.json`은 변경하지 않습니다. `npm-project`는 비어 있거나 이 스크립트가 생성한 프로젝트여야 하며, 소유 표시가 없는 기존 프로젝트나 심볼릭 링크 대상은 오류로 처리합니다. 설치용 manifest는 유지하지만 프로젝트 루트의 lockfile은 생성하지 않으며 npm 자체 업데이트 확인도 끕니다. Node.js와 npm이 필요하며, 도구 부재·빈 파일 목록·의존성 누락·손상된 tarball·설치 명령 실패는 오류 종료로 이어집니다. npm의 일반 설치 lifecycle은 유지합니다. 이 스크립트는 의존성을 전달된 파일에 연결하며, OS·아키텍처 간 네이티브 패키지 변환이나 설치 lifecycle의 외부 다운로드 대체는 수행하지 않습니다.
 
-일반 `ScriptGenerator`에는 APT·APK 전용 설치 블록이 없고, Conda 항목도 pip 설치 블록으로 묶입니다. `.conda` 파일을 설치하는 Conda 전용 스크립트로 간주하면 안 됩니다. OS 다운로드 전용 스크립트는 별도의 `OSScriptGenerator`가 제공합니다. `includeVerification`/`mirrorPath` 옵션은 이 클래스에 없습니다.
+Conda는 pip와 별도의 설치 블록을 생성합니다. CLI는 완료된 Conda 다운로드 항목의 실제 파일 경로를 `condaPackageFiles`로 전달하므로 `--no-deps` 입력의 메타데이터에 파일명이 없어도 다운로드한 파일을 참조합니다. 이 옵션을 생략한 API 호출은 각 Conda 항목의 정확한 `metadata.filename`을 사용합니다. 파일명 누락·빈 명시 목록·잘못된 상대 경로·지원하지 않는 확장자는 생성 오류이며, 다른 패키지의 `.tar.bz2`를 함께 설치하지 않도록 폴더 전체를 확장자로 탐색하지 않습니다. 실행 시에는 선언된 파일의 존재를 확인합니다.
+
+Conda 블록은 [명시적 로컬 아카이브 설치](https://docs.conda.io/projects/conda/en/stable/commands/install.html)를 사용합니다. 기본 대상 `SCRIPT_DIR/conda-env`가 없으면 `conda create --offline --yes --no-default-packages --prefix ...`를, 기존 Conda 환경이면 `conda install --offline --yes --prefix ...`를 실행합니다. `DEPS_SMUGGLER_CONDA_PREFIX`로 대상을 지정할 수 있고 상대 경로는 스크립트 폴더 기준입니다. 일반 파일·디렉터리를 기존 환경으로 덮어쓰지 않으며, 필수 파일이나 Conda가 없거나 명령이 실패하면 Bash·PowerShell 모두 non-zero로 종료합니다. `includeErrorHandling: false`여도 Conda 실패를 성공으로 처리하지 않습니다.
+
+명시적 파일 설치는 전달된 파일 집합을 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. Python noarch 패키지는 대상 환경에 호환되는 Python이 필요하므로, `--no-deps` 묶음은 기존 환경을 지정하거나 런타임을 별도로 준비해야 합니다. 이 내용은 CLI의 `ScriptGenerator`에 관한 것으로 Electron의 별도 `shared/script-utils` 생성기를 변경하지 않습니다.
+
+일반 `ScriptGenerator`에는 APT·APK 전용 설치 블록이 없습니다. OS 다운로드 전용 스크립트는 별도의 `OSScriptGenerator`가 제공합니다. `includeVerification`/`mirrorPath` 옵션은 이 클래스에 없습니다.
 
 Docker 설치 블록은 다운로더와 같은 `buildDockerArchiveFilename()`을 사용해 `packages/<repo>-<tag>.tar`를 로드합니다. namespace·registry 제거와 파일명 정규화도 동일하게 적용하므로 `busybox:1.36`은 `busybox-1.36.tar`를 참조합니다. Bash와 PowerShell 모두 파일명을 인용해 공백이 포함된 추출 경로에서도 하나의 `docker load -i` 인자로 전달합니다. 아키텍처나 ZIP·tar.gz 선택은 내부 이미지 tar 이름에 영향을 주지 않습니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -233,6 +233,18 @@ DEPS_SMUGGLER_NATIVE_DOCKER=1 bash scripts/verify-worktree.sh \
 
 실제 CLI 다운로드 검증은 `busybox:1.36`의 `--arch amd64 --format zip`과 `--arch arm64 --format tar.gz` 출력에서 `packages/busybox-1.36.tar`, tar 내부 manifest와 config 아키텍처, 원본 설치 스크립트의 참조 경로를 함께 확인합니다. Docker가 없는 환경의 파일·스크립트 검사와 엔진을 사용한 로드 결과는 구분해 기록합니다.
 
+### Conda 설치 스크립트 오프라인 검증
+
+`src/core/packager/conda-install-script.integration.test.ts`는 생성한 Bash와 Windows PowerShell 스크립트를 실제 프로세스로 실행합니다. 기본 회귀는 기록용 실행 파일로 pip·Conda 인자 분리, `.conda`·`.tar.bz2`의 정확한 경로, 공백·인용 문자, 루트만 포함한 목록, 환경 경로 지정, 재실행과 오류 종료를 검사합니다. 기록용 실행 파일의 성공을 실제 Conda 설치 성공으로 간주하지 않습니다. CLI 단위 테스트는 다운로드 항목에 메타데이터 파일명이 없어도 실제 완료 경로를 전달하며 다른 타입의 파일을 Conda 목록에 섞지 않는지 확인합니다.
+
+`src/core/packager/conda-native-consumer.integration.test.ts`는 Ubuntu CI의 기존 Miniconda를 사용하는 native 검증을 별도로 실행합니다.
+
+```bash
+DEPS_SMUGGLER_NATIVE_CONDA=1 bash scripts/verify-worktree.sh src/core/packager/conda-native-consumer.integration.test.ts
+```
+
+기본 실행에서는 native 검증을 건너뛰며, 명시적으로 opt-in한 환경에서 Linux나 필수 도구 조건이 맞지 않으면 실패합니다. 임시 prefix·캐시·설정과 `CONDA_REGISTER_ENVS=false`로 사용자 환경 등록 파일까지 격리합니다. 실제 Conda로 두 아카이브 형식을 설치하고 패키지 목록과 설치 파일을 검사하며, 설정한 로컬 채널의 HTTP 요청이 없는지 확인합니다. Python noarch 설치는 호환되는 Python이 있는 임시 환경에서 별도로 검사합니다. 일반 noarch 파일의 설치만으로 Python import 성공을 주장하지 않습니다. 도구 설치나 호스트 base 환경 변경은 수행하지 않습니다.
+
 ### npm 설치 스크립트 오프라인 검증
 
 `src/cli/npm-manifest.integration.test.ts`는 로컬 레지스트리와 실제 tarball을 제공하고 별도 CLI 프로세스에서 `--no-deps` 다운로드를 실행합니다. `latest`와 고정 버전 요청 모두 ZIP의 manifest 버전이 tarball 내부 `package/package.json`의 버전과 일치하는지 확인합니다. 이 검증은 npm 설치를 실행하지 않습니다. npm 다운로더 단위 테스트는 성공 후 버전·메타데이터 갱신과 기존 입력 정보 보존, 실패 시 입력 미변경을 검증합니다.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -245,6 +245,8 @@ DEPS_SMUGGLER_NATIVE_CONDA=1 bash scripts/verify-worktree.sh src/core/packager/c
 
 기본 실행에서는 native 검증을 건너뛰며, 명시적으로 opt-in한 환경에서 Linux나 필수 도구 조건이 맞지 않으면 실패합니다. 임시 prefix·캐시·설정과 `CONDA_REGISTER_ENVS=false`로 사용자 환경 등록 파일까지 격리합니다. 실제 Conda로 두 아카이브 형식을 설치하고 패키지 목록과 설치 파일을 검사하며, 설정한 로컬 채널의 HTTP 요청이 없는지 확인합니다. Python noarch 설치는 호환되는 Python이 있는 임시 환경에서 별도로 검사합니다. 일반 noarch 파일의 설치만으로 Python import 성공을 주장하지 않습니다. 도구 설치나 호스트 base 환경 변경은 수행하지 않습니다.
 
+Python 검증 환경은 runner의 base 환경에 설치된 Python과 전이 의존성 기록에 해당하는 캐시 아카이브만 임시 경로로 복사해 준비합니다. 필요한 아카이브가 없으면 구체적인 준비 오류로 실패합니다. 생성 스크립트에는 `CONDA_OFFLINE=false`를 전달해 스크립트 자체의 `--offline` 옵션을 검증하며, 환경 준비·설치·import 단계별 실행 시간을 CI 로그에 남깁니다.
+
 ### npm 설치 스크립트 오프라인 검증
 
 `src/cli/npm-manifest.integration.test.ts`는 로컬 레지스트리와 실제 tarball을 제공하고 별도 CLI 프로세스에서 `--no-deps` 다운로드를 실행합니다. `latest`와 고정 버전 요청 모두 ZIP의 manifest 버전이 tarball 내부 `package/package.json`의 버전과 일치하는지 확인합니다. 이 검증은 npm 설치를 실행하지 않습니다. npm 다운로더 단위 테스트는 성공 후 버전·메타데이터 갱신과 기존 입력 정보 보존, 실패 시 입력 미변경을 검증합니다.

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -968,6 +968,77 @@ describe('downloadCommand', () => {
     ]);
   });
 
+  it('Conda 스크립트에는 완료된 실제 archive 경로만 전달한다', async () => {
+    const outputRoot = '/tmp/conda script output';
+    const condaArchive = `${outputRoot}/nested dir/six-1.17.0-py312h06a4308_0.tar.bz2`;
+    const condaDependencyArchive = `${outputRoot}/nested dir/python_abi-3.12-0.conda`;
+    const pipArchive = `${outputRoot}/pip/requests-2.32.0.tar.bz2`;
+    vi.mocked(resolveAllDependencies).mockResolvedValueOnce({
+      originalPackages: [
+        {
+          id: 'conda-six-1.17.0',
+          type: 'conda',
+          name: 'six',
+          version: '1.17.0',
+          architecture: 'x86_64',
+        },
+      ],
+      allPackages: [
+        {
+          id: 'conda-six-1.17.0',
+          type: 'conda',
+          name: 'six',
+          version: '1.17.0',
+          architecture: 'x86_64',
+        },
+      ],
+      dependencyTrees: [],
+      failedPackages: [],
+    });
+    startDownload.mockResolvedValueOnce({
+      success: true,
+      totalSize: 1024,
+      duration: 1000,
+      items: [{
+        id: 'conda-six-1.17.0',
+        package: { type: 'conda', name: 'six', version: '1.17.0' },
+        status: 'completed',
+        progress: 100,
+        filePath: condaArchive,
+        filePaths: [condaArchive, condaDependencyArchive, condaDependencyArchive],
+      }, {
+        id: 'pip-requests-2.32.0',
+        package: { type: 'pip', name: 'requests', version: '2.32.0' },
+        status: 'completed',
+        progress: 100,
+        filePath: pipArchive,
+        filePaths: [pipArchive],
+      }],
+    });
+
+    await downloadCommand(commandOptions({
+      type: 'conda',
+      package: 'six',
+      pkgVersion: '1.17.0',
+      deps: false,
+      output: outputRoot,
+    }));
+
+    expect(generateAllScripts).toHaveBeenCalledWith(
+      expect.any(Array),
+      outputRoot,
+      expect.objectContaining({
+        condaPackageFiles: [
+          { relativePath: 'nested dir/six-1.17.0-py312h06a4308_0.tar.bz2' },
+          { relativePath: 'nested dir/python_abi-3.12-0.conda' },
+        ],
+      }),
+    );
+    expect(generateAllScripts.mock.calls[0][2].condaPackageFiles).not.toContainEqual({
+      relativePath: 'pip/requests-2.32.0.tar.bz2',
+    });
+  });
+
   it('기본 Maven --no-deps의 latest는 concrete root artifact를 resolver로 검증한다', async () => {
     const concreteRoot = {
       id: 'maven-org.example:demo-3.0.2',

--- a/src/cli/commands/download.test.ts
+++ b/src/cli/commands/download.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadCommand } from './download';
 import { resolveAllDependencies } from '../../core/shared';
@@ -969,10 +970,10 @@ describe('downloadCommand', () => {
   });
 
   it('Conda 스크립트에는 완료된 실제 archive 경로만 전달한다', async () => {
-    const outputRoot = '/tmp/conda script output';
-    const condaArchive = `${outputRoot}/nested dir/six-1.17.0-py312h06a4308_0.tar.bz2`;
-    const condaDependencyArchive = `${outputRoot}/nested dir/python_abi-3.12-0.conda`;
-    const pipArchive = `${outputRoot}/pip/requests-2.32.0.tar.bz2`;
+    const outputRoot = path.resolve('tmp', 'conda script output');
+    const condaArchive = path.join(outputRoot, 'nested dir', 'six-1.17.0-py312h06a4308_0.tar.bz2');
+    const condaDependencyArchive = path.join(outputRoot, 'nested dir', 'python_abi-3.12-0.conda');
+    const pipArchive = path.join(outputRoot, 'pip', 'requests-2.32.0.tar.bz2');
     vi.mocked(resolveAllDependencies).mockResolvedValueOnce({
       originalPackages: [
         {

--- a/src/cli/commands/download.ts
+++ b/src/cli/commands/download.ts
@@ -13,7 +13,7 @@ import {
   getArchivePackager,
   ArchiveFormat,
 } from '../../core/packager/archive-packager';
-import { getScriptGenerator } from '../../core/packager/script-generator';
+import { getScriptGenerator, type ScriptOptions } from '../../core/packager/script-generator';
 import { DownloadPackage, resolveAllDependencies } from '../../core/shared';
 import { PackageInfo, PackageType, Architecture } from '../../types';
 import type { PipTargetPlatform } from '../../types/platform/pip-target-platform';
@@ -86,6 +86,33 @@ function getPipTargetPlatform(
     arch,
     pythonVersion: options.pythonVersion,
   };
+}
+
+function getArchiveRelativePath(filePath: string, outputPath: string): string {
+  const archiveBasePath = path.resolve(outputPath);
+  const sourcePath = path.resolve(filePath);
+  const relativePath = path.relative(archiveBasePath, sourcePath);
+  const isContained =
+    relativePath.length > 0 &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath);
+
+  return (isContained ? relativePath : path.basename(filePath)).split(path.sep).join('/');
+}
+
+function getCondaPackageFiles(
+  items: Array<{ package: PackageInfo; status: string; filePath?: string; filePaths?: string[] }>,
+  outputPath: string,
+): Array<{ relativePath: string }> {
+  const relativePaths = new Set<string>();
+  for (const item of items) {
+    if (item.status !== 'completed' || item.package.type !== 'conda' || !item.filePath) continue;
+    for (const filePath of item.filePaths ?? [item.filePath]) {
+      relativePaths.add(getArchiveRelativePath(filePath, outputPath));
+    }
+  }
+  return [...relativePaths].map(relativePath => ({ relativePath }));
 }
 
 function toDownloadPackage(pkg: PackageInfo): DownloadPackage {
@@ -425,14 +452,15 @@ export async function downloadCommand(options: DownloadCommandOptions): Promise<
       // 설치 스크립트 생성
       console.log(chalk.cyan('\n설치 스크립트 생성 중...'));
       const scriptGenerator = getScriptGenerator();
+      const scriptOptions: ScriptOptions = {};
       if (packages.some(pkg => pkg.type === 'npm')) {
-        await scriptGenerator.generateAllScripts(packages, outputPath, {
-          npmPackageFiles: files.map(filePath => ({ filePath, relativePath: path.basename(filePath) })),
-          npmRootPackages: prepared.npmRootPackages,
-        });
-      } else {
-        await scriptGenerator.generateAllScripts(packages, outputPath);
+        scriptOptions.npmPackageFiles = files.map(filePath => ({ filePath, relativePath: path.basename(filePath) }));
+        scriptOptions.npmRootPackages = prepared.npmRootPackages;
       }
+      if (packages.some(pkg => pkg.type === 'conda')) {
+        scriptOptions.condaPackageFiles = getCondaPackageFiles(result.items, outputPath);
+      }
+      await scriptGenerator.generateAllScripts(packages, outputPath, scriptOptions);
       console.log(chalk.green('✓ 설치 스크립트 생성 완료'));
     } else {
       console.log(chalk.yellow('⚠ 다운로드 완료 (일부 실패)'));

--- a/src/core/packager/conda-install-script.integration.test.ts
+++ b/src/core/packager/conda-install-script.integration.test.ts
@@ -1,0 +1,318 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getScriptGenerator, type ScriptOptions } from './script-generator';
+import type { PackageInfo } from '../../types';
+
+const condaRoot: PackageInfo = { type: 'conda', name: 'fixture-root', version: '1.0.0' };
+const condaDependency: PackageInfo = { type: 'conda', name: 'fixture-dependency', version: '2.0.0' };
+const pipPackage: PackageInfo = { type: 'pip', name: 'fixture-pip', version: '3.0.0' };
+const rootArchive = "nested dir/O'Reilly $root.conda";
+const dependencyArchive = 'nested dir/fixture-dependency-2.0.0-0.tar.bz2';
+
+function options(files: string[]): ScriptOptions {
+  return { condaPackageFiles: files.map((relativePath) => ({ relativePath })) };
+}
+
+function generatedScript(
+  scripts: Awaited<ReturnType<ReturnType<typeof getScriptGenerator>['generateAllScripts']>>,
+  type: 'bash' | 'powershell'
+) {
+  const script = scripts.find((candidate) => candidate.type === type);
+  if (!script) throw new Error('Missing generated ' + type + ' script');
+  return script;
+}
+
+async function createBundle(root: string, relativePaths: string[]): Promise<{ outputDir: string; packageDir: string }> {
+  const outputDir = path.join(root, 'bundle with spaces');
+  const packageDir = path.join(outputDir, 'packages');
+  await fs.promises.mkdir(packageDir, { recursive: true });
+  for (const relativePath of relativePaths) {
+    const filePath = path.join(packageDir, relativePath);
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.promises.writeFile(filePath, relativePath + '\n');
+  }
+  return { outputDir, packageDir };
+}
+
+async function createCondaShim(root: string): Promise<{ binDir: string; logPath: string }> {
+  const binDir = path.join(root, 'shim bin');
+  const logPath = path.join(root, 'conda argv.jsonl');
+  const nodeShim = path.join(root, 'conda argv shim.cjs');
+  await fs.promises.mkdir(binDir, { recursive: true });
+  await fs.promises.writeFile(
+    nodeShim,
+    [
+      "const fs = require('node:fs');",
+      "const path = require('node:path');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.CONDA_SHIM_LOG, JSON.stringify(args) + '\\n');",
+      "const prefixIndex = args.indexOf('--prefix');",
+      "const prefix = prefixIndex >= 0 ? args[prefixIndex + 1] : undefined;",
+      "const exitCode = Number(process.env.CONDA_SHIM_EXIT_CODE || '0');",
+      "if (exitCode === 0 && prefix && (args[0] === 'create' || args[0] === 'install')) {",
+      "  fs.mkdirSync(path.join(prefix, 'conda-meta'), { recursive: true });",
+      "  fs.writeFileSync(path.join(prefix, 'conda-meta', 'history'), 'fixture\\\\n');",
+      "}",
+      "process.exit(exitCode);",
+      "",
+    ].join('\n')
+  );
+
+  if (process.platform === 'win32') {
+    await fs.promises.writeFile(
+      path.join(binDir, 'conda.cmd'),
+      '@echo off\r\n"' + process.execPath + '" "' + nodeShim + '" %*\r\nexit /b %ERRORLEVEL%\r\n'
+    );
+    await fs.promises.writeFile(
+      path.join(binDir, 'pip.cmd'),
+      '@echo off\r\n"' + process.execPath + '" "' + nodeShim + '" pip %*\r\nexit /b %ERRORLEVEL%\r\n'
+    );
+  } else {
+    await fs.promises.writeFile(
+      path.join(binDir, 'conda'),
+      '#!/bin/sh\nexec "' + process.execPath + '" "' + nodeShim + '" "$@"\n',
+      { mode: 0o755 }
+    );
+    await fs.promises.writeFile(
+      path.join(binDir, 'pip'),
+      '#!/bin/sh\nexec "' + process.execPath + '" "' + nodeShim + '" pip "$@"\n',
+      { mode: 0o755 }
+    );
+  }
+  return { binDir, logPath };
+}
+
+async function runScript(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv
+): Promise<{ stdout: string; stderr: string; code: number | null; signal: NodeJS.Signals | null }> {
+  const command = process.platform === 'win32'
+    ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+    : '/bin/bash';
+  const args = process.platform === 'win32'
+    ? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]
+    : [scriptPath];
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: path.dirname(scriptPath), env });
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => child.kill('SIGTERM'), 30_000);
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ stdout, stderr, code, signal });
+    });
+  });
+}
+
+async function readCalls(logPath: string): Promise<string[][]> {
+  if (!fs.existsSync(logPath)) return [];
+  const content = await fs.promises.readFile(logPath, 'utf8');
+  return content.trim() === '' ? [] : content.trim().split('\n').map((line) => JSON.parse(line) as string[]);
+}
+
+function testEnvironment(
+  shim: { binDir: string; logPath: string },
+  extra: NodeJS.ProcessEnv = {}
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: shim.binDir + path.delimiter + (process.env.PATH ?? ''),
+    DEPS_SMUGGLER_CONDA_PREFIX: '',
+    CONDA_SHIM_LOG: shim.logPath,
+    ...extra,
+  };
+}
+
+function expectCompleted(result: { code: number | null; signal: NodeJS.Signals | null }): void {
+  expect(typeof result.code).toBe('number');
+  expect(result.signal).toBeNull();
+}
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  return fs.realpathSync.native(directory);
+}
+
+function generatedArchivePath(bundle: { outputDir: string; packageDir: string }, relativePath: string): string {
+  if (process.platform === 'win32') return path.join(bundle.packageDir, relativePath);
+  return bundle.outputDir + path.sep + '.' + path.sep + 'packages' + path.sep + relativePath.split('/').join(path.sep);
+}
+
+describe('Conda offline installer consumer contract', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const directory of tempDirs.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('keeps pip separate, passes exact quoted archives, and reruns with install', async () => {
+    const root = await makeTempDir('depssmuggler conda consumer-');
+    tempDirs.push(root);
+    const bundle = await createBundle(root, [rootArchive, dependencyArchive]);
+    const shim = await createCondaShim(root);
+    const scripts = await getScriptGenerator().generateAllScripts(
+      [pipPackage, condaRoot, condaDependency],
+      bundle.outputDir,
+      options([rootArchive, dependencyArchive])
+    );
+    const script = generatedScript(scripts, process.platform === 'win32' ? 'powershell' : 'bash');
+    const firstRun = await runScript(script.path, testEnvironment(shim));
+    expectCompleted(firstRun);
+    expect(firstRun.code).toBe(0);
+
+    const prefix = path.join(bundle.outputDir, 'conda-env');
+    expect(fs.existsSync(path.join(prefix, 'conda-meta', 'history'))).toBe(true);
+    await fs.promises.writeFile(path.join(prefix, 'sentinel-preserved'), 'keep');
+    const secondRun = await runScript(script.path, testEnvironment(shim));
+    expectCompleted(secondRun);
+    expect(secondRun.code).toBe(0);
+    expect(await fs.promises.readFile(path.join(prefix, 'sentinel-preserved'), 'utf8')).toBe('keep');
+
+    const expectedArchives = [
+      generatedArchivePath(bundle, rootArchive),
+      generatedArchivePath(bundle, dependencyArchive),
+    ];
+    const calls = await readCalls(shim.logPath);
+    const condaCalls = calls.filter((call) => call[0] === 'create' || call[0] === 'install');
+    const pipCalls = calls.filter((call) => call[0] === 'pip');
+    expect(condaCalls).toEqual([
+      ['create', '--offline', '--yes', '--no-default-packages', '--prefix', prefix, ...expectedArchives],
+      ['install', '--offline', '--yes', '--prefix', prefix, ...expectedArchives],
+    ]);
+    expect(pipCalls).toHaveLength(2);
+    for (const call of pipCalls) {
+      expect(call).toContain('install');
+      expect(call).toContain('fixture-pip==3.0.0');
+      expect(call).not.toContain(rootArchive);
+      expect(call).not.toContain(dependencyArchive);
+    }
+  }, 60_000);
+
+  it('passes only the root archive for a no-deps bundle', async () => {
+    const root = await makeTempDir('depssmuggler conda nodeps-');
+    tempDirs.push(root);
+    const bundle = await createBundle(root, [rootArchive]);
+    const shim = await createCondaShim(root);
+    const scripts = await getScriptGenerator().generateAllScripts([condaRoot], bundle.outputDir, options([rootArchive]));
+    const script = generatedScript(scripts, process.platform === 'win32' ? 'powershell' : 'bash');
+    const result = await runScript(script.path, testEnvironment(shim));
+    expectCompleted(result);
+    expect(result.code).toBe(0);
+    expect((await readCalls(shim.logPath)).filter((call) => call[0] !== 'pip')).toEqual([
+      ['create', '--offline', '--yes', '--no-default-packages', '--prefix', path.join(bundle.outputDir, 'conda-env'), generatedArchivePath(bundle, rootArchive)],
+    ]);
+  }, 60_000);
+
+  it('uses install mode for relative and absolute existing prefixes', async () => {
+    const root = await makeTempDir('depssmuggler conda prefixes-');
+    tempDirs.push(root);
+    const bundle = await createBundle(root, [rootArchive]);
+    const shim = await createCondaShim(root);
+    const relativePrefix = path.join(bundle.outputDir, 'existing relative');
+    const absolutePrefix = path.join(root, 'existing absolute');
+    for (const prefix of [relativePrefix, absolutePrefix]) {
+      await fs.promises.mkdir(path.join(prefix, 'conda-meta'), { recursive: true });
+      await fs.promises.writeFile(path.join(prefix, 'conda-meta', 'history'), 'existing\n');
+    }
+    const scripts = await getScriptGenerator().generateAllScripts([condaRoot], bundle.outputDir, options([rootArchive]));
+    const script = generatedScript(scripts, process.platform === 'win32' ? 'powershell' : 'bash');
+    const relativeResult = await runScript(script.path, testEnvironment(shim, { DEPS_SMUGGLER_CONDA_PREFIX: 'existing relative' }));
+    const absoluteResult = await runScript(script.path, testEnvironment(shim, { DEPS_SMUGGLER_CONDA_PREFIX: absolutePrefix }));
+    expectCompleted(relativeResult);
+    expectCompleted(absoluteResult);
+    expect(relativeResult.code).toBe(0);
+    expect(absoluteResult.code).toBe(0);
+    expect((await readCalls(shim.logPath)).filter((call) => call[0] !== 'pip')).toEqual([
+      ['install', '--offline', '--yes', '--prefix', relativePrefix, generatedArchivePath(bundle, rootArchive)],
+      ['install', '--offline', '--yes', '--prefix', absolutePrefix, generatedArchivePath(bundle, rootArchive)],
+    ]);
+  }, 60_000);
+
+  it('fails before Conda when an archive is missing or the executable is unavailable', async () => {
+    const root = await makeTempDir('depssmuggler conda missing-');
+    tempDirs.push(root);
+    const bundle = await createBundle(root, []);
+    const shim = await createCondaShim(root);
+    const missingScripts = await getScriptGenerator().generateAllScripts(
+      [condaRoot],
+      bundle.outputDir,
+      { includeErrorHandling: false, ...options(['missing.conda']) }
+    );
+    const missingResult = await runScript(
+      generatedScript(missingScripts, process.platform === 'win32' ? 'powershell' : 'bash').path,
+      testEnvironment(shim)
+    );
+    expectCompleted(missingResult);
+    expect(missingResult.code).not.toBe(0);
+    expect(missingResult.stdout).not.toContain('모든 설치가 완료되었습니다');
+    expect(missingResult.stdout + missingResult.stderr).toContain('Conda 아카이브를 찾을 수 없습니다');
+    expect(await readCalls(shim.logPath)).toEqual([]);
+
+    const executableRoot = await makeTempDir('depssmuggler conda no-exe-');
+    tempDirs.push(executableRoot);
+    const executableBundle = await createBundle(executableRoot, [rootArchive]);
+    const executableScripts = await getScriptGenerator().generateAllScripts(
+      [condaRoot],
+      executableBundle.outputDir,
+      { includeErrorHandling: false, ...options([rootArchive]) }
+    );
+    const emptyPath = path.join(executableRoot, 'empty path');
+    await fs.promises.mkdir(emptyPath);
+    if (process.platform !== 'win32') {
+      await fs.promises.symlink('/usr/bin/dirname', path.join(emptyPath, 'dirname'));
+    }
+    const noExecutableResult = await runScript(
+      generatedScript(executableScripts, process.platform === 'win32' ? 'powershell' : 'bash').path,
+      {
+        ...process.env,
+        PATH: emptyPath,
+        DEPS_SMUGGLER_CONDA_PREFIX: '',
+        CONDA_SHIM_LOG: shim.logPath,
+      }
+    );
+    expectCompleted(noExecutableResult);
+    expect(noExecutableResult.code).not.toBe(0);
+    expect(noExecutableResult.stdout).not.toContain('모든 설치가 완료되었습니다');
+    expect(noExecutableResult.stdout + noExecutableResult.stderr).toContain('Conda가 설치되어 있지 않습니다');
+  }, 60_000);
+
+  it('propagates Conda failure and preserves an ordinary existing directory', async () => {
+    const root = await makeTempDir('depssmuggler conda failure-');
+    tempDirs.push(root);
+    const bundle = await createBundle(root, [rootArchive]);
+    const shim = await createCondaShim(root);
+    const scripts = await getScriptGenerator().generateAllScripts(
+      [condaRoot],
+      bundle.outputDir,
+      { includeErrorHandling: false, ...options([rootArchive]) }
+    );
+    const failed = await runScript(
+      generatedScript(scripts, process.platform === 'win32' ? 'powershell' : 'bash').path,
+      testEnvironment(shim, { CONDA_SHIM_EXIT_CODE: '23' })
+    );
+    expectCompleted(failed);
+    expect(failed.code).not.toBe(0);
+    expect(failed.stdout).not.toContain('모든 설치가 완료되었습니다');
+    expect(await readCalls(shim.logPath)).toHaveLength(1);
+
+    await fs.promises.rm(shim.logPath, { force: true });
+    const ordinaryPrefix = path.join(root, 'ordinary existing');
+    await fs.promises.mkdir(ordinaryPrefix, { recursive: true });
+    const sentinel = path.join(ordinaryPrefix, 'sentinel');
+    await fs.promises.writeFile(sentinel, 'keep');
+    const ordinary = await runScript(
+      generatedScript(scripts, process.platform === 'win32' ? 'powershell' : 'bash').path,
+      testEnvironment(shim, { DEPS_SMUGGLER_CONDA_PREFIX: ordinaryPrefix })
+    );
+    expectCompleted(ordinary);
+    expect(ordinary.code).not.toBe(0);
+    expect(await fs.promises.readFile(sentinel, 'utf8')).toBe('keep');
+    expect(await readCalls(shim.logPath)).toEqual([]);
+  }, 60_000);
+});

--- a/src/core/packager/conda-native-consumer.integration.test.ts
+++ b/src/core/packager/conda-native-consumer.integration.test.ts
@@ -1,0 +1,405 @@
+import { execFile as execFileCallback, spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getScriptGenerator, type ScriptOptions } from './script-generator';
+import type { PackageInfo } from '../../types';
+
+const execFile = promisify(execFileCallback);
+const nativeEnabled = process.env.DEPS_SMUGGLER_NATIVE_CONDA === '1';
+const nativeSuite = nativeEnabled ? describe : describe.skip;
+
+type RunResult = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+function generatedScript(
+  scripts: Awaited<ReturnType<ReturnType<typeof getScriptGenerator>['generateAllScripts']>>
+) {
+  const script = scripts.find((candidate) => candidate.type === 'bash');
+  if (!script) throw new Error('Generated Bash installer is missing');
+  return script;
+}
+
+function condaOptions(relativePaths: string[]): ScriptOptions {
+  return { condaPackageFiles: relativePaths.map((relativePath) => ({ relativePath })) };
+}
+
+async function runBash(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+  timeout = 180_000
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath], { cwd: path.dirname(scriptPath), env });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => child.kill('SIGTERM'), timeout);
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code, signal });
+    });
+  });
+}
+
+async function findConda(): Promise<{ executable: string; root: string; python: string }> {
+  const candidates = [
+    process.env.CONDA ? path.join(process.env.CONDA, 'bin', 'conda') : undefined,
+    '/usr/share/miniconda/bin/conda',
+    'conda',
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  for (const executable of candidates) {
+    try {
+      const version = await execFile(executable, ['--version'], { timeout: 15_000 });
+      const root = (
+        await execFile(executable, ['info', '--base'], { timeout: 15_000 })
+      ).stdout.trim();
+      if (!root) throw new Error(`Conda did not report a base prefix for ${executable}`);
+      const python = path.join(root, 'bin', 'python');
+      await execFile(python, ['--version'], { timeout: 15_000 });
+      console.log(
+        `native conda: ${executable} (${version.stdout.trim() || version.stderr.trim()})`
+      );
+      return { executable, root, python };
+    } catch {
+      // Probe the next runner-provided installation.
+    }
+  }
+  throw new Error('DEPS_SMUGGLER_NATIVE_CONDA=1 requires an existing Conda installation');
+}
+
+async function createFixture(
+  python: string,
+  source: string,
+  output: string,
+  filename: string
+): Promise<string> {
+  const script = [
+    'import sys',
+    'from conda_package_handling.api import create',
+    'create(sys.argv[1], None, sys.argv[2], out_folder=sys.argv[3])',
+  ].join('\n');
+  await execFile(python, ['-c', script, source, filename, output], {
+    timeout: 30_000,
+    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1', PYTHONPATH: undefined, PYTHONHOME: undefined },
+  });
+  const archive = path.join(output, filename);
+  if (!fs.existsSync(archive)) throw new Error(`conda-package-handling did not create ${filename}`);
+  return archive;
+}
+
+async function createPackageSource(
+  root: string,
+  name: string,
+  version: string,
+  moduleName?: string,
+  depends: string[] = []
+): Promise<string> {
+  const source = path.join(root, `${name}-source`);
+  await fs.promises.mkdir(path.join(source, 'info'), { recursive: true });
+  const index = {
+    name,
+    version,
+    build: '0',
+    build_number: 0,
+    subdir: 'noarch',
+    ...(moduleName ? { noarch: 'python' } : {}),
+    depends: moduleName ? ['python', ...depends] : depends,
+  };
+  await fs.promises.writeFile(path.join(source, 'info', 'index.json'), JSON.stringify(index));
+  const files: string[] = [];
+  if (moduleName) {
+    const modulePath = path.join(source, 'site-packages', `${moduleName}.py`);
+    await fs.promises.mkdir(path.dirname(modulePath), { recursive: true });
+    await fs.promises.writeFile(
+      modulePath,
+      `__version__ = ${JSON.stringify(version)}\nPAYLOAD = "depssmuggler-native-payload"\n`
+    );
+    files.push(path.relative(source, modulePath));
+  } else {
+    const payload = path.join(source, 'share', `${name}.txt`);
+    await fs.promises.mkdir(path.dirname(payload), { recursive: true });
+    await fs.promises.writeFile(payload, `${name}-${version}\n`);
+    files.push(path.relative(source, payload));
+  }
+  await fs.promises.writeFile(path.join(source, 'info', 'files'), `${files.join('\n')}\n`);
+  if (moduleName) {
+    await fs.promises.writeFile(
+      path.join(source, 'info', 'link.json'),
+      '{"package_metadata_version": 1, "noarch": {"type": "python"}}\n'
+    );
+  }
+  return source;
+}
+
+async function writeIsolatedEnv(root: string, trapPort: number): Promise<NodeJS.ProcessEnv> {
+  const envs = path.join(root, 'envs');
+  const cache = path.join(root, 'cache');
+  const condarc = path.join(root, 'condarc');
+  await Promise.all([
+    fs.promises.mkdir(envs, { recursive: true }),
+    fs.promises.mkdir(cache, { recursive: true }),
+  ]);
+  await fs.promises.writeFile(
+    condarc,
+    `channels:\n  - http://127.0.0.1:${trapPort}/trap\ncreate_default_packages:\n  - unavailable-test-default\n`
+  );
+  return {
+    ...process.env,
+    DEPS_SMUGGLER_CONDA_PREFIX: '',
+    PYTHONDONTWRITEBYTECODE: '1',
+    PYTHONNOUSERSITE: '1',
+    PYTHONPATH: undefined,
+    PYTHONHOME: undefined,
+    CONDA_REGISTER_ENVS: 'false',
+    CONDA_NO_PLUGINS: 'true',
+    CONDA_SOLVER: 'classic',
+    CONDA_ENVS_PATH: envs,
+    CONDA_PKGS_DIRS: cache,
+    CONDARC: condarc,
+    CONDA_CHANNELS: `http://127.0.0.1:${trapPort}/trap`,
+  };
+}
+
+nativeSuite('native Conda offline installer consumer', () => {
+  const tempDirs: string[] = [];
+  let trap: http.Server | undefined;
+  let requests = 0;
+
+  afterEach(async () => {
+    const activeTrap = trap;
+    trap = undefined;
+    if (activeTrap?.listening) {
+      await new Promise<void>((resolve) => activeTrap.close(() => resolve()));
+    }
+    for (const directory of tempDirs.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+    requests = 0;
+  });
+
+  async function prepareNative() {
+    if (process.platform !== 'linux') {
+      throw new Error('DEPS_SMUGGLER_NATIVE_CONDA=1 requires Linux');
+    }
+    const conda = await findConda();
+    const tempRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'depssmuggler native conda-')
+    );
+    tempDirs.push(tempRoot);
+    requests = 0;
+    trap = http.createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(500);
+      response.end();
+    });
+    const activeTrap = trap;
+    if (!activeTrap) throw new Error('Conda HTTP trap was not created');
+    await new Promise<void>((resolve, reject) => {
+      activeTrap.once('error', reject);
+      activeTrap.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = trap.address();
+    if (!address || typeof address === 'string') throw new Error('Conda HTTP trap has no port');
+    const env = await writeIsolatedEnv(tempRoot, address.port);
+    return {
+      ...conda,
+      tempRoot,
+      env: { ...env, PATH: `${path.join(conda.root, 'bin')}:${process.env.PATH ?? ''}` },
+    };
+  }
+
+  it('creates a fresh isolated prefix from a real .conda archive and records exact package metadata', async () => {
+    const setup = await prepareNative();
+    const source = await createPackageSource(
+      setup.tempRoot,
+      'depssmuggler-native-data',
+      '1.0.0',
+      undefined,
+      ['depssmuggler-native-dependency']
+    );
+    const dependencySource = await createPackageSource(
+      setup.tempRoot,
+      'depssmuggler-native-dependency',
+      '1.0.0'
+    );
+    const fixtureDir = path.join(setup.tempRoot, 'fixtures');
+    await fs.promises.mkdir(fixtureDir, { recursive: true });
+    const archive = await createFixture(
+      setup.python,
+      source,
+      fixtureDir,
+      'depssmuggler-native-data-1.0.0-0.conda'
+    );
+    const dependencyArchive = await createFixture(
+      setup.python,
+      dependencySource,
+      fixtureDir,
+      'depssmuggler-native-dependency-1.0.0-0.tar.bz2'
+    );
+    const outputDir = path.join(setup.tempRoot, 'bundle');
+    const packageDir = path.join(outputDir, 'packages');
+    await fs.promises.mkdir(packageDir, { recursive: true });
+    await fs.promises.copyFile(archive, path.join(packageDir, path.basename(archive)));
+    await fs.promises.copyFile(
+      dependencyArchive,
+      path.join(packageDir, path.basename(dependencyArchive))
+    );
+    const pkg: PackageInfo = {
+      type: 'conda',
+      name: 'depssmuggler-native-data',
+      version: '1.0.0',
+      metadata: { filename: path.basename(archive) },
+    };
+    const dependencyPkg: PackageInfo = {
+      type: 'conda',
+      name: 'depssmuggler-native-dependency',
+      version: '1.0.0',
+      metadata: { filename: path.basename(dependencyArchive) },
+    };
+    const scripts = await getScriptGenerator().generateAllScripts(
+      [pkg, dependencyPkg],
+      outputDir,
+      condaOptions([path.basename(archive), path.basename(dependencyArchive)])
+    );
+    const result = await runBash(generatedScript(scripts).path, setup.env);
+    expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.signal).toBeNull();
+    const listed = JSON.parse(
+      (
+        await execFile(
+          setup.executable,
+          ['list', '--json', '--prefix', path.join(outputDir, 'conda-env')],
+          {
+            env: setup.env,
+            timeout: 30_000,
+          }
+        )
+      ).stdout
+    ) as Array<{ name: string; version: string }>;
+    expect(listed).toHaveLength(2);
+    expect(listed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: pkg.name, version: pkg.version }),
+        expect.objectContaining({ name: dependencyPkg.name, version: dependencyPkg.version }),
+      ])
+    );
+    expect(
+      await fs.promises.readFile(
+        path.join(outputDir, 'conda-env', 'share', `${pkg.name}.txt`),
+        'utf8'
+      )
+    ).toBe(`${pkg.name}-${pkg.version}\n`);
+    expect(
+      await fs.promises.readFile(
+        path.join(outputDir, 'conda-env', 'share', `${dependencyPkg.name}.txt`),
+        'utf8'
+      )
+    ).toBe(`${dependencyPkg.name}-${dependencyPkg.version}\n`);
+    expect(listed.some((entry) => entry.name === 'unavailable-test-default')).toBe(false);
+    expect(requests).toBe(0);
+  }, 240_000);
+
+  it('installs a unique Python noarch tar.bz2 into a cloned temporary Python prefix and preserves it on repeat', async () => {
+    const setup = await prepareNative();
+    const basePrefix = setup.root;
+    const sourceCache = path.join(setup.root, 'pkgs');
+    if (!fs.existsSync(sourceCache)) {
+      throw new Error(`Native Conda cache prerequisite missing: ${sourceCache}`);
+    }
+    const isolatedCache = setup.env.CONDA_PKGS_DIRS;
+    if (!isolatedCache) throw new Error('Native Conda isolated cache was not configured');
+    await fs.promises.cp(sourceCache, isolatedCache, { recursive: true });
+    const source = await createPackageSource(
+      setup.tempRoot,
+      'depssmuggler-native-python',
+      '1.0.0',
+      'depssmuggler_native_fixture'
+    );
+    const fixtureDir = path.join(setup.tempRoot, 'fixtures');
+    await fs.promises.mkdir(fixtureDir, { recursive: true });
+    const archive = await createFixture(
+      setup.python,
+      source,
+      fixtureDir,
+      'depssmuggler-native-python-1.0.0-0.tar.bz2'
+    );
+    const outputDir = path.join(setup.tempRoot, 'bundle');
+    const packageDir = path.join(outputDir, 'packages');
+    await fs.promises.mkdir(packageDir, { recursive: true });
+    await fs.promises.copyFile(archive, path.join(packageDir, path.basename(archive)));
+    const prefix = path.join(setup.tempRoot, 'python-prefix');
+    await execFile(
+      setup.executable,
+      [
+        'create',
+        '--offline',
+        '--yes',
+        '--no-default-packages',
+        '--clone',
+        basePrefix,
+        '--prefix',
+        prefix,
+      ],
+      { env: setup.env, timeout: 120_000 }
+    );
+    const before = JSON.parse(
+      (
+        await execFile(setup.executable, ['list', '--json', '--prefix', prefix], {
+          env: setup.env,
+          timeout: 30_000,
+        })
+      ).stdout
+    ) as Array<{ name: string }>;
+    expect(before.some((entry) => entry.name === 'depssmuggler-native-python')).toBe(false);
+    const pkg: PackageInfo = {
+      type: 'conda',
+      name: 'depssmuggler-native-python',
+      version: '1.0.0',
+      metadata: { filename: path.basename(archive) },
+    };
+    const scripts = await getScriptGenerator().generateAllScripts(
+      [pkg],
+      outputDir,
+      condaOptions([path.basename(archive)])
+    );
+    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: prefix };
+    const first = await runBash(generatedScript(scripts).path, env);
+    expect(first.code, `${first.stdout}\n${first.stderr}`).toBe(0);
+    expect(first.signal).toBeNull();
+    const importResult = await execFile(
+      path.join(prefix, 'bin', 'python'),
+      [
+        '-c',
+        'import json,sys,depssmuggler_native_fixture as m; print(json.dumps({"prefix":sys.prefix,"file":m.__file__,"version":m.__version__,"payload":m.PAYLOAD}))',
+      ],
+      { env, timeout: 30_000 }
+    );
+    const imported = JSON.parse(importResult.stdout.trim()) as {
+      prefix: string;
+      file: string;
+      version: string;
+      payload: string;
+    };
+    expect(imported.prefix).toBe(prefix);
+    expect(imported.file.startsWith(`${prefix}${path.sep}`)).toBe(true);
+    expect(imported.version).toBe('1.0.0');
+    expect(imported.payload).toBe('depssmuggler-native-payload');
+    const sentinel = path.join(prefix, 'sentinel');
+    await fs.promises.writeFile(sentinel, 'preserve');
+    const second = await runBash(generatedScript(scripts).path, env);
+    expect(second.code, `${second.stdout}\n${second.stderr}`).toBe(0);
+    expect(second.signal).toBeNull();
+    expect(await fs.promises.readFile(sentinel, 'utf8')).toBe('preserve');
+    expect(requests).toBe(0);
+  }, 300_000);
+});

--- a/src/core/packager/conda-native-consumer.integration.test.ts
+++ b/src/core/packager/conda-native-consumer.integration.test.ts
@@ -31,6 +31,37 @@ function condaOptions(relativePaths: string[]): ScriptOptions {
   return { condaPackageFiles: relativePaths.map((relativePath) => ({ relativePath })) };
 }
 
+function nativeProcessEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.CONDA_PREFIX;
+  delete env.CONDA_DEFAULT_ENV;
+  delete env.PYTHONHOME;
+  delete env.PYTHONPATH;
+  return {
+    ...env,
+    CONDA_NO_PLUGINS: 'true',
+    CONDA_SOLVER: 'classic',
+    CONDA_OFFLINE: 'true',
+    CONDA_REGISTER_ENVS: 'false',
+    PYTHONDONTWRITEBYTECODE: '1',
+    PYTHONNOUSERSITE: '1',
+    ...overrides,
+  };
+}
+
+async function nativePhase<T>(name: string, action: () => Promise<T>): Promise<T> {
+  const started = Date.now();
+  console.log(`native phase: ${name} start`);
+  try {
+    const result = await action();
+    console.log(`native phase: ${name} end (${Date.now() - started}ms)`);
+    return result;
+  } catch (error) {
+    console.error(`native phase: ${name} failed (${Date.now() - started}ms)`, error);
+    throw error;
+  }
+}
+
 async function runBash(
   scriptPath: string,
   env: NodeJS.ProcessEnv,
@@ -52,29 +83,51 @@ async function runBash(
 }
 
 async function findConda(): Promise<{ executable: string; root: string; python: string }> {
-  const candidates = [
+  const candidates = [...new Set([
     process.env.CONDA ? path.join(process.env.CONDA, 'bin', 'conda') : undefined,
     '/usr/share/miniconda/bin/conda',
     'conda',
-  ].filter((candidate): candidate is string => Boolean(candidate));
+  ].filter((candidate): candidate is string => Boolean(candidate)))];
+  const failures: string[] = [];
   for (const executable of candidates) {
+    const started = Date.now();
     try {
-      const version = await execFile(executable, ['--version'], { timeout: 15_000 });
+      const version = await execFile(executable, ['--version'], {
+        env: nativeProcessEnv({ CONDA_OFFLINE: 'true' }),
+        timeout: 60_000,
+      });
       const root = (
-        await execFile(executable, ['info', '--base'], { timeout: 15_000 })
+        await execFile(executable, ['info', '--base'], {
+          env: nativeProcessEnv({ CONDA_OFFLINE: 'true' }),
+          timeout: 60_000,
+        })
       ).stdout.trim();
       if (!root) throw new Error(`Conda did not report a base prefix for ${executable}`);
       const python = path.join(root, 'bin', 'python');
-      await execFile(python, ['--version'], { timeout: 15_000 });
+      await execFile(python, ['--version'], {
+        env: nativeProcessEnv({ CONDA_OFFLINE: 'true' }),
+        timeout: 60_000,
+      });
       console.log(
         `native conda: ${executable} (${version.stdout.trim() || version.stderr.trim()})`
       );
       return { executable, root, python };
-    } catch {
-      // Probe the next runner-provided installation.
+    } catch (error) {
+      const elapsed = Date.now() - started;
+      const details = error as {
+        message?: string;
+        stderr?: string;
+        code?: number | string;
+        signal?: string;
+      };
+      const message = `${executable}: ${details.message ?? 'probe failed'}${details.code !== undefined ? ` (code ${details.code})` : ''}${details.signal ? ` (signal ${details.signal})` : ''}${details.stderr ? `: ${details.stderr.trim()}` : ''}`;
+      failures.push(message);
+      console.error(`native conda probe failed (${elapsed}ms): ${message}`);
     }
   }
-  throw new Error('DEPS_SMUGGLER_NATIVE_CONDA=1 requires an existing Conda installation');
+  throw new Error(
+    `DEPS_SMUGGLER_NATIVE_CONDA=1 requires an existing Conda installation; probes failed:\n${failures.join('\n')}`
+  );
 }
 
 async function createFixture(
@@ -90,7 +143,7 @@ async function createFixture(
   ].join('\n');
   await execFile(python, ['-c', script, source, filename, output], {
     timeout: 30_000,
-    env: { ...process.env, PYTHONDONTWRITEBYTECODE: '1', PYTHONPATH: undefined, PYTHONHOME: undefined },
+    env: nativeProcessEnv(),
   });
   const archive = path.join(output, filename);
   if (!fs.existsSync(archive)) throw new Error(`conda-package-handling did not create ${filename}`);
@@ -154,7 +207,7 @@ async function writeIsolatedEnv(root: string, trapPort: number): Promise<NodeJS.
     `channels:\n  - http://127.0.0.1:${trapPort}/trap\ncreate_default_packages:\n  - unavailable-test-default\n`
   );
   return {
-    ...process.env,
+    ...nativeProcessEnv(),
     DEPS_SMUGGLER_CONDA_PREFIX: '',
     PYTHONDONTWRITEBYTECODE: '1',
     PYTHONNOUSERSITE: '1',
@@ -163,11 +216,62 @@ async function writeIsolatedEnv(root: string, trapPort: number): Promise<NodeJS.
     CONDA_REGISTER_ENVS: 'false',
     CONDA_NO_PLUGINS: 'true',
     CONDA_SOLVER: 'classic',
+    CONDA_OFFLINE: 'false',
     CONDA_ENVS_PATH: envs,
     CONDA_PKGS_DIRS: cache,
     CONDARC: condarc,
     CONDA_CHANNELS: `http://127.0.0.1:${trapPort}/trap`,
   };
+}
+
+type RuntimeArchive = { name: string; filename: string; source: string };
+
+async function collectPythonRuntimeArchives(
+  setup: { python: string; root: string; tempRoot: string; env: NodeJS.ProcessEnv }
+): Promise<RuntimeArchive[]> {
+  return nativePhase('python prerequisite discovery', async () => {
+    const script = [
+      'import glob, json, os, sys',
+      'from conda.models.match_spec import MatchSpec',
+      'base, cache = sys.argv[1:3]',
+      'records = {}',
+      'for filename in glob.glob(os.path.join(base, "conda-meta", "*.json")):',
+      '  with open(filename, encoding="utf-8") as stream: record = json.load(stream)',
+      '  if record.get("name"): records[record["name"]] = record',
+      'queue, selected = ["python"], {}',
+      'while queue:',
+      '  name = queue.pop(0)',
+      '  if not name or name.startswith("__") or name in selected: continue',
+      '  record = records.get(name)',
+      '  if record is None: raise RuntimeError(f"missing installed runtime record: {name}")',
+      '  selected[name] = record',
+      '  for dependency in record.get("depends", []):',
+      '    dependency_name = MatchSpec(dependency).name',
+      '    if dependency_name and not dependency_name.startswith("__") and dependency_name not in selected: queue.append(dependency_name)',
+      'result = []',
+      'for name, record in selected.items():',
+      '  candidates = [record.get("fn"), record.get("name") + "-" + record.get("version") + "-" + record.get("build") + ".conda", record.get("name") + "-" + record.get("version") + "-" + record.get("build") + ".tar.bz2"]',
+      '  archive = next((candidate for candidate in candidates if candidate and os.path.isfile(os.path.join(cache, candidate))), None)',
+      '  if archive is None: raise RuntimeError("missing cached archive for runtime record: " + name + " (" + str(record.get("fn")) + ")")',
+      '  result.append({"name": name, "filename": archive, "source": os.path.join(cache, archive)})',
+      'print(json.dumps(result))',
+    ].join('\n');
+    const result = await execFile(
+      setup.python,
+      ['-c', script, setup.root, path.join(setup.root, 'pkgs')],
+      { env: setup.env, timeout: 60_000, maxBuffer: 2 * 1024 * 1024 }
+    );
+    const archives = JSON.parse(result.stdout) as RuntimeArchive[];
+    if (!archives.length) throw new Error('No installed Python runtime records were discovered');
+    const runtimeDir = path.join(setup.tempRoot, 'runtime-artifacts');
+    await fs.promises.mkdir(runtimeDir, { recursive: true });
+    for (const archive of archives) {
+      const destination = path.join(runtimeDir, archive.filename);
+      await fs.promises.copyFile(archive.source, destination);
+      archive.source = destination;
+    }
+    return archives;
+  });
 }
 
 nativeSuite('native Conda offline installer consumer', () => {
@@ -232,20 +336,24 @@ nativeSuite('native Conda offline installer consumer', () => {
       'depssmuggler-native-dependency',
       '1.0.0'
     );
-    const fixtureDir = path.join(setup.tempRoot, 'fixtures');
-    await fs.promises.mkdir(fixtureDir, { recursive: true });
-    const archive = await createFixture(
-      setup.python,
-      source,
-      fixtureDir,
-      'depssmuggler-native-data-1.0.0-0.conda'
-    );
-    const dependencyArchive = await createFixture(
-      setup.python,
-      dependencySource,
-      fixtureDir,
-      'depssmuggler-native-dependency-1.0.0-0.tar.bz2'
-    );
+    const { archive, dependencyArchive } = await nativePhase('generic fixture', async () => {
+      const fixtureDir = path.join(setup.tempRoot, 'fixtures');
+      await fs.promises.mkdir(fixtureDir, { recursive: true });
+      return {
+        archive: await createFixture(
+          setup.python,
+          source,
+          fixtureDir,
+          'depssmuggler-native-data-1.0.0-0.conda'
+        ),
+        dependencyArchive: await createFixture(
+          setup.python,
+          dependencySource,
+          fixtureDir,
+          'depssmuggler-native-dependency-1.0.0-0.tar.bz2'
+        ),
+      };
+    });
     const outputDir = path.join(setup.tempRoot, 'bundle');
     const packageDir = path.join(outputDir, 'packages');
     await fs.promises.mkdir(packageDir, { recursive: true });
@@ -266,12 +374,14 @@ nativeSuite('native Conda offline installer consumer', () => {
       version: '1.0.0',
       metadata: { filename: path.basename(dependencyArchive) },
     };
-    const scripts = await getScriptGenerator().generateAllScripts(
-      [pkg, dependencyPkg],
-      outputDir,
-      condaOptions([path.basename(archive), path.basename(dependencyArchive)])
-    );
-    const result = await runBash(generatedScript(scripts).path, setup.env);
+    const result = await nativePhase('generic create/install', async () => {
+      const scripts = await getScriptGenerator().generateAllScripts(
+        [pkg, dependencyPkg],
+        outputDir,
+        condaOptions([path.basename(archive), path.basename(dependencyArchive)])
+      );
+      return runBash(generatedScript(scripts).path, setup.env);
+    });
     expect(result.code, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.signal).toBeNull();
     const listed = JSON.parse(
@@ -309,49 +419,55 @@ nativeSuite('native Conda offline installer consumer', () => {
     expect(requests).toBe(0);
   }, 240_000);
 
-  it('installs a unique Python noarch tar.bz2 into a cloned temporary Python prefix and preserves it on repeat', async () => {
+  it('installs a unique Python noarch tar.bz2 into a temporary Python prefix and preserves it on repeat', async () => {
     const setup = await prepareNative();
-    const basePrefix = setup.root;
-    const sourceCache = path.join(setup.root, 'pkgs');
-    if (!fs.existsSync(sourceCache)) {
-      throw new Error(`Native Conda cache prerequisite missing: ${sourceCache}`);
-    }
     const isolatedCache = setup.env.CONDA_PKGS_DIRS;
     if (!isolatedCache) throw new Error('Native Conda isolated cache was not configured');
-    await fs.promises.cp(sourceCache, isolatedCache, { recursive: true });
+    const runtimeArchives = await collectPythonRuntimeArchives(setup);
     const source = await createPackageSource(
       setup.tempRoot,
       'depssmuggler-native-python',
       '1.0.0',
       'depssmuggler_native_fixture'
     );
-    const fixtureDir = path.join(setup.tempRoot, 'fixtures');
-    await fs.promises.mkdir(fixtureDir, { recursive: true });
-    const archive = await createFixture(
-      setup.python,
-      source,
-      fixtureDir,
-      'depssmuggler-native-python-1.0.0-0.tar.bz2'
-    );
+    const archive = await nativePhase('Python fixture', async () => {
+      const fixtureDir = path.join(setup.tempRoot, 'fixtures');
+      await fs.promises.mkdir(fixtureDir, { recursive: true });
+      return createFixture(
+        setup.python,
+        source,
+        fixtureDir,
+        'depssmuggler-native-python-1.0.0-0.tar.bz2'
+      );
+    });
     const outputDir = path.join(setup.tempRoot, 'bundle');
     const packageDir = path.join(outputDir, 'packages');
     await fs.promises.mkdir(packageDir, { recursive: true });
     await fs.promises.copyFile(archive, path.join(packageDir, path.basename(archive)));
     const prefix = path.join(setup.tempRoot, 'python-prefix');
-    await execFile(
-      setup.executable,
-      [
-        'create',
-        '--offline',
-        '--yes',
-        '--no-default-packages',
-        '--clone',
-        basePrefix,
-        '--prefix',
-        prefix,
-      ],
-      { env: setup.env, timeout: 120_000 }
+    await nativePhase('Python runtime create', async () => {
+      await execFile(
+        setup.executable,
+        [
+          'create',
+          '--offline',
+          '--yes',
+          '--no-default-packages',
+          '--prefix',
+          prefix,
+          ...runtimeArchives.map((archive) => archive.source),
+        ],
+        { env: setup.env, timeout: 120_000, maxBuffer: 2 * 1024 * 1024 }
+      );
+    });
+    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: prefix };
+    const prefixPython = await nativePhase('temporary Python prerequisite', () =>
+      execFile(path.join(prefix, 'bin', 'python'), ['-c', 'import sys; print(sys.prefix)'], {
+        env,
+        timeout: 60_000,
+      })
     );
+    expect(prefixPython.stdout.trim()).toBe(prefix);
     const before = JSON.parse(
       (
         await execFile(setup.executable, ['list', '--json', '--prefix', prefix], {
@@ -372,17 +488,20 @@ nativeSuite('native Conda offline installer consumer', () => {
       outputDir,
       condaOptions([path.basename(archive)])
     );
-    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: prefix };
-    const first = await runBash(generatedScript(scripts).path, env);
+    const first = await nativePhase('generated Python install', () =>
+      runBash(generatedScript(scripts).path, env)
+    );
     expect(first.code, `${first.stdout}\n${first.stderr}`).toBe(0);
     expect(first.signal).toBeNull();
-    const importResult = await execFile(
-      path.join(prefix, 'bin', 'python'),
-      [
-        '-c',
-        'import json,sys,depssmuggler_native_fixture as m; print(json.dumps({"prefix":sys.prefix,"file":m.__file__,"version":m.__version__,"payload":m.PAYLOAD}))',
-      ],
-      { env, timeout: 30_000 }
+    const importResult = await nativePhase('Python import', () =>
+      execFile(
+        path.join(prefix, 'bin', 'python'),
+        [
+          '-c',
+          'import json,sys,depssmuggler_native_fixture as m; print(json.dumps({"prefix":sys.prefix,"file":m.__file__,"version":m.__version__,"payload":m.PAYLOAD}))',
+        ],
+        { env, timeout: 60_000, maxBuffer: 2 * 1024 * 1024 }
+      )
     );
     const imported = JSON.parse(importResult.stdout.trim()) as {
       prefix: string;
@@ -396,7 +515,9 @@ nativeSuite('native Conda offline installer consumer', () => {
     expect(imported.payload).toBe('depssmuggler-native-payload');
     const sentinel = path.join(prefix, 'sentinel');
     await fs.promises.writeFile(sentinel, 'preserve');
-    const second = await runBash(generatedScript(scripts).path, env);
+    const second = await nativePhase('generated Python repeat install', () =>
+      runBash(generatedScript(scripts).path, env)
+    );
     expect(second.code, `${second.stdout}\n${second.stderr}`).toBe(0);
     expect(second.signal).toBeNull();
     expect(await fs.promises.readFile(sentinel, 'utf8')).toBe('preserve');

--- a/src/core/packager/script-generator.test.ts
+++ b/src/core/packager/script-generator.test.ts
@@ -383,7 +383,7 @@ describe('ScriptGenerator', () => {
       const outputPath = path.join(tempDir, 'install.sh');
       const packages: PackageInfo[] = [
         { name: 'requests', version: '2.28.0', type: 'pip' },
-        { name: 'numpy', version: '1.23.0', type: 'conda' },
+        { name: 'numpy', version: '1.23.0', type: 'conda', metadata: { filename: 'numpy-1.23.0-py312_0.conda' } },
         { name: 'org.springframework:spring-core', version: '5.3.0', type: 'maven', metadata: { groupId: 'org.springframework', artifactId: 'spring-core' } },
         { name: 'httpd', version: '2.4.0', type: 'yum' },
         { name: 'nginx', version: 'latest', type: 'docker' },
@@ -399,18 +399,58 @@ describe('ScriptGenerator', () => {
       expect(content).toContain('docker');
     });
 
-    it('conda 패키지도 pip으로 설치되어야 함', async () => {
+    it('Conda 패키지는 명시된 archive를 offline 설치해야 함', async () => {
       const outputPath = path.join(tempDir, 'install.sh');
       const packages: PackageInfo[] = [
-        { name: 'numpy', version: '1.23.0', type: 'conda' },
+        {
+          name: 'six',
+          version: '1.17.0',
+          type: 'conda',
+          metadata: { filename: 'six-1.17.0-py312h06a4308_0.tar.bz2' },
+        },
       ];
 
-      await generator.generateBashScript(packages, outputPath);
+      await generator.generateBashScript(packages, outputPath, { includeErrorHandling: false });
 
       const content = await fs.readFile(outputPath, 'utf-8');
-      // conda 패키지도 pip install로 처리됨
-      expect(content).toContain('pip install');
-      expect(content).toContain('numpy');
+      expect(content).toContain('command -v conda');
+      expect(content).toContain('conda create --offline --yes --no-default-packages');
+      expect(content).toContain('six-1.17.0-py312h06a4308_0.tar.bz2');
+      expect(content).toContain('DEPS_SMUGGLER_CONDA_PREFIX');
+      expect(content).toContain('install_conda_packages || exit 1');
+      expect(content).not.toContain('pip install');
+    });
+
+    it('Conda 매핑은 portable 경로를 dedupe하고 셸 특수문자를 보존해야 함', async () => {
+      const bashPath = path.join(tempDir, 'install.sh');
+      const powershellPath = path.join(tempDir, 'install.ps1');
+      const packages: PackageInfo[] = [
+        { name: 'six', version: '1.17.0', type: 'conda' },
+      ];
+      const relativePath = "nested dir/O'Reilly $six.conda";
+
+      await generator.generateBashScript(packages, bashPath, {
+        condaPackageFiles: [{ relativePath }, { relativePath }],
+      });
+      await generator.generatePowerShellScript(packages, powershellPath, {
+        condaPackageFiles: [{ relativePath }],
+      });
+
+      const bash = await fs.readFile(bashPath, 'utf-8');
+      const powershell = await fs.readFile(powershellPath, 'utf-8');
+      expect(bash).toContain("'nested dir/O'\\''Reilly $six.conda'");
+      expect(bash.match(/nested dir\/O'\\''Reilly \$six\.conda/g)).toHaveLength(1);
+      expect(powershell).toContain("'nested dir/O''Reilly $six.conda'");
+    });
+
+    it('Conda 매핑이 없으면 metadata filename을 요구하고 잘못된 경로를 거부해야 함', async () => {
+      const outputPath = path.join(tempDir, 'install.sh');
+      const packages: PackageInfo[] = [{ name: 'six', version: '1.17.0', type: 'conda' }];
+
+      await expect(generator.generateBashScript(packages, outputPath)).rejects.toThrow(/Conda.*filename|파일명/i);
+      await expect(generator.generateBashScript(packages, outputPath, {
+        condaPackageFiles: [{ relativePath: '../escape.conda' }],
+      })).rejects.toThrow(/경로|상대|portable/i);
     });
   });
 

--- a/src/core/packager/script-generator.ts
+++ b/src/core/packager/script-generator.ts
@@ -18,6 +18,11 @@ export interface ScriptOptions {
   packageDir?: string; // 패키지 디렉토리 경로 (기본: ./packages)
   npmPackageFiles?: NpmPackageFile[]; // 다운로드 원본과 압축물 packages/ 내부 상대 경로
   npmRootPackages?: PackageInfo[]; // 직접 요청한 npm 패키지의 해결된 버전
+  condaPackageFiles?: CondaPackageFile[]; // 압축물 packages/ 내부 Conda archive 상대 경로
+}
+
+export interface CondaPackageFile {
+  relativePath: string;
 }
 
 export interface GeneratedScript {
@@ -77,6 +82,46 @@ export class ScriptGenerator {
 
   private powerShellQuote(value: string): string {
     return `'${value.replace(/'/g, "''")}'`;
+  }
+
+  private getCondaArchivePaths(
+    packages: PackageInfo[],
+    packageFiles?: CondaPackageFile[],
+  ): string[] {
+    const relativePaths = packageFiles !== undefined
+      ? packageFiles.map(file => file.relativePath)
+      : packages.map(pkg => {
+        const filename = pkg.metadata?.filename;
+        if (typeof filename !== 'string' || filename.length === 0) {
+          throw new Error(`Conda 패키지 ${pkg.name}@${pkg.version}의 아카이브 파일명이 없습니다 (metadata.filename)`);
+        }
+        return filename;
+      });
+
+    if (relativePaths.length === 0) {
+      throw new Error('Conda 패키지 파일 매핑이 비어 있습니다.');
+    }
+
+    const normalized = new Set<string>();
+    for (const relativePath of relativePaths) {
+      if (typeof relativePath !== 'string') {
+        throw new Error('Conda 패키지 파일 경로가 유효하지 않습니다.');
+      }
+      const portablePath = relativePath.replace(/\\/g, '/');
+      const segments = portablePath.split('/');
+      if (
+        portablePath.length === 0 ||
+        portablePath.startsWith('/') ||
+        /^[A-Za-z]:\//.test(portablePath) ||
+        segments.some(segment => segment.length === 0 || segment === '.' || segment === '..') ||
+        !/\.(?:conda|tar\.bz2)$/i.test(portablePath)
+      ) {
+        throw new Error(`Conda 패키지 파일 경로가 유효하지 않습니다: ${relativePath}`);
+      }
+      normalized.add(portablePath);
+    }
+
+    return [...normalized];
   }
 
   /**
@@ -149,12 +194,9 @@ export class ScriptGenerator {
     // 패키지 타입별로 그룹화
     const packagesByType = this.groupPackagesByType(packages);
 
-    // pip/conda 패키지 설치
-    if (packagesByType.has('pip') || packagesByType.has('conda')) {
-      const pipPackages = [
-        ...(packagesByType.get('pip') || []),
-        ...(packagesByType.get('conda') || []),
-      ];
+    // pip 패키지 설치
+    if (packagesByType.has('pip')) {
+      const pipPackages = packagesByType.get('pip') || [];
 
       lines.push('#-------------------------------------------------------------------------------');
       lines.push('# Python 패키지 설치');
@@ -185,6 +227,58 @@ export class ScriptGenerator {
       }
 
       lines.push('    log_info "Python 패키지 설치 완료"');
+      lines.push('}');
+      lines.push('');
+    }
+
+    // Conda 패키지 설치
+    if (packagesByType.has('conda')) {
+      const condaPackages = packagesByType.get('conda') || [];
+      const condaArchivePaths = this.getCondaArchivePaths(condaPackages, options.condaPackageFiles);
+      lines.push('#-------------------------------------------------------------------------------');
+      lines.push('# Conda 패키지 오프라인 설치');
+      lines.push('#-------------------------------------------------------------------------------');
+      lines.push('');
+      lines.push('install_conda_packages() {');
+      lines.push('    log_info "Conda 패키지 설치 중..."');
+      lines.push('    if ! command -v conda &> /dev/null; then');
+      lines.push('        log_error "Conda가 설치되어 있지 않습니다."');
+      lines.push('        return 1');
+      lines.push('    fi');
+      lines.push('');
+      lines.push('    local conda_relative_path conda_archive_path');
+      lines.push('    local conda_archive_paths=()');
+      for (const relativePath of condaArchivePaths) {
+        lines.push(`    conda_relative_path=${this.shellQuote(relativePath)}`);
+        lines.push('    conda_archive_path="$SCRIPT_DIR/$PACKAGE_DIR/$conda_relative_path"');
+        lines.push('    if [[ ! -f "$conda_archive_path" ]]; then');
+        lines.push('        log_error "Conda 아카이브를 찾을 수 없습니다: $conda_archive_path"');
+        lines.push('        return 1');
+        lines.push('    fi');
+        lines.push('    conda_archive_paths+=("$conda_archive_path")');
+      }
+      lines.push('');
+      lines.push('    local conda_prefix="${DEPS_SMUGGLER_CONDA_PREFIX:-$SCRIPT_DIR/conda-env}"');
+      lines.push('    if [[ "$conda_prefix" != /* ]]; then conda_prefix="$SCRIPT_DIR/$conda_prefix"; fi');
+      lines.push('    if [[ -e "$conda_prefix" && ! -d "$conda_prefix" ]]; then');
+      lines.push('        log_error "Conda 환경 경로가 디렉터리가 아닙니다: $conda_prefix"');
+      lines.push('        return 1');
+      lines.push('    fi');
+      lines.push('    if [[ -f "$conda_prefix/conda-meta/history" ]]; then');
+      lines.push('        conda install --offline --yes --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
+      lines.push('            log_error "Conda 패키지 설치에 실패했습니다."');
+      lines.push('            return 1');
+      lines.push('        }');
+      lines.push('    elif [[ -e "$conda_prefix" ]]; then');
+      lines.push('        log_error "기존 경로가 Conda 환경이 아닙니다: $conda_prefix"');
+      lines.push('        return 1');
+      lines.push('    else');
+      lines.push('        conda create --offline --yes --no-default-packages --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
+      lines.push('            log_error "Conda 환경 생성에 실패했습니다."');
+      lines.push('            return 1');
+      lines.push('        }');
+      lines.push('    fi');
+      lines.push('    log_info "Conda 패키지 설치 완료: $conda_prefix"');
       lines.push('}');
       lines.push('');
     }
@@ -384,8 +478,12 @@ export class ScriptGenerator {
     lines.push('    echo ""');
     lines.push('');
 
-    if (packagesByType.has('pip') || packagesByType.has('conda')) {
+    if (packagesByType.has('pip')) {
       lines.push('    install_python_packages');
+      lines.push('    echo ""');
+    }
+    if (packagesByType.has('conda')) {
+      lines.push('    install_conda_packages || exit 1');
       lines.push('    echo ""');
     }
     if (packagesByType.has('maven')) {
@@ -485,12 +583,9 @@ export class ScriptGenerator {
     // 패키지 타입별로 그룹화
     const packagesByType = this.groupPackagesByType(packages);
 
-    // pip/conda 패키지 설치
-    if (packagesByType.has('pip') || packagesByType.has('conda')) {
-      const pipPackages = [
-        ...(packagesByType.get('pip') || []),
-        ...(packagesByType.get('conda') || []),
-      ];
+    // pip 패키지 설치
+    if (packagesByType.has('pip')) {
+      const pipPackages = packagesByType.get('pip') || [];
 
       lines.push('#-------------------------------------------------------------------------------');
       lines.push('# Python 패키지 설치');
@@ -524,6 +619,53 @@ export class ScriptGenerator {
       }
 
       lines.push('    Write-Info "Python 패키지 설치 완료"');
+      lines.push('}');
+      lines.push('');
+    }
+
+    // Conda 패키지 설치
+    if (packagesByType.has('conda')) {
+      const condaPackages = packagesByType.get('conda') || [];
+      const condaArchivePaths = this.getCondaArchivePaths(condaPackages, options.condaPackageFiles);
+      lines.push('#-------------------------------------------------------------------------------');
+      lines.push('# Conda 패키지 오프라인 설치');
+      lines.push('#-------------------------------------------------------------------------------');
+      lines.push('');
+      lines.push('function Install-CondaPackages {');
+      lines.push('    Write-Info "Conda 패키지 설치 중..."');
+      lines.push('    if (-not (Get-Command conda -ErrorAction SilentlyContinue)) {');
+      lines.push('        throw "Conda가 설치되어 있지 않습니다."');
+      lines.push('    }');
+      lines.push('');
+      lines.push('    $CondaArchivePaths = @()');
+      for (const relativePath of condaArchivePaths) {
+        lines.push(`    $CondaArchivePath = Join-Path -Path $PackageDir -ChildPath ${this.powerShellQuote(relativePath)}`);
+        lines.push('    if (-not (Test-Path -LiteralPath $CondaArchivePath -PathType Leaf)) {');
+        lines.push('        throw "Conda 아카이브를 찾을 수 없습니다: $CondaArchivePath"');
+        lines.push('    }');
+        lines.push('    $CondaArchivePaths += $CondaArchivePath');
+      }
+      lines.push('');
+      lines.push('    $CondaPrefix = $env:DEPS_SMUGGLER_CONDA_PREFIX');
+      lines.push('    if ([string]::IsNullOrWhiteSpace($CondaPrefix)) {');
+      lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath \'conda-env\'');
+      lines.push('    } elseif (-not [System.IO.Path]::IsPathRooted($CondaPrefix)) {');
+      lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath $CondaPrefix');
+      lines.push('    }');
+      lines.push('    if (Test-Path -LiteralPath $CondaPrefix -PathType Leaf) {');
+      lines.push('        throw "Conda 환경 경로가 디렉터리가 아닙니다: $CondaPrefix"');
+      lines.push('    }');
+      lines.push('    $CondaHistory = Join-Path -Path $CondaPrefix -ChildPath \'conda-meta/history\'');
+      lines.push('    if (Test-Path -LiteralPath $CondaHistory -PathType Leaf) {');
+      lines.push('        & conda install --offline --yes --prefix $CondaPrefix @CondaArchivePaths');
+      lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
+      lines.push('    } elseif (Test-Path -LiteralPath $CondaPrefix) {');
+      lines.push('        throw "기존 경로가 Conda 환경이 아닙니다: $CondaPrefix"');
+      lines.push('    } else {');
+      lines.push('        & conda create --offline --yes --no-default-packages --prefix $CondaPrefix @CondaArchivePaths');
+      lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 환경 생성에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
+      lines.push('    }');
+      lines.push('    Write-Info "Conda 패키지 설치 완료: $CondaPrefix"');
       lines.push('}');
       lines.push('');
     }
@@ -672,8 +814,12 @@ export class ScriptGenerator {
     lines.push('Write-Host ""');
     lines.push('');
 
-    if (packagesByType.has('pip') || packagesByType.has('conda')) {
+    if (packagesByType.has('pip')) {
       lines.push('Install-PythonPackages');
+      lines.push('Write-Host ""');
+    }
+    if (packagesByType.has('conda')) {
+      lines.push('Install-CondaPackages');
       lines.push('Write-Host ""');
     }
     if (packagesByType.has('maven')) {


### PR DESCRIPTION
## 요약

Conda 산출물을 pip 설치 경로로 보내던 CLI 설치 스크립트를 Conda 전용 오프라인 설치 경로로 분리합니다. 생성 스크립트는 실제 전달된 `.conda`/`.tar.bz2` 파일만 `conda create` 또는 기존 환경의 `conda install`에 전달합니다.

## 변경 내용

- Conda와 pip 설치 스크립트 분기
- 기본 prefix `SCRIPT_DIR/conda-env` 지원
- `DEPS_SMUGGLER_CONDA_PREFIX`로 기존 인식된 Conda 환경 override 지원
- 새 prefix는 `conda create --offline --yes --no-default-packages` 사용
- 기존 `conda-meta/history`가 있는 prefix는 `conda install --offline --yes` 사용
- 실제 다운로드 파일 경로를 명시적으로 전달하고, 누락 파일·실패·Conda 실행 파일 부재 시 즉시 non-zero 종료
- `condaPackageFiles` 매핑의 portable relative path와 `.conda`/`.tar.bz2` 확장자 검증
- no-deps Conda 다운로드에서도 completed item의 실제 `filePath`/`filePaths`를 설치 입력으로 사용
- 직접 API fallback에서는 metadata filename을 사용하며, filename이 없으면 추측하지 않고 실패
- 명시적 로컬 파일 설치를 사용하므로 의존성·버전·아키텍처 호환성을 다시 해결하지 않음
- `--no-deps`의 Python noarch 패키지는 호환 Python이 있는 환경을 지정하거나 필요한 런타임도 함께 전달해야 함
- 문서: `docs/cli.md`, `docs/packagers.md`, `docs/testing.md`
- 변경 범위는 CLI ScriptGenerator API이며 Electron legacy script-utils caller는 범위에서 제외

## 검증

- 소스 회귀 테스트: 67개 통과
- 생성 스크립트 subprocess 테스트: 5개 통과 (로컬 Bash, Windows CI에서는 PowerShell 실행)
- 전체 테스트: 2,792개 통과, 151개 건너뜀
- TypeScript 두 설정: 통과
- 변경 파일 lint: 오류 0개, 기존 경고 1개; git diff --check 통과
- 실제 Node 20 CLI:
  - defaults/six/1.16.0 ZIP 및 tar.gz: exit 0, 실제 `.tar.bz2` 전달
  - conda-forge/six/1.16.0 ZIP 및 tar.gz: exit 0, 실제 `.conda` 전달
  - 생성 스크립트 4개: 모두 외부 cwd에서 unmodified 실행 exit 0
  - record-only Conda shim: 4개 모두 `conda create --offline --yes --no-default-packages`와 정확한 절대 artifact argv 확인
  - 기존 `conda-meta/history` prefix: `conda install --offline --yes` 경로 exit 0
  - pip 호출: 없음
- 이전 Windows CI에서 1개 테스트가 실패했습니다. 테스트가 POSIX `/tmp/conda script output`을 고정해 Windows의 `D:\tmp\conda script output`과 불일치한 문제였으며, 테스트를 플랫폼 경로 API로 보정했습니다. Windows의 PowerShell/recording-shim 검증은 통과했고 실제 native Conda 2건은 Ubuntu 전용입니다.
- 보정 후 CI run `34368502459`의 7개 job이 모두 통과했습니다. Ubuntu native Conda job은 `/usr/share/miniconda/bin/conda` 26.7.1로 `.conda`와 `.tar.bz2`를 새 prefix에 설치하고, 별도 Python noarch prefix에서 import 및 repeat install을 검증해 2건 모두 통과했습니다.
- Windows 기본 소비자/PowerShell 및 recording-shim 검증은 5건 통과했고, 실제 native Conda 2건은 Ubuntu 전용이라 Windows에서는 건너뜁니다.
- native linking/import 주장은 위 CI에서 실제 확인된 범위로 한정합니다.

Closes #85
