### PR TITLE
fix: YUM 저장소에 RPM 제공 기능 이름 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ depssmuggler --help
 | Python `conda` | 지원 | 지원 | 채널 선택, Python·CUDA·플랫폼을 고려한 빌드 선택 |
 | Java `maven` | 지원 | 지원 | Maven Central, POM·BOM·플러그인, 네이티브 classifier 선택 |
 | Node.js `npm` | 지원 | 지원 | npm Registry 검색·버전 조회·tarball 다운로드 |
-| OS `yum` | 지원 | 지원 | RPM 계열 배포판, 의존성 해결과 로컬 저장소 출력 |
+| OS `yum` | 지원 | 지원 | RPM 계열 배포판, provides capability를 포함한 의존성 해결과 로컬 저장소 출력 |
 | OS `apt` | 지원 | 지원 | Ubuntu/Debian, 의존성 포함 DEB 다운로드 |
 | OS `apk` | 지원 | 지원 | Alpine, APK 다운로드·아카이브·로컬 저장소 출력 |
 | Container `docker` | 지원 | 지원 | Docker Hub 이미지·태그·플랫폼 선택과 이미지 아카이브 |

--- a/docs/os-package-downloader.md
+++ b/docs/os-package-downloader.md
@@ -310,6 +310,8 @@ XML 속성을 일괄 숫자 변환하지 않으므로 RPM 버전·release·의�
 
 YUM 파싱 결과는 `{ schemaVersion: 1, packages }` 캐시로 저장합니다. 이전 배열 형식, 알 수 없는 스키마와 잘못된 버전 타입은 다시 파싱해 같은 키에 저장하며, 현재 형식은 JSON 저장·복원 뒤에도 버전·release·의존성 버전 문자열을 유지합니다.
 
+YUM `primary.xml.gz`의 `rpm:provides`에는 패키지 자체의 이름을 항상 포함하고, `OSPackageInfo.provides`에 있는 capability 이름을 중복 없이 추가합니다. 이름은 XML 속성으로 escape하므로 `libtinfo.so.6()(64bit)` 같은 라이브러리 capability도 생성 저장소의 DNF 검색에 전달됩니다. 현재 `provides` 타입은 `string[]`이므로 RPM provide의 flags·epoch·ver·rel 속성은 별도로 보존하거나 비교하지 않습니다.
+
 ```typescript
 interface RepomdInfo {
   revision: string;
@@ -630,6 +632,10 @@ class OSRepoPackager {
 | APK | `APKINDEX.tar.gz` | `APKINDEX` 항목 하나를 담은 gzip tar 아카이브를 Node `tar`로 생성 |
 
 현재 패키저는 `createrepo`, `dpkg-scanpackages`, `apk index`를 실행하지 않습니다. YUM은 `Packages/` 하위에, APT/APK는 저장소 루트에 파일을 복사합니다.
+
+YUM 저장소를 생성할 때 `primary.xml.gz`의 각 RPM에는 self-provide와 입력 패키지의 distinct `provides` capability 이름이 기록됩니다. 이 정보는 다운로드된 RPM payload에서 새로 추출하지 않고 resolver/parser가 가진 `OSPackageInfo.provides`를 사용합니다. 현재 모델은 capability 이름만 표현하므로 versioned 또는 flags가 붙은 RPM provides의 의미까지 native solver에서 재현한다고 보장하지 않습니다.
+
+Rocky 9 Bash 묶음에서는 `libtinfo.so.6()(64bit)` 조회와 해당 기능의 DNF 의존성 해결을 확인했습니다. 빈 installroot의 전체 Bash 설치는 별도로 누락된 `setup` 패키지 때문에 아직 실패하며 [#147](https://github.com/jonggeun2001/DepsSmuggler/issues/147)에서 추적합니다.
 
 APT는 수신한 `Packages`의 `aptControlFields`에서 의존성 조건과 대안, `Pre-Depends`, `Provides`, `Conflicts`, `Breaks`, `Replaces`, `Multi-Arch`, `Installed-Size` 등 Control 필드를 보존합니다. 여러 줄 값이 있으면 Debian continuation 문법으로 출력하므로 설명의 들여쓰기와 빈 문단 표기도 유지됩니다. 상위 저장소가 짧은 설명과 `Description-md5`만 제공하면 그 값을 유지하며, 별도 Translation 파일을 받거나 DEB의 긴 설명을 추출하지는 않습니다. `Packages.gz`에는 같은 `Packages` 내용을 압축합니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,6 +167,10 @@ DEPS_SMUGGLER_NATIVE_MAVEN=1 bash scripts/verify-worktree.sh \
 
 `src/cli/yum-metadata-failure.integration.test.ts`는 로컬 HTTP 서버의 repomd/primary XML을 실제 자식 CLI로 읽습니다. XML 제한 초과 시 저장소·원인과 종료 코드 `1`이 전달되고 빈 검색 성공으로 바뀌지 않아야 합니다. 이 세 파일은 외부 저장소 없이 기본 테스트에서 실행합니다.
 
+`src/core/downloaders/os-shared/repo-packager.test.ts`의 YUM 회귀는 생성된 `primary.xml.gz`를 풀어 self-provide와 `OSPackageInfo.provides`의 distinct capability 이름이 함께 기록되는지, XML 특수 문자가 escape되는지 확인합니다. 이 단위 검사는 native RPM 도구나 외부 저장소를 사용하지 않습니다. 별도 Rocky Linux/DNF 검증에서는 새 임시 저장소의 `primary.xml.gz`에 실제 RPM이 제공하는 capability 이름이 들어갔는지 먼저 비교하고, 그 다음 격리 installroot에서 로컬 저장소를 소비합니다. native DNF 결과는 해당 실행의 종료 코드와 로그로 판단하며, 이 문서의 단위 회귀만으로 전체 Rocky 시스템 설치 성공을 의미하지 않습니다.
+
+`src/core/downloaders/yum-provides-repository.integration.test.ts`는 loopback HTTP 서버의 압축 `primary.xml.gz`를 실제 YUM parser로 읽은 뒤, parser 결과를 `OSRepoPackager.createLocalRepo`에 전달해 생성 metadata의 capability와 XML escape를 확인합니다. RPM payload는 작은 fake 파일이며, local HTTP parser→packager 경계만 검증하므로 native RPM/DNF 설치 성공을 의미하지 않습니다.
+
 `src/core/downloaders/yum.integration.test.ts`는 현재 OS backend API로 실제 Rocky Linux 9 저장소의 `zlib` 검색(limit 3)과 의존성 없는 RPM ZIP 다운로드를 검증합니다. 오래된 다운로더 API와 조용한 조기 성공 처리를 제거했으며, 아래 명령으로 명시적으로 실행합니다. 외부 네트워크를 사용하고 임시 캐시·출력을 정리합니다. 네이티브 Yum/RPM 설치 트랜잭션을 수행하는 테스트는 아닙니다.
 
 ```bash

--- a/src/core/downloaders/os-shared/repo-packager.test.ts
+++ b/src/core/downloaders/os-shared/repo-packager.test.ts
@@ -257,6 +257,29 @@ describe('OSRepoPackager', () => {
     expect(content).toContain('rel="3.el9"');
   });
 
+  it('YUM primary.xml은 RPM provides capability를 self-provide와 함께 보존하고 XML을 escape한다', async () => {
+    const packager = new OSRepoPackager();
+    const pkg = {
+      ...createRpmPackage(),
+      provides: ['httpd', 'libtinfo.so.6()(64bit)', 'capability <x>&y', 'libtinfo.so.6()(64bit)', ''],
+    };
+    const downloadedFile = path.join(tempDir, 'httpd-provides.rpm');
+    fs.writeFileSync(downloadedFile, 'rpm');
+
+    const result = await packager.createLocalRepo(
+      [pkg],
+      new Map([[getDownloadedFileKey(pkg), downloadedFile]]),
+      { packageManager: 'yum', outputPath: path.join(tempDir, 'provides-repo'), repoName: 'test-repo' }
+    );
+    const primaryXml = gunzipSync(fs.readFileSync(result.metadataFiles.find((file) => file.endsWith('primary.xml.gz'))!)).toString('utf8');
+
+    expect(primaryXml.match(/<rpm:entry name="httpd"/g)).toHaveLength(1);
+    expect(primaryXml.match(/<rpm:entry name="libtinfo\.so\.6\(\)\(64bit\)"\/>/g)).toHaveLength(1);
+    expect(primaryXml).toContain('<rpm:entry name="capability &lt;x&gt;&amp;y"/>');
+    expect(primaryXml).not.toContain('name=""');
+    expect(primaryXml).not.toContain('name="undefined"');
+  });
+
   it('APK 메타데이터는 APKINDEX 단일 member를 갖는 gzip tar archive를 생성한다', async () => {
     const packager = new OSRepoPackager();
     const pkg = createApkPackage();

--- a/src/core/downloaders/os-shared/repo-packager.ts
+++ b/src/core/downloaders/os-shared/repo-packager.ts
@@ -256,6 +256,11 @@ export class OSRepoPackager {
       lines.push(`    <format>`);
       lines.push(`      <rpm:provides>`);
       lines.push(`        <rpm:entry name="${this.escapeXml(pkg.name)}" flags="EQ" epoch="0" ver="${this.escapeXml(pkg.version)}" rel="${release}"/>`);
+      for (const provide of [...new Set(pkg.provides ?? [])]) {
+        if (provide && provide !== pkg.name) {
+          lines.push(`        <rpm:entry name="${this.escapeXml(provide)}"/>`);
+        }
+      }
       lines.push(`      </rpm:provides>`);
 
       if (pkg.dependencies.length > 0) {

--- a/src/core/downloaders/yum-provides-repository.integration.test.ts
+++ b/src/core/downloaders/yum-provides-repository.integration.test.ts
@@ -1,0 +1,104 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createServer, type Server } from 'node:http';
+import { gzipSync, gunzipSync } from 'node:zlib';
+import { afterEach, describe, expect, it } from 'vitest';
+import { YumMetadataParser } from './yum';
+import { OSRepoPackager } from './os-shared/repo-packager';
+import { getDownloadedFileKey, getPackageFilename } from './os-shared/package-file-utils';
+import type { Repository } from './os-shared/types';
+
+const repository: Repository = {
+  id: 'fixture-9',
+  name: 'YUM capability fixture',
+  baseUrl: '',
+  enabled: true,
+  gpgCheck: false,
+  isOfficial: false,
+};
+
+describe('YUM parser to local repository capability boundary', () => {
+  let server: Server | undefined;
+  let tempRoot: string | undefined;
+
+  afterEach(async () => {
+    if (server?.listening) await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = undefined;
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  });
+
+  it('preserves parsed provides and requires through generated primary.xml.gz', async () => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'depssmuggler-yum-provides-'));
+    const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="2">
+  <package type="rpm">
+    <name>consumer</name><arch>x86_64</arch><version epoch="0" ver="1.0" rel="1"/>
+    <checksum type="sha256">${crypto.createHash('sha256').update('consumer').digest('hex')}</checksum>
+    <summary>consumer</summary><description>consumer</description><size package="8" installed="8" archive="8"/>
+    <location href="Packages/consumer-1.0-1.x86_64.rpm"/>
+    <format><rpm:requires><rpm:entry name="libtinfo.so.6()(64bit)"/></rpm:requires>
+      <rpm:provides><rpm:entry name="consumer"/><rpm:entry name="capability &lt;x&gt;&amp;y"/></rpm:provides></format>
+  </package>
+  <package type="rpm">
+    <name>ncurses-libs</name><arch>x86_64</arch><version epoch="0" ver="6.0" rel="2"/>
+    <checksum type="sha256">${crypto.createHash('sha256').update('ncurses').digest('hex')}</checksum>
+    <summary>ncurses</summary><description>ncurses</description><size package="7" installed="7" archive="7"/>
+    <location href="Packages/ncurses-libs-6.0-2.x86_64.rpm"/>
+    <format><rpm:provides>
+      <rpm:entry name="ncurses-libs"/><rpm:entry name="libtinfo.so.6()(64bit)"/>
+      <rpm:entry name="libtinfo.so.6()(64bit)"/><rpm:entry name="capability &lt;x&gt;&amp;y"/>
+    </rpm:provides></format>
+  </package>
+</metadata>`;
+    server = createServer((request, response) => {
+      if (request.url === '/repodata/primary.xml.gz') {
+        response.writeHead(200, { 'content-type': 'application/gzip' });
+        response.end(gzipSync(Buffer.from(primaryXml)));
+      } else {
+        response.writeHead(404);
+        response.end();
+      }
+    });
+    await new Promise<void>((resolve) => server?.listen(0, '127.0.0.1', () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('fixture server did not start');
+
+    const parser = new YumMetadataParser({ ...repository, baseUrl: `http://127.0.0.1:${address.port}` });
+    const packages = await parser.parsePrimary('repodata/primary.xml.gz');
+    expect(packages).toHaveLength(2);
+    const consumer = packages.find((pkg) => pkg.name === 'consumer');
+    const provider = packages.find((pkg) => pkg.name === 'ncurses-libs');
+    expect(consumer?.dependencies).toEqual([{ name: 'libtinfo.so.6()(64bit)', version: undefined, operator: undefined, isOptional: false }]);
+    expect(provider?.provides).toEqual([
+      'ncurses-libs',
+      'libtinfo.so.6()(64bit)',
+      'libtinfo.so.6()(64bit)',
+      'capability <x>&y',
+    ]);
+
+    const downloaded = new Map<string, string>();
+    for (const pkg of packages) {
+      const file = path.join(tempRoot, getPackageFilename(pkg, 'yum'));
+      fs.writeFileSync(file, `${pkg.name}-${pkg.version}-${pkg.release}`);
+      downloaded.set(getDownloadedFileKey(pkg), file);
+    }
+    const repoPath = path.join(tempRoot, 'local yum repo');
+    const result = await new OSRepoPackager().createLocalRepo(packages, downloaded, {
+      packageManager: 'yum',
+      outputPath: repoPath,
+      repoName: 'fixture',
+      includeSetupScript: false,
+    });
+    const primaryPath = result.metadataFiles.find((file) => file.endsWith('primary.xml.gz'));
+    expect(primaryPath).toBeDefined();
+    const generated = gunzipSync(fs.readFileSync(primaryPath!)).toString('utf8');
+    expect(generated).toContain('name="libtinfo.so.6()(64bit)"');
+    expect(generated).toContain('name="capability &lt;x&gt;&amp;y"');
+    expect((generated.match(/name="libtinfo\.so\.6\(\)\(64bit\)"/g) ?? []).length).toBe(2);
+    expect((generated.match(/name="capability &lt;x&gt;&amp;y"/g) ?? []).length).toBe(2);
+    expect(result.packageCount).toBe(2);
+  });
+});


### PR DESCRIPTION
YUM 저장소를 만들 때 RPM의 제공 기능 목록을 버리고 패키지 자기 이름만 기록해, 반출한 ncurses-libs가 있어도 DNF가 `libtinfo.so.6()(64bit)`를 찾지 못했습니다. 이제 파서가 보존한 `provides` 이름을 XML에 기록하고 중복·빈 항목을 제외합니다. 자기 이름의 기존 버전 정보는 유지하며, 추가 제공 이름에 임의 버전 속성을 만들지 않습니다.

검증:
- 표준 전체 테스트: 3017 PASS / 162 SKIP. 타입 검사 통과, ESLint 오류 0개.
- 압축된 primary XML 회귀는 수정 전 실패했습니다. 생성 metadata의 제공 이름·중복·빈 항목·XML escape를 확인하며, 별도 로컬 HTTP 검사로 실제 YUM 파서 → 저장소 생성 경계를 검증합니다. 이 테스트의 RPM payload는 fixture입니다.
- 실제 CLI로 Rocky 9 Bash를 다시 다운로드했습니다. exit 0, RPM 4개 및 저장소·TAR.GZ 생성.
- 두 개의 독립 Rocky amd64 컨테이너에서 `--network none`, 저장소 read-only 조건으로 DNF 조회 시 ncurses-libs 제공자를 찾았습니다. `dnf --assumeno install 'libtinfo.so.6()(64bit)'`도 두 번 모두 의존성 해결과 ncurses-libs/ncurses-base의 트랜잭션 계획을 만들었습니다. `--assumeno`에 따른 종료 코드 1은 설치를 의도적으로 중단한 결과입니다. 실제 설치 성공으로 해석하지 않습니다.
- 빈 installroot의 전체 Bash 설치는 두 번 모두 `setup` RPM 누락으로 실패했습니다. #136의 기존 libtinfo 누락 메시지는 사라졌으며, 별도 결함 #147로 등록했습니다. RPM 제공 이름 보존의 이번 검증과 전체 시스템 설치를 구분합니다.

README, OS 패키지 문서와 테스트 문서에 동작 및 제한을 반영했습니다. 버전이 붙은 capability의 flags/epoch/ver/rel 보존·비교는 기존 모델의 별도 제한이며 이 PR은 resolver 선택을 바꾸지 않습니다. 제품 빌드·설치·배포는 수행하지 않았습니다.

Closes #136
