### PR TITLE
fix: GUI 혼합 패키지의 npm 오프라인 설치 누락 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ depssmuggler os cache clear
 | 항목 | 현재 동작 |
 |------|-----------|
 | 압축·설치 스크립트 | 일반 GUI와 CLI에서 ZIP/tar.gz 지원. 일반 GUI는 설치 스크립트 포함 여부를 선택하고, CLI는 생성한 `install.sh`·`install.ps1`을 출력 폴더와 아카이브 최상위에 포함합니다. OS 출력에는 전용 스크립트 생성기가 있습니다. |
-| 설치 스크립트 범위 | CLI의 npm 스크립트는 전달된 `.tgz`를 오프라인으로 설치해 스크립트 폴더의 `npm-project/node_modules`에 배치하며, 전이 의존성의 여러 버전을 함께 보존합니다. CLI의 Conda 스크립트는 전달된 Conda 아카이브를 오프라인으로 설치합니다. GUI의 Conda 항목은 아직 pip 명령으로 처리하므로 Conda 오프라인 설치를 보장하지 않습니다. 생성기별 범위는 [Packagers](docs/packagers.md)를 참고하세요. |
+| 설치 스크립트 범위 | CLI와 GUI의 npm 스크립트는 실제로 다운로드된 `.tgz`와 직접 요청한 확정 버전을 공통 설치 계획에 전달해 오프라인으로 `npm-project/node_modules`에 설치하며, 전이 의존성의 여러 버전을 함께 보존합니다. pip와 npm이 함께 있는 묶음은 두 설치가 모두 성공할 때만 전체 성공으로 처리합니다. CLI의 Conda 스크립트는 전달된 Conda 아카이브를 오프라인으로 설치합니다. GUI의 Conda 항목은 현재 `pip install` 명령을 생성하므로 Conda 오프라인 설치를 보장하지 않으며, 이 동작은 별도 #137 범위입니다. 생성기별 범위는 [Packagers](docs/packagers.md)를 참고하세요. |
 | 파일 분할 | 일반 GUI의 이메일 전달 중 첨부 한도를 초과하고 분할 설정이 켜진 경우 적용합니다. 로컬 저장 경로에서 자동 분할하지 않습니다. |
 | SMTP 테스트 | Electron IPC로 실제 연결을 테스트합니다. 브라우저 개발 환경에서는 시뮬레이션이며, Electron API가 일부 누락되면 안내 후 비활성화됩니다. |
 | 업데이트 | 배포 앱에서 시작 후 확인하고 사용자가 다운로드·설치할 수 있습니다. 개발 환경은 모의 동작입니다. `autoUpdate`·`autoDownloadUpdate` 설정은 저장되지만 updater 동작을 제어하는 연결은 아직 없습니다. |

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -172,6 +172,8 @@ fi
 ```
 
 **PowerShell (install.ps1)의 Python 설치 부분 (핵심 흐름)**
+
+생성되는 `install.ps1`은 Windows PowerShell 5.1에서 한글 오류 메시지를 올바르게 읽도록 UTF-8 BOM을 포함합니다.
 ```powershell
 # $PipFindLinkArgs는 Get-ChildItem -ErrorAction Stop으로 준비합니다.
 try {

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -129,6 +129,8 @@ const archive = archiver('zip', { zlib: { level: 9 } });
 | `generatePowerShellScript` | packages, outputPath, options? | Promise<string> | PowerShell 스크립트 생성 |
 | `generateAllScripts` | packages, outputDir, options? | Promise<GeneratedScript[]> | 모든 형식 스크립트 생성 |
 
+Electron GUI의 shared `generateInstallScripts`도 비동기 생성기이며, npm 패키지가 포함된 경우 공통 `ScriptGenerator`의 npm plan/runtime section을 재사용합니다. delivery pipeline은 실제 다운로드가 끝난 뒤 생성기를 기다린 다음 아카이브를 만듭니다. npm을 포함하지 않는 GUI 묶음은 기존 non-npm 설치기 분기를 계속 사용합니다.
+
 ### 내부 메서드
 
 | 메서드 | 설명 |
@@ -195,11 +197,11 @@ Maven의 `_remote.repositories`는 대상 저장소의 기존 내용을 보존�
 
 CLI와 GUI 저장소 구조는 전체 GAV 목록이 하나의 원본 저장소 루트에 모두 존재하는지로 구분합니다. `example`과 `m2repo.example` 그룹이 함께 있어도 같은 원본 구조에서 각각의 파일을 선택합니다. 두 구조가 모두 조건을 만족하거나 어느 구조에도 전체 목록이 없으면 복사 전에 오류로 종료합니다.
 
-npm은 스크립트 생성 시 원본 `.tgz`의 `package.json`에서 이름·버전을 읽어 파일 경로와 함께 Bash·PowerShell 안에 기록합니다. CLI는 `npmPackageFiles`에 실제 다운로드 경로와 아카이브 `packages/` 안의 상대 경로를 전달합니다. 이 옵션이 없으면 생성 시점의 `packageDir` 아래에서 `.tgz`를 탐색하므로 패키지 파일이 먼저 준비되어 있어야 합니다. 원본 tarball은 수정하거나 추출하지 않습니다. scoped 패키지와 공백이 포함된 경로를 지원합니다.
+npm은 스크립트 생성 시 원본 `.tgz`의 `package.json`에서 이름·버전을 읽어 파일 경로와 함께 Bash·PowerShell 안에 기록합니다. CLI와 GUI 모두 실제 다운로드 destination과 아카이브 `packages/` 안의 상대 경로를 `npmPackageFiles`로 전달할 수 있으며, GUI router는 추측한 파일명이 아니라 실제 저장한 `filePath`를 반환합니다. 이 옵션이 없으면 생성 시점의 `packageDir` 아래에서 `.tgz`를 탐색하므로 패키지 파일이 먼저 준비되어 있어야 합니다. 원본 tarball은 수정하거나 추출하지 않습니다. scoped 패키지와 공백이 포함된 경로를 지원합니다.
 
 실행 시 포함된 Node.js 코드가 스크립트 폴더의 `npm-project/package.json`에 실제 루트만 로컬 `file:` 의존성으로 등록합니다. 전이 패키지는 이를 요구하는 상위 패키지별 `overrides`로 연결해 같은 이름의 여러 버전과 서로 다른 peer 의존성 배치를 보존합니다. 이는 npm 10에서 전역 버전별 override를 로컬 파일로 바꾼 후 다시 해석할 때 첫 버전으로 합쳐지는 문제도 피합니다. tarball과 설치 대상은 실제 경로로 통일하고, `npm install --offline`으로 `npm-project/node_modules`에 설치합니다. Bash는 이 경로를 `--prefix`로 전달합니다. PowerShell은 생성 프로젝트로 잠시 이동해 `--prefix` 없이 설치한 뒤 성공·실패에 관계없이 위치를 복원합니다. Windows npm 10은 명시한 prefix가 로컬·전역 설치 위치에 함께 적용되면 현재 폴더를 추가 패키지로 읽을 수 있으므로 이 호출 방식을 사용합니다. bundle 루트에 사용자 `package.json`이 없어도 설치할 수 있습니다.
 
-CLI는 `npmRootPackages`에 실제 직접 요청 목록과 해결된 버전을 전달합니다. API 호출에서 이 옵션을 생략하면 이름별 가장 높은 전달 버전을 직접 루트로 취급하므로, 전이 목록을 함께 넘기는 호출자는 실제 루트를 지정해야 합니다. 동일 이름의 서로 다른 직접 버전 요청은 스크립트 생성 오류입니다. 원본 manifest의 일반·선택·peer 의존성을 읽어 전달된 호환 버전에 연결하며, 설치 범위에서 이미 선택한 호환 버전을 우선합니다. 순환 재방문은 반복문으로 처리하고, 계획 깊이 128 또는 규칙 100,000개를 초과하면 스크립트 생성 단계에서 명시적으로 실패합니다.
+CLI와 GUI는 `npmRootPackages`에 직접 요청 목록과 해결된 확정 버전을 전달합니다. API 호출에서 이 옵션을 생략하면 이름별 가장 높은 전달 버전을 직접 루트로 취급하므로, 전이 목록을 함께 넘기는 호출자는 실제 루트를 지정해야 합니다. 동일 이름의 서로 다른 직접 버전 요청은 스크립트 생성 오류입니다. 원본 manifest의 일반·선택·peer 의존성을 읽어 전달된 호환 버전에 연결하며, 설치 범위에서 이미 선택한 호환 버전을 우선합니다. 순환 재방문은 반복문으로 처리하고, 계획 깊이 128 또는 규칙 100,000개를 초과하면 스크립트 생성 단계에서 명시적으로 실패합니다.
 
 상위 폴더의 사용자 `package.json`은 변경하지 않습니다. `npm-project`는 비어 있거나 이 스크립트가 생성한 프로젝트여야 하며, 소유 표시가 없는 기존 프로젝트나 심볼릭 링크 대상은 오류로 처리합니다. 설치용 manifest는 유지하지만 프로젝트 루트의 lockfile은 생성하지 않으며 npm 자체 업데이트 확인도 끕니다. Node.js와 npm이 필요하며, 도구 부재·빈 파일 목록·의존성 누락·손상된 tarball·설치 명령 실패는 오류 종료로 이어집니다. npm의 일반 설치 lifecycle은 유지합니다. 이 스크립트는 의존성을 전달된 파일에 연결하며, OS·아키텍처 간 네이티브 패키지 변환이나 설치 lifecycle의 외부 다운로드 대체는 수행하지 않습니다.
 
@@ -207,7 +209,7 @@ Conda는 pip와 별도의 설치 블록을 생성합니다. CLI는 완료된 Con
 
 Conda 블록은 [명시적 로컬 아카이브 설치](https://docs.conda.io/projects/conda/en/stable/commands/install.html)를 사용합니다. 기본 대상 `SCRIPT_DIR/conda-env`가 없으면 `conda create --offline --yes --no-default-packages --prefix ...`를, 기존 Conda 환경이면 `conda install --offline --yes --prefix ...`를 실행합니다. `DEPS_SMUGGLER_CONDA_PREFIX`로 대상을 지정할 수 있고 상대 경로는 스크립트 폴더 기준입니다. 일반 파일·디렉터리를 기존 환경으로 덮어쓰지 않으며, 필수 파일이나 Conda가 없거나 명령이 실패하면 Bash·PowerShell 모두 non-zero로 종료합니다. `includeErrorHandling: false`여도 Conda 실패를 성공으로 처리하지 않습니다.
 
-명시적 파일 설치는 전달된 파일 집합을 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. Python noarch 패키지는 대상 환경에 호환되는 Python이 필요하므로, `--no-deps` 묶음은 기존 환경을 지정하거나 런타임을 별도로 준비해야 합니다. 이 내용은 CLI의 `ScriptGenerator`에 관한 것으로 Electron의 별도 `shared/script-utils` 생성기를 변경하지 않습니다.
+명시적 파일 설치는 전달된 파일 집합을 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. Python noarch 패키지는 대상 환경에 호환되는 Python이 필요하므로, `--no-deps` 묶음은 기존 환경을 지정하거나 런타임을 별도로 준비해야 합니다. GUI와 CLI는 npm 설치 계획과 runtime을 공유하지만, GUI의 현재 Conda `pip install` 동작 변경은 이 문서 범위가 아니며 #137에서 별도로 다룹니다.
 
 일반 `ScriptGenerator`에는 APT·APK 전용 설치 블록이 없습니다. OS 다운로드 전용 스크립트는 별도의 `OSScriptGenerator`가 제공합니다. `includeVerification`/`mirrorPath` 옵션은 이 클래스에 없습니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -306,6 +306,10 @@ Python 검증 환경은 runner의 base 환경에 설치된 Python과 전이 의�
 
 위 npm 소비자 테스트는 bundle 루트에 사용자 `package.json`이 있는 경우와 없는 경우를 모두 실행합니다. 사용자 manifest가 있으면 바이트를 보존하고 해당 프로젝트를 추가 패키지로 설치하지 않아야 하며, 없으면 새로 만들지 않아야 합니다. 이는 Windows npm 10에서 `--prefix` 때문에 현재 bundle 폴더가 추가 설치 대상이 되어 발생했던 오류를 검출합니다.
 
+`src/core/packager/gui-mixed-native-consumer.integration.test.ts`는 실제 `createDeliveryPipeline`, shared script generator, archive packager를 실행해 local fixture 기반 pip·npm 묶음을 ZIP으로 만든다. router 자체는 `electron/services/download-package-router.test.ts`에서 실제 destination을 성공 결과에 넣는지 별도로 검증한다. consumer는 생성된 ZIP만 새 디렉터리에 풀고 독립 Python venv·npm cache·loopback registry 차단 환경에서 `install.sh`를 실행한다. 직접 npm root와 전이 모듈의 `require`가 모두 성공하고 pip와 npm 설치가 모두 성공한 경우에만 완료 메시지와 종료 코드 `0`을 허용한다. npm 실패나 파일 경로 누락은 전체 성공으로 바꾸지 않는다. Windows PowerShell 실행은 해당 CI 환경에서 확인하며, 이 local fixture 테스트는 실제 공개 패키지 배포물이나 Conda native 설치를 주장하지 않는다.
+
+별도 수동 검증에서는 이전 GUI 산출물의 공개 패키지를 수정된 delivery pipeline으로 다시 묶었다. 원본 출력 디렉터리를 지우고 ZIP만 새 환경에 전달한 두 번의 실행에서 `colorama 0.4.6`, `is-odd 3.0.1`, `is-number 6.0.0` 로딩과 npm 레지스트리 요청 0건을 확인했다. 이는 위 로컬 fixture 검사와 별도이며, 수정된 pipeline 산출물 검증이지 새로 빌드한 GUI 앱 자체의 실행 검증이나 Conda 설치 검증은 아니다.
+
 ### Maven 설치 스크립트 canonical 저장소 검증
 
 `src/core/packager/script-generator.test.ts`의 canonical tree 회귀는 Maven 없이도 실행할 수 있습니다. 공백이 포함된 임시 추출 경로에서 실제 Bash subprocess(Windows에서는 native PowerShell)를 생성·실행하고, CLI `packages/<m2path>`와 GUI `packages/m2repo/<m2path>`의 JAR-only·companion POM·parent/BOM POM-only·classifier·checksum을 `MAVEN_REPO_LOCAL`에 경로·바이트 그대로 복사하는지 검사합니다. pip 파일과 flat 파일은 대상 저장소에 복사되지 않습니다. Maven native offline consumer 검증과 macOS에서 PowerShell이 없는 경우는 별도 환경 제한으로 기록합니다.

--- a/electron/download-handlers.test.ts
+++ b/electron/download-handlers.test.ts
@@ -424,10 +424,10 @@ describe('registerDownloadHandlers', () => {
           artifactPaths: [expectedArchivePath],
           deliveryMethod: 'local',
           results: [
-            {
+            expect.objectContaining({
               id: 'pip-requests-2.28.0',
               success: true,
-            },
+            }),
           ],
         })
       );
@@ -482,10 +482,10 @@ describe('registerDownloadHandlers', () => {
           artifactPaths: [expectedArchivePath],
           deliveryMethod: 'local',
           results: [
-            {
+            expect.objectContaining({
               id: 'pip-requests-2.28.0',
               success: true,
-            },
+            }),
           ],
         })
       );
@@ -806,7 +806,8 @@ describe('registerDownloadHandlers', () => {
             id: 'pip-requests-2.28.0',
             name: 'requests',
           }),
-        ]
+        ],
+        expect.any(Object),
       );
       expect(createArchiveFromDirectoryMock).toHaveBeenCalledWith(
         outputDir,

--- a/electron/services/download-orchestrator.test.ts
+++ b/electron/services/download-orchestrator.test.ts
@@ -288,7 +288,7 @@ describe('createDownloadOrchestrator', () => {
         id: 'pip-requests-2.28.0',
         name: 'requests',
       }),
-    ]);
+    ], { npmPackageFiles: [], npmRootPackages: undefined });
     expect(archivePackager.createArchiveFromDirectory).toHaveBeenCalledWith(
       '/tmp/out',
       '/tmp/out.tar.gz',

--- a/electron/services/download-package-router.test.ts
+++ b/electron/services/download-package-router.test.ts
@@ -5,12 +5,14 @@ const {
   copyMock,
   downloadMavenPackageMock,
   downloadFileMock,
+  getNpmDownloaderMock,
   ensureDirMock,
   pathExistsMock,
 } = vi.hoisted(() => ({
   copyMock: vi.fn(),
   downloadMavenPackageMock: vi.fn(),
   downloadFileMock: vi.fn(),
+  getNpmDownloaderMock: vi.fn(),
   ensureDirMock: vi.fn(),
   pathExistsMock: vi.fn(),
 }));
@@ -25,7 +27,7 @@ vi.mock('../../src/core', () => ({
   getCondaDownloader: vi.fn(),
   getDockerDownloader: vi.fn(),
   getMavenDownloader: () => ({ downloadPackage: downloadMavenPackageMock }),
-  getNpmDownloader: vi.fn(),
+  getNpmDownloader: getNpmDownloaderMock,
 }));
 
 vi.mock('../../src/core/shared', () => ({
@@ -73,6 +75,26 @@ describe('createDownloadPackageRouter Maven 처리', () => {
     pathExistsMock.mockResolvedValue(true);
     copyMock.mockResolvedValue(undefined);
     downloadFileMock.mockResolvedValue(undefined);
+    getNpmDownloaderMock.mockReturnValue({
+      getPackageMetadata: vi.fn().mockResolvedValue({
+        metadata: { downloadUrl: 'https://registry.example/is-odd/-/is-odd-3.0.1.tgz' },
+      }),
+    });
+  });
+
+  it('성공한 npm 다운로드 결과에 실제 packages 경로를 반환한다', async () => {
+    const router = createDownloadPackageRouter();
+    const result = await router.downloadPackage(
+      { id: 'npm-is-odd', type: 'npm', name: 'is-odd', version: '3.0.1' },
+      createContext() as never,
+    );
+
+    expect(result).toMatchObject({
+      id: 'npm-is-odd',
+      success: true,
+      filePath: path.join(packagesDir, 'is-odd-3.0.1.tgz'),
+    });
+    expect(downloadFileMock.mock.calls[0][1]).toBe(result.filePath);
   });
 
   it('uses the canonical defaults repository in the metadata fallback', async () => {

--- a/electron/services/download-package-router.ts
+++ b/electron/services/download-package-router.ts
@@ -172,7 +172,7 @@ export function createDownloadPackageRouter(): DownloadPackageRouter {
           true
         );
         progressEmitter.clearPackageProgress(pkg.id);
-        return { id: pkg.id, success: true };
+        return { id: pkg.id, success: true, filePath: destinationPath };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         log.error(`Download failed for ${pkg.name}:`, errorMessage);

--- a/electron/services/download/delivery-pipeline.test.ts
+++ b/electron/services/download/delivery-pipeline.test.ts
@@ -45,6 +45,57 @@ const createBaseParams = () => ({
 });
 
 describe('createDeliveryPipeline', () => {
+  it('설치 스크립트 준비를 기다리고 비동기 실패 시 압축하지 않는다', async () => {
+    const scriptDeferred = createDeferred<void>();
+    const createArchiveFromDirectory = vi.fn();
+    const generateInstallScripts = vi.fn(() => scriptDeferred.promise);
+    const pipeline = createDeliveryPipeline({
+      archivePackager: { createArchiveFromDirectory } as never,
+      generateInstallScripts,
+      initializeEmailSender: vi.fn() as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn() as never,
+    });
+    const base = createBaseParams();
+    const result = pipeline.finalizeDownload({
+      ...base,
+      options: { ...base.options, includeScripts: true },
+      progressEmitter: { emitDownloadStatus: vi.fn() } as never,
+      isCancelled: () => false,
+    });
+    await Promise.resolve();
+    expect(createArchiveFromDirectory).not.toHaveBeenCalled();
+    scriptDeferred.reject(new Error('missing npm tarball'));
+    expect(await result).toMatchObject({ success: false, error: 'missing npm tarball' });
+    expect(createArchiveFromDirectory).not.toHaveBeenCalled();
+  });
+
+  it('npm 결과 파일 경로와 다운로드 전 루트 선택을 스크립트 생성기로 전달한다', async () => {
+    const generateInstallScripts = vi.fn().mockResolvedValue(undefined);
+    const pipeline = createDeliveryPipeline({
+      archivePackager: { createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.zip') } as never,
+      generateInstallScripts,
+      initializeEmailSender: vi.fn() as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn() as never,
+    });
+    const base = createBaseParams();
+    const npm = { id: 'npm-is-number', type: 'npm', name: 'is-number', version: '6.0.0' };
+    const roots = [{ type: 'npm' as const, name: 'is-odd', version: '3.0.1' }];
+    await pipeline.finalizeDownload({
+      ...base,
+      deliveredPackages: [...base.deliveredPackages, npm],
+      results: [...base.results, { id: npm.id, success: true, filePath: '/tmp/out/packages/npm/custom-name.tgz' }],
+      options: { ...base.options, includeScripts: true, npmRootPackages: roots },
+      progressEmitter: { emitDownloadStatus: vi.fn() } as never,
+      isCancelled: () => false,
+    });
+    expect(generateInstallScripts).toHaveBeenCalledWith('/tmp/out', [...base.deliveredPackages, npm], {
+      npmRootPackages: roots,
+      npmPackageFiles: [{ filePath: '/tmp/out/packages/npm/custom-name.tgz', relativePath: 'npm/custom-name.tgz' }],
+    });
+  });
+
   it('지원하지 않는 출력 형식이면 실패 payload를 반환해야 함', async () => {
     const archivePackager = {
       createArchiveFromDirectory: vi.fn(),

--- a/electron/services/download/delivery-pipeline.ts
+++ b/electron/services/download/delivery-pipeline.ts
@@ -1,4 +1,5 @@
 import * as fse from 'fs-extra';
+import * as path from 'path';
 import { initializeEmailSender } from '../../../src/core/mailer/email-sender';
 import { getArchivePackager } from '../../../src/core/packager/archive-packager';
 import { getFileSplitter } from '../../../src/core/packager/file-splitter';
@@ -57,7 +58,20 @@ export function createDeliveryPipeline(deps: DeliveryPipelineDeps): DeliveryPipe
 
       if (includeScripts) {
         try {
-          deps.generateInstallScripts(outputDir, deliveredPackages);
+          const npmPackageFiles = deliveredPackages.filter(pkg => pkg.type === 'npm').map(pkg => {
+            const filePath = results.find(result => result.id === pkg.id && result.success)?.filePath;
+            if (!filePath) {
+              throw new Error(`npm 패키지 파일 경로가 없습니다: ${pkg.name}@${pkg.version}`);
+            }
+            return {
+              filePath,
+              relativePath: path.relative(path.join(outputDir, 'packages'), filePath).split(path.sep).join('/'),
+            };
+          });
+          await deps.generateInstallScripts(outputDir, deliveredPackages, {
+            npmPackageFiles,
+            npmRootPackages: options.npmRootPackages,
+          });
         } catch (error) {
           return {
             success: false,

--- a/src/core/packager/gui-mixed-native-consumer.integration.test.ts
+++ b/src/core/packager/gui-mixed-native-consumer.integration.test.ts
@@ -1,0 +1,206 @@
+import { execFile } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import archiver from 'archiver';
+import * as tar from 'tar';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getArchivePackager } from './archive-packager';
+import { getFileSplitter } from './file-splitter';
+import { createDeliveryPipeline } from '../../../electron/services/download/delivery-pipeline';
+import { initializeEmailSender } from '../mailer/email-sender';
+import { generateInstallScripts } from '../shared';
+import type { PackageInfo } from '../../types';
+
+const execFileAsync = promisify(execFile);
+async function zipFile(output: string, files: Record<string, string>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const archive = archiver('zip');
+    const stream = createWriteStream(output);
+    stream.on('close', resolve);
+    archive.on('error', reject);
+    archive.pipe(stream);
+    for (const [name, content] of Object.entries(files)) archive.append(content, { name });
+    void archive.finalize();
+  });
+}
+
+async function createWheel(root: string): Promise<string> {
+  const wheel = path.join(root, 'colorama-0.4.6-py2.py3-none-any.whl');
+  await zipFile(wheel, {
+    'colorama/__init__.py': '__version__ = "0.4.6"\n',
+    'colorama-0.4.6.dist-info/METADATA': 'Metadata-Version: 2.1\nName: colorama\nVersion: 0.4.6\n',
+    'colorama-0.4.6.dist-info/WHEEL': 'Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py2.py3-none-any\n',
+    'colorama-0.4.6.dist-info/RECORD': '',
+  });
+  return wheel;
+}
+
+async function createNpmTarball(root: string, name: string, version: string, dependency?: string): Promise<string> {
+  const source = path.join(root, `${name}-${version}-source`);
+  await fs.mkdir(path.join(source, 'package'), { recursive: true });
+  await fs.writeFile(path.join(source, 'package/package.json'), JSON.stringify({
+    name,
+    version,
+    main: 'index.js',
+    ...(dependency ? { dependencies: { 'is-number': dependency } } : {}),
+  }));
+  await fs.writeFile(path.join(source, 'package/index.js'), dependency
+    ? "module.exports = { name: 'is-odd', dependency: require('is-number') };\n"
+    : "module.exports = { name: 'is-number', version: '6.0.0' };\n");
+  const target = path.join(root, `${name}-${version}.tgz`);
+  await tar.create({ cwd: source, file: target, gzip: true }, ['package']);
+  return target;
+}
+
+async function zipEntries(filePath: string): Promise<string[]> {
+  const python = process.platform === 'win32' ? 'py' : 'python3';
+  const args = process.platform === 'win32' ? ['-3', '-c'] : ['-c'];
+  args.push('import sys, zipfile; print("\\n".join(zipfile.ZipFile(sys.argv[1]).namelist()))', filePath);
+  const output = await execFileAsync(python, args);
+  return output.stdout.trim().split(/\r?\n/).filter(Boolean);
+}
+
+async function extractZip(filePath: string, destination: string): Promise<void> {
+  const python = process.platform === 'win32' ? 'py' : 'python3';
+  const args = process.platform === 'win32' ? ['-3', '-c'] : ['-c'];
+  args.push('import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', filePath, destination);
+  await execFileAsync(python, args);
+}
+
+describe('GUI mixed pip/npm native archive consumer', () => {
+  let tempRoot: string | undefined;
+  let registry: Server | undefined;
+
+  afterEach(async () => {
+    if (tempRoot) await fs.rm(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+    if (registry?.listening) await new Promise<void>((resolve) => registry?.close(() => resolve()));
+    registry = undefined;
+  });
+
+  it('puts both native installers in the ZIP and consumes pip plus npm offline', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-gui-mixed-'));
+    const output = path.join(tempRoot, 'delivery output');
+    const packageDir = path.join(output, 'packages');
+    const pipDir = path.join(packageDir, 'pip');
+    const npmDir = path.join(packageDir, 'npm');
+    await fs.mkdir(pipDir, { recursive: true });
+    await fs.mkdir(npmDir, { recursive: true });
+    const wheel = await createWheel(tempRoot);
+    const rootTgz = await createNpmTarball(tempRoot, 'is-odd', '3.0.1', '6.0.0');
+    const dependencyTgz = await createNpmTarball(tempRoot, 'is-number', '6.0.0');
+    await fs.copyFile(wheel, path.join(pipDir, path.basename(wheel)));
+    await fs.copyFile(rootTgz, path.join(npmDir, path.basename(rootTgz)));
+    await fs.copyFile(dependencyTgz, path.join(npmDir, path.basename(dependencyTgz)));
+    await fs.mkdir(path.join(packageDir, 'unrelated'), { recursive: true });
+    await fs.writeFile(path.join(packageDir, 'unrelated', 'not-an-npm-package.tgz'), 'unrelated archive payload');
+
+    const packages = [
+      { id: 'pip-colorama', type: 'pip', name: 'colorama', version: '0.4.6', filePath: path.join(pipDir, path.basename(wheel)) },
+      { id: 'npm-is-odd', type: 'npm', name: 'is-odd', version: '3.0.1', filePath: path.join(npmDir, path.basename(rootTgz)) },
+      { id: 'npm-is-number', type: 'npm', name: 'is-number', version: '6.0.0', filePath: path.join(npmDir, path.basename(dependencyTgz)) },
+    ];
+    const packageInfos = packages.map(({ filePath: _filePath, ...pkg }) => pkg) as PackageInfo[];
+    let registryRequests = 0;
+    registry = createServer((_request, response) => {
+      registryRequests += 1;
+      response.writeHead(503);
+      response.end('network access is forbidden during offline install');
+    });
+    await new Promise<void>((resolve) => registry?.listen(0, '127.0.0.1', () => resolve()));
+    const registryAddress = registry.address();
+    if (!registryAddress || typeof registryAddress === 'string') throw new Error('registry fixture did not start');
+    const registryUrl = `http://127.0.0.1:${registryAddress.port}`;
+
+    const pipeline = createDeliveryPipeline({
+      archivePackager: getArchivePackager(),
+      generateInstallScripts,
+      initializeEmailSender,
+      getFileSplitter,
+      stat: fs.stat,
+    });
+    const result = await pipeline.finalizeDownload({
+      outputDir: output,
+      options: {
+        outputDir: output,
+        outputFormat: 'zip',
+        includeScripts: true,
+        deliveryMethod: 'local',
+        npmRootPackages: packageInfos.filter((pkg) => pkg.type === 'npm' && pkg.name === 'is-odd'),
+      },
+      deliveredPackages: packages,
+      packageInfos,
+      results: packages.map(({ id, filePath }) => ({ id, success: true, filePath })),
+      failedDownloadCount: 0,
+      progressEmitter: { emitDownloadStatus: () => undefined },
+      isCancelled: () => false,
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    const archivePath = String(result.outputPath);
+    const entries = await zipEntries(archivePath);
+    expect(entries).toContain('install.sh');
+    expect(entries).toContain('install.ps1');
+
+    // Consume only the archive; the original generated output is unavailable.
+    await fs.rm(output, { recursive: true, force: true });
+    const extracted = path.join(tempRoot, 'archive extracted');
+    await fs.mkdir(extracted, { recursive: true });
+    await extractZip(archivePath, extracted);
+    const installUser = path.join(tempRoot, 'python venv');
+    const windows = process.platform === 'win32';
+    await execFileAsync(windows ? 'py' : 'python3', windows ? ['-3', '-m', 'venv', installUser] : ['-m', 'venv', installUser]);
+    const env = {
+      ...process.env,
+      PATH: `${path.join(installUser, windows ? 'Scripts' : 'bin')}${path.delimiter}${process.env.PATH ?? ''}`,
+      PIP_CONFIG_FILE: path.join(tempRoot, 'empty-pip.conf'),
+      npm_config_cache: path.join(tempRoot, 'npm cache'),
+      npm_config_userconfig: path.join(tempRoot, 'empty-npmrc'),
+      npm_config_globalconfig: path.join(tempRoot, 'empty-global-npmrc'),
+      npm_config_registry: registryUrl,
+      PIP_DISABLE_PIP_VERSION_CHECK: '1',
+    };
+    await fs.writeFile(env.PIP_CONFIG_FILE, '');
+    await fs.writeFile(env.npm_config_userconfig, '');
+    await fs.writeFile(env.npm_config_globalconfig, '');
+    const python = path.join(installUser, windows ? 'Scripts/python.exe' : 'bin/python');
+    const installCommand = windows
+      ? { file: 'powershell.exe', args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', path.join(extracted, 'install.ps1')] }
+      : { file: 'bash', args: [path.join(extracted, 'install.sh')] };
+    const install = await execFileAsync(installCommand.file, installCommand.args, {
+      cwd: extracted,
+      env,
+      timeout: 180_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    expect(install.stderr).not.toContain('ERROR');
+    const pythonCheck = await execFileAsync(python, ['-c', 'import colorama; print(colorama.__version__)'], { env });
+    expect(pythonCheck.stdout.trim()).toBe('0.4.6');
+    const npmProject = path.join(extracted, 'npm-project');
+    const npmCheck = await execFileAsync(process.execPath, ['-e', "const odd=require('./node_modules/is-odd'); if (!odd.dependency) process.exit(1); console.log(odd.name)"], { cwd: npmProject, env });
+    expect(npmCheck.stdout.trim()).toBe('is-odd');
+    await expect(fs.access(path.join(npmProject, 'node_modules/is-number/package.json'))).resolves.toBeUndefined();
+    expect(registryRequests).toBe(0);
+
+    const brokenBundle = path.join(tempRoot, 'archive missing root');
+    await fs.mkdir(brokenBundle, { recursive: true });
+    await extractZip(archivePath, brokenBundle);
+    await fs.rm(path.join(brokenBundle, 'packages/npm/is-odd-3.0.1.tgz'));
+    let failureOutput = '';
+    try {
+      await execFileAsync(
+        installCommand.file,
+        installCommand.args.map((arg) => arg.replace(extracted, brokenBundle)),
+        { cwd: brokenBundle, env, timeout: 180_000, maxBuffer: 4 * 1024 * 1024 },
+      );
+    } catch (error) {
+      const failure = error as { stdout?: string; stderr?: string };
+      failureOutput = `${failure.stdout ?? ''}\n${failure.stderr ?? ''}`;
+    }
+    expect(failureOutput).not.toContain('Installation complete!');
+    await expect(fs.access(path.join(brokenBundle, 'npm-project'))).rejects.toThrow();
+  }, 300_000);
+});

--- a/src/core/packager/npm-install-script.ts
+++ b/src/core/packager/npm-install-script.ts
@@ -1,0 +1,62 @@
+import type { NpmInstallPlan } from './npm-install-plan';
+import { buildNpmProjectSetupScript } from './npm-install-runtime';
+
+export function buildNpmBashInstallLines(npmPlan: NpmInstallPlan): string[] {
+  const lines: string[] = [];
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('# npm 패키지 오프라인 설치');
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('');
+  lines.push('install_npm_packages() {');
+  lines.push('    log_info "npm 패키지 설치 중..."');
+  lines.push('    if ! command -v node &> /dev/null || ! command -v npm &> /dev/null; then');
+  lines.push('        log_error "Node.js와 npm이 설치되어 있어야 합니다."');
+  lines.push('        return 1');
+  lines.push('    fi');
+  lines.push('');
+  lines.push('    local npm_project_encoded npm_project');
+  lines.push('    npm_project_encoded="$(node - "$SCRIPT_DIR" "$PACKAGE_DIR" <<\'DEPS_SMUGGLER_NPM\'');
+  lines.push(buildNpmProjectSetupScript(npmPlan));
+  lines.push('DEPS_SMUGGLER_NPM');
+  lines.push('    )" || return 1');
+  lines.push('    npm_project="$(node -e \'process.stdout.write(Buffer.from(process.argv[1], "base64").toString("utf8"))\' "$npm_project_encoded")" || return 1');
+  lines.push('');
+  lines.push('    npm install --offline --no-audit --no-fund --update-notifier=false --no-save --package-lock=false --global=false --prefix "$npm_project" || {');
+  lines.push('        log_error "npm 패키지 설치에 실패했습니다."');
+  lines.push('        return 1');
+  lines.push('    }');
+  lines.push('    log_info "npm 패키지 설치 완료: $npm_project/node_modules"');
+  lines.push('}');
+  lines.push('');
+  return lines;
+}
+
+export function buildNpmPowerShellInstallLines(npmPlan: NpmInstallPlan): string[] {
+  const lines: string[] = [];
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('# npm 패키지 오프라인 설치');
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('');
+  lines.push('function Install-NpmPackages {');
+  lines.push('    Write-Info "npm 패키지 설치 중..."');
+  lines.push('    if (-not (Get-Command node -ErrorAction SilentlyContinue) -or -not (Get-Command npm -ErrorAction SilentlyContinue)) {');
+  lines.push('        throw "Node.js와 npm이 설치되어 있어야 합니다."');
+  lines.push('    }');
+  lines.push('    $NpmSetupScript = @\'');
+  lines.push(buildNpmProjectSetupScript(npmPlan));
+  lines.push('\'@');
+  lines.push('    $NpmProjectEncoded = $NpmSetupScript | & node - "$ScriptDir" "$PackageDir"');
+  lines.push('    if ($LASTEXITCODE -ne 0) { throw "npm 설치 프로젝트 준비에 실패했습니다." }');
+  lines.push('    $NpmProject = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($NpmProjectEncoded))');
+  lines.push('    Push-Location -LiteralPath $NpmProject -ErrorAction Stop');
+  lines.push('    try {');
+  lines.push('        & npm install --offline --no-audit --no-fund --update-notifier=false --no-save --package-lock=false --global=false');
+  lines.push('        if ($LASTEXITCODE -ne 0) { throw "npm 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
+  lines.push('    } finally {');
+  lines.push('        Pop-Location');
+  lines.push('    }');
+  lines.push('    Write-Info "npm 패키지 설치 완료: $NpmProject/node_modules"');
+  lines.push('}');
+  lines.push('');
+  return lines;
+}

--- a/src/core/packager/script-generator.ts
+++ b/src/core/packager/script-generator.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { createNpmInstallPlan, NpmPackageFile } from './npm-install-plan';
-import { buildNpmProjectSetupScript } from './npm-install-runtime';
+import { buildNpmBashInstallLines, buildNpmPowerShellInstallLines } from './npm-install-script';
 import { PackageInfo } from '../../types';
 import logger from '../../utils/logger';
 import { stripLeadingDotSlash, toUnixPath, getWriteOptions } from '../shared/path-utils';
@@ -327,31 +327,7 @@ export class ScriptGenerator {
     // npm 패키지 설치
     if (packagesByType.has('npm')) {
       const npmPlan = await createNpmInstallPlan(packages, outputPath, packageDir, options.npmPackageFiles, options.npmRootPackages);
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('# npm 패키지 오프라인 설치');
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('');
-      lines.push('install_npm_packages() {');
-      lines.push('    log_info "npm 패키지 설치 중..."');
-      lines.push('    if ! command -v node &> /dev/null || ! command -v npm &> /dev/null; then');
-      lines.push('        log_error "Node.js와 npm이 설치되어 있어야 합니다."');
-      lines.push('        return 1');
-      lines.push('    fi');
-      lines.push('');
-      lines.push('    local npm_project_encoded npm_project');
-      lines.push('    npm_project_encoded="$(node - "$SCRIPT_DIR" "$PACKAGE_DIR" <<\'DEPS_SMUGGLER_NPM\'');
-      lines.push(buildNpmProjectSetupScript(npmPlan));
-      lines.push('DEPS_SMUGGLER_NPM');
-      lines.push('    )" || return 1');
-      lines.push('    npm_project="$(node -e \'process.stdout.write(Buffer.from(process.argv[1], "base64").toString("utf8"))\' "$npm_project_encoded")" || return 1');
-      lines.push('');
-      lines.push('    npm install --offline --no-audit --no-fund --update-notifier=false --no-save --package-lock=false --global=false --prefix "$npm_project" || {');
-      lines.push('        log_error "npm 패키지 설치에 실패했습니다."');
-      lines.push('        return 1');
-      lines.push('    }');
-      lines.push('    log_info "npm 패키지 설치 완료: $npm_project/node_modules"');
-      lines.push('}');
-      lines.push('');
+      lines.push(...buildNpmBashInstallLines(npmPlan));
     }
 
     // Maven 패키지 설치
@@ -763,31 +739,7 @@ export class ScriptGenerator {
     // npm 패키지 설치
     if (packagesByType.has('npm')) {
       const npmPlan = await createNpmInstallPlan(packages, outputPath, packageDir, options.npmPackageFiles, options.npmRootPackages);
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('# npm 패키지 오프라인 설치');
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('');
-      lines.push('function Install-NpmPackages {');
-      lines.push('    Write-Info "npm 패키지 설치 중..."');
-      lines.push('    if (-not (Get-Command node -ErrorAction SilentlyContinue) -or -not (Get-Command npm -ErrorAction SilentlyContinue)) {');
-      lines.push('        throw "Node.js와 npm이 설치되어 있어야 합니다."');
-      lines.push('    }');
-      lines.push('    $NpmSetupScript = @\'');
-      lines.push(buildNpmProjectSetupScript(npmPlan));
-      lines.push('\'@');
-      lines.push('    $NpmProjectEncoded = $NpmSetupScript | & node - "$ScriptDir" "$PackageDir"');
-      lines.push('    if ($LASTEXITCODE -ne 0) { throw "npm 설치 프로젝트 준비에 실패했습니다." }');
-      lines.push('    $NpmProject = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($NpmProjectEncoded))');
-      lines.push('    Push-Location -LiteralPath $NpmProject -ErrorAction Stop');
-      lines.push('    try {');
-      lines.push('        & npm install --offline --no-audit --no-fund --update-notifier=false --no-save --package-lock=false --global=false');
-      lines.push('        if ($LASTEXITCODE -ne 0) { throw "npm 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
-      lines.push('    } finally {');
-      lines.push('        Pop-Location');
-      lines.push('    }');
-      lines.push('    Write-Info "npm 패키지 설치 완료: $NpmProject/node_modules"');
-      lines.push('}');
-      lines.push('');
+      lines.push(...buildNpmPowerShellInstallLines(npmPlan));
     }
 
     // Maven 패키지 설치

--- a/src/core/shared/script-utils.test.ts
+++ b/src/core/shared/script-utils.test.ts
@@ -13,14 +13,15 @@ describe('generateInstallScripts', () => {
     }
   });
 
-  it('중첩된 pip 아티팩트 디렉터리를 Bash와 PowerShell에서 모두 탐색한다', () => {
+  it('중첩된 pip 아티팩트 디렉터리를 Bash와 PowerShell에서 모두 탐색한다', async () => {
     const outputDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'script-utils-'),
     );
     outputDirs.push(outputDir);
 
-    generateInstallScripts(outputDir, [
+    await generateInstallScripts(outputDir, [
       {
+        id: 'pip-requests',
         name: 'requests',
         version: '2.28.0',
         type: 'pip',
@@ -46,5 +47,26 @@ describe('generateInstallScripts', () => {
       'Get-ChildItem -Path $PackagesDir -Directory -Recurse',
     );
     expect(powerShellScript).toContain('@PipFindLinkArgs');
+  });
+
+  it('npm tarball이 없으면 설치 성공 스크립트를 만들지 않는다', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'script-utils-npm-'));
+    outputDirs.push(outputDir);
+    await expect((async () => generateInstallScripts(outputDir, [
+      { id: 'npm-is-odd', type: 'npm', name: 'is-odd', version: '3.0.1' },
+    ]))()).rejects.toThrow();
+    expect(fs.existsSync(path.join(outputDir, 'install.sh'))).toBe(false);
+  });
+
+  it('npm 루트 다운로드가 모두 실패해도 pip만 설치하는 성공 스크립트를 만들지 않는다', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'script-utils-root-'));
+    outputDirs.push(outputDir);
+    await expect(generateInstallScripts(outputDir, [
+      { id: 'pip-colorama', type: 'pip', name: 'colorama', version: '0.4.6' },
+    ], {
+      npmRootPackages: [{ type: 'npm', name: 'is-odd', version: '3.0.1' }],
+      npmPackageFiles: [],
+    })).rejects.toThrow('is-odd@3.0.1');
+    expect(fs.existsSync(path.join(outputDir, 'install.sh'))).toBe(false);
   });
 });

--- a/src/core/shared/script-utils.test.ts
+++ b/src/core/shared/script-utils.test.ts
@@ -36,6 +36,9 @@ describe('generateInstallScripts', () => {
       path.join(outputDir, 'install.ps1'),
       'utf8',
     );
+    const powerShellBytes = fs.readFileSync(path.join(outputDir, 'install.ps1'));
+
+    expect(powerShellBytes.subarray(0, 3)).toEqual(Buffer.from([0xef, 0xbb, 0xbf]));
 
     expect(bashScript).toContain(
       'find "$SCRIPT_DIR/packages" -type d -print0',

--- a/src/core/shared/script-utils.ts
+++ b/src/core/shared/script-utils.ts
@@ -41,7 +41,11 @@ export async function generateInstallScripts(
   // Windows에서는 mode 옵션이 무시되므로 조건부 처리
   const bashWriteOptions = isWindows ? {} : { mode: 0o755 };
   fs.writeFileSync(path.join(outputDir, 'install.sh'), bashScript, bashWriteOptions);
-  fs.writeFileSync(path.join(outputDir, 'install.ps1'), psScript);
+  // Windows PowerShell 5.1 needs the UTF-8 BOM to decode Korean diagnostics correctly.
+  fs.writeFileSync(
+    path.join(outputDir, 'install.ps1'),
+    Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(psScript, 'utf8')]),
+  );
 
   // Docker 이미지가 포함된 경우 docker-load 스크립트 생성
   const dockerPackages = packages.filter((p) => p.type === 'docker');

--- a/src/core/shared/script-utils.ts
+++ b/src/core/shared/script-utils.ts
@@ -3,16 +3,40 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { DownloadPackage } from './types';
 import { isWindows } from './path-utils';
+import type { PackageInfo } from '../../types';
+import { createNpmInstallPlan, type NpmInstallPlan, type NpmPackageFile } from '../packager/npm-install-plan';
+import { buildNpmBashInstallLines, buildNpmPowerShellInstallLines } from '../packager/npm-install-script';
+
+export interface InstallScriptOptions {
+  npmRootPackages?: PackageInfo[];
+  npmPackageFiles?: NpmPackageFile[];
+}
 
 /**
  * 설치 스크립트 생성 (Bash + PowerShell)
  */
-export function generateInstallScripts(
+export async function generateInstallScripts(
   outputDir: string,
-  packages: DownloadPackage[]
-): void {
-  const bashScript = generateBashScript(packages);
-  const psScript = generatePowerShellScript(packages);
+  packages: DownloadPackage[],
+  options: InstallScriptOptions = {},
+): Promise<void> {
+  for (const root of options.npmRootPackages ?? []) {
+    if (root.type === 'npm' && !packages.some(pkg =>
+      pkg.type === 'npm' && pkg.name === root.name && pkg.version === root.version)) {
+      throw new Error(`직접 npm 패키지 다운로드가 누락되었습니다: ${root.name}@${root.version}`);
+    }
+  }
+  const npmPlan = packages.some(pkg => pkg.type === 'npm')
+    ? await createNpmInstallPlan(
+        packages.map(pkg => ({ ...pkg, type: pkg.type as PackageInfo['type'] })),
+        path.join(outputDir, 'install.sh'),
+        './packages',
+        options.npmPackageFiles,
+        options.npmRootPackages,
+      )
+    : undefined;
+  const bashScript = generateBashScript(packages, npmPlan);
+  const psScript = generatePowerShellScript(packages, npmPlan);
 
   // Windows에서는 mode 옵션이 무시되므로 조건부 처리
   const bashWriteOptions = isWindows ? {} : { mode: 0o755 };
@@ -34,7 +58,7 @@ export function generateInstallScripts(
 /**
  * Bash 설치 스크립트 생성
  */
-function generateBashScript(packages: DownloadPackage[]): string {
+function generateBashScript(packages: DownloadPackage[], npmPlan?: NpmInstallPlan): string {
   const pipPackages = packages.filter((p) => p.type === 'pip');
   const condaPackages = packages.filter((p) => p.type === 'conda');
   const mavenPackages = packages.filter((p) => p.type === 'maven');
@@ -51,6 +75,12 @@ echo "Installing packages..."
 
 SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
 
+${npmPlan ? `PACKAGE_DIR="$SCRIPT_DIR/packages"
+log_info() { echo "$@"; }
+log_error() { echo "$@" >&2; }
+${buildNpmBashInstallLines(npmPlan).join('\n')}
+` : ''}
+
 ${hasPythonPackages ? `PIP_FIND_LINK_ARGS=()
 while IFS= read -r -d '' directory; do
     PIP_FIND_LINK_ARGS+=(--find-links="$directory")
@@ -66,6 +96,7 @@ ${condaPackages.map((p) => `pip install --no-index "\${PIP_FIND_LINK_ARGS[@]}" $
 ${mavenPackages.length > 0 ? `# Maven 아티팩트 복사
 echo "Maven artifacts are in packages/ directory"
 ` : ''}
+${npmPlan ? 'install_npm_packages || exit 1' : ''}
 echo "Installation complete!"
 `;
 }
@@ -73,7 +104,7 @@ echo "Installation complete!"
 /**
  * PowerShell 설치 스크립트 생성
  */
-function generatePowerShellScript(packages: DownloadPackage[]): string {
+function generatePowerShellScript(packages: DownloadPackage[], npmPlan?: NpmInstallPlan): string {
   const pipPackages = packages.filter((p) => p.type === 'pip');
   const condaPackages = packages.filter((p) => p.type === 'conda');
   const mavenPackages = packages.filter((p) => p.type === 'maven');
@@ -91,6 +122,11 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 $PackagesDir = Join-Path -Path $ScriptDir -ChildPath 'packages'
 
+${npmPlan ? `$PackageDir = $PackagesDir
+function Write-Info { param([string]$Message) Write-Host $Message }
+${buildNpmPowerShellInstallLines(npmPlan).join('\n')}
+` : ''}
+
 ${hasPythonPackages ? `$PipFindLinkArgs = @("--find-links=$PackagesDir")
 $PipFindLinkArgs += @(
     Get-ChildItem -Path $PackagesDir -Directory -Recurse |
@@ -99,7 +135,8 @@ $PipFindLinkArgs += @(
 
 ` : ''}
 ${pipPackages.length > 0 ? `# pip 패키지 설치
-${pipPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==${p.version}`).join('\n')}
+${pipPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==${p.version}
+if ($LASTEXITCODE -ne 0) { throw "pip 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }`).join('\n')}
 ` : ''}
 ${condaPackages.length > 0 ? `# conda 패키지 설치
 ${condaPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==${p.version}`).join('\n')}
@@ -107,6 +144,7 @@ ${condaPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==$
 ${mavenPackages.length > 0 ? `# Maven 아티팩트 복사
 Write-Host "Maven artifacts are in packages/ directory"
 ` : ''}
+${npmPlan ? 'Install-NpmPackages' : ''}
 Write-Host "Installation complete!"
 `;
 }

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -46,6 +46,8 @@ export interface DownloadPackageResult {
   id: string;
   success: boolean;
   error?: string;
+  /** 실제로 저장된 파일 경로 (일반 파일 다운로드 성공 시) */
+  filePath?: string;
 }
 
 export type DownloadResult = DownloadPackageResult;

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
@@ -366,6 +366,59 @@ describe('useDownloadPageController', () => {
     expect(rendered.result.current.isDownloading).toBe(true);
   });
 
+  it('start 시 npm 직접 요청만 npmRootPackages로 전달하고 dependency는 제외한다', async () => {
+    const { electronAPI, rendered, stores } = await loadController({
+      cartItems: [{ id: 'npm-root', type: 'npm', name: 'is-odd', version: '3.0.1', addedAt: Date.now() }],
+    });
+    act(() => {
+      stores.useDownloadStore.setState({
+        items: [
+          {
+            id: 'npm-root', name: 'is-odd', version: '3.0.1', type: 'npm', isDependency: false,
+            status: 'pending', progress: 0, downloadedBytes: 0, totalBytes: 0, speed: 0,
+          },
+          {
+            id: 'npm-dependency', name: 'is-number', version: '6.0.0', type: 'npm', isDependency: true,
+            status: 'pending', progress: 0, downloadedBytes: 0, totalBytes: 0, speed: 0,
+          },
+        ],
+      });
+    });
+    await waitFor(() => expect(rendered.result.current.downloadItems).toHaveLength(2));
+
+    await act(async () => {
+      await rendered.result.current.handleStartDownload();
+    });
+
+    expect(electronAPI.download.start).toHaveBeenCalledWith(expect.objectContaining({
+      options: expect.objectContaining({
+        npmRootPackages: [{ type: 'npm', name: 'is-odd', version: '3.0.1', metadata: undefined }],
+      }),
+    }));
+  });
+
+  it('npm 항목이 dependency만이어도 npmRootPackages를 빈 배열로 전달한다', async () => {
+    const { electronAPI, rendered } = await loadController({
+      cartItems: [{ id: 'npm-root', type: 'npm', name: 'is-odd', version: '3.0.1', addedAt: Date.now() }],
+      includeDependencies: true,
+      downloadState: {
+        depsResolved: true,
+        items: [{
+          id: 'npm-dependency', name: 'is-number', version: '6.0.0', type: 'npm', isDependency: true,
+          status: 'pending', progress: 0, downloadedBytes: 0, totalBytes: 0, speed: 0,
+        }],
+      },
+    });
+
+    await act(async () => {
+      await rendered.result.current.handleStartDownload();
+    });
+
+    expect(electronAPI.download.start).toHaveBeenCalledWith(expect.objectContaining({
+      options: expect.objectContaining({ npmRootPackages: [] }),
+    }));
+  });
+
   it('pause 시 상태와 IPC 호출을 일시정지로 바꾼다', async () => {
     const { electronAPI, rendered, stores } = await loadController({
       downloadState: {

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.tsx
@@ -28,6 +28,7 @@ import type {
   HistoryPackageItem,
   HistorySettings,
   HistoryStatus,
+  PackageInfo,
 } from '../../../../types';
 import type { AllCompleteData, DependencyAPI } from '../../../../types/electron';
 import type { CartItem } from '../../../stores/cart-store';
@@ -1111,6 +1112,17 @@ export function useDownloadPageController() {
           fileSplitEnabled: enableFileSplit,
           maxFileSizeMB: maxFileSize,
         });
+        const npmItems = downloadItems.filter(item => item.type === 'npm');
+        if (npmItems.length > 0) {
+          options.npmRootPackages = downloadItems
+            .filter(item => item.type === 'npm' && !item.isDependency)
+            .map((item): PackageInfo => ({
+              type: 'npm',
+              name: item.name,
+              version: item.version,
+              metadata: item.metadata,
+            }));
+        }
 
         await window.electronAPI.download.start({
           sessionId: sessionSnapshot.id,
@@ -1379,6 +1391,14 @@ export function useDownloadPageController() {
         fileSplitEnabled: enableFileSplit,
         maxFileSizeMB: maxFileSize,
       });
+      if (item.type === 'npm') {
+        options.npmRootPackages = [{
+          type: 'npm',
+          name: item.name,
+          version: item.version,
+          metadata: item.metadata,
+        } satisfies PackageInfo];
+      }
 
       await window.electronAPI.download.start({
         sessionId: sessionSnapshot.id,

--- a/src/types/download/options.ts
+++ b/src/types/download/options.ts
@@ -1,3 +1,4 @@
+import type { PackageInfo } from '../package-manager/metadata';
 import type { Architecture } from '../platform/architecture';
 import type { TargetOS } from '../platform/os-target';
 
@@ -37,6 +38,8 @@ export interface DownloadOptions {
   email?: DownloadEmailOptions;
   fileSplit?: DownloadFileSplitOptions;
   smtp?: DownloadSmtpOptions;
+  /** Directly requested npm roots, distinct from resolved dependency packages. */
+  npmRootPackages?: PackageInfo[];
 }
 
 export interface PipDownloadOptions extends DownloadOptions {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -82,6 +82,8 @@ export interface DownloadStartOptions {
     from?: string;
     secure?: boolean;
   };
+  /** Directly requested npm roots, distinct from resolved dependency packages. */
+  npmRootPackages?: PackageInfo[];
 }
 
 export interface SmtpConnectionConfig {


### PR DESCRIPTION
GUI에서 pip와 npm을 함께 반출하면 설치 스크립트가 npm을 건너뛰고 성공 종료했습니다. 이제 CLI와 같은 npm 설치 계획과 Bash·PowerShell 블록을 사용해 직접 패키지와 전이 의존성을 `npm-project/node_modules`에 오프라인으로 설치합니다.

다운로드 결과의 실제 파일 경로와 사용자가 선택한 npm 루트 버전을 전달하고, 무관한 `.tgz` 파일은 설치 계획에서 제외합니다. 비동기 스크립트 준비를 기다린 뒤 압축하며, 루트 다운로드 누락·스크립트 생성 실패·설치 명령 실패는 전체 성공으로 표시하지 않습니다. 단일 재시도는 해당 요청의 루트만 전달합니다. GUI Conda 문제는 #137에서 별도로 처리합니다.

검증:
- `bash scripts/verify-worktree.sh`: 3015 PASS / 162 SKIP. 기존 IPC 기대값도 추가된 결과·옵션 계약에 맞춰 갱신했습니다.
- `npx tsc --noEmit` 통과, ESLint 오류 0개, `git diff --check` 통과.
- 독립 리뷰의 Windows PowerShell 5.1 인코딩 지적을 반영해 `install.ps1`에 UTF-8 BOM을 기록합니다. BOM 회귀는 수정 전 실패했고, 수정 후 shared·IPC 20개 및 GUI 혼합 설치 소비자 1개가 통과했습니다. 타입 검사도 다시 통과했습니다.
- 새 GUI delivery 통합 검사는 실제 pipeline·생성기·ZIP을 사용합니다. 원본 출력을 삭제한 뒤 별도 Python venv와 npm 캐시에서 로컬 fixture의 Python import 및 npm 루트·전이 모듈 require를 확인하고, npm tarball 제거 시 오류 종료와 완료 문구 부재를 검사합니다. npm 레지스트리 요청은 0건입니다.
- 기존 CLI npm 설치 소비자 검사도 통과했습니다.
- 이전 GUI 감사의 실제 공개 배포물 colorama 0.4.6 / is-odd 3.0.1 / is-number 6.0.0을 수정된 pipeline으로 다시 묶어 ZIP만 새 환경에 전달했습니다. 두 번 모두 실제 import·require에 성공했고 npm 레지스트리 요청은 0건입니다.
- 로컬 macOS에서는 Bash를 실행했습니다. Windows PowerShell 실행은 CI에서 검증합니다. 제품 빌드·설치·배포는 수행하지 않았습니다.

README, 설치 스크립트 문서, 테스트 문서에 동작과 검증 범위를 반영했습니다.

Closes #135
