### PR TITLE
fix: GUI Conda 파일을 오프라인 Conda 설치기로 전달

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ depssmuggler os cache clear
 | 항목 | 현재 동작 |
 |------|-----------|
 | 압축·설치 스크립트 | 일반 GUI와 CLI에서 ZIP/tar.gz 지원. 일반 GUI는 설치 스크립트 포함 여부를 선택하고, CLI는 생성한 `install.sh`·`install.ps1`을 출력 폴더와 아카이브 최상위에 포함합니다. OS 출력에는 전용 스크립트 생성기가 있습니다. |
-| 설치 스크립트 범위 | CLI와 GUI의 npm 스크립트는 실제로 다운로드된 `.tgz`와 직접 요청한 확정 버전을 공통 설치 계획에 전달해 오프라인으로 `npm-project/node_modules`에 설치하며, 전이 의존성의 여러 버전을 함께 보존합니다. pip와 npm이 함께 있는 묶음은 두 설치가 모두 성공할 때만 전체 성공으로 처리합니다. CLI의 Conda 스크립트는 전달된 Conda 아카이브를 오프라인으로 설치합니다. GUI의 Conda 항목은 현재 `pip install` 명령을 생성하므로 Conda 오프라인 설치를 보장하지 않으며, 이 동작은 별도 #137 범위입니다. 생성기별 범위는 [Packagers](docs/packagers.md)를 참고하세요. |
+| 설치 스크립트 범위 | CLI와 GUI의 npm 스크립트는 실제로 다운로드된 `.tgz`와 직접 요청한 확정 버전을 공통 설치 계획에 전달해 오프라인으로 `npm-project/node_modules`에 설치하며, 전이 의존성의 여러 버전을 함께 보존합니다. CLI와 GUI의 Conda 스크립트는 실제로 완료된 Conda 아카이브 경로를 전달받아 오프라인 `conda create/install`을 실행합니다. pip와 npm 또는 Conda가 함께 있는 묶음은 각 설치가 모두 성공할 때만 전체 성공으로 처리합니다. 기본 Conda 환경 경로는 `SCRIPT_DIR/conda-env`이며 `DEPS_SMUGGLER_CONDA_PREFIX`로 바꿀 수 있습니다. Python noarch 패키지는 호환되는 Python 환경이 필요합니다. 생성기별 범위는 [Packagers](docs/packagers.md)를 참고하세요. |
 | 파일 분할 | 일반 GUI의 이메일 전달 중 첨부 한도를 초과하고 분할 설정이 켜진 경우 적용합니다. 로컬 저장 경로에서 자동 분할하지 않습니다. |
 | SMTP 테스트 | Electron IPC로 실제 연결을 테스트합니다. 브라우저 개발 환경에서는 시뮬레이션이며, Electron API가 일부 누락되면 안내 후 비활성화됩니다. |
 | 업데이트 | 배포 앱에서 시작 후 확인하고 사용자가 다운로드·설치할 수 있습니다. 개발 환경은 모의 동작입니다. `autoUpdate`·`autoDownloadUpdate` 설정은 저장되지만 updater 동작을 제어하는 연결은 아직 없습니다. |

--- a/docs/packagers.md
+++ b/docs/packagers.md
@@ -129,7 +129,7 @@ const archive = archiver('zip', { zlib: { level: 9 } });
 | `generatePowerShellScript` | packages, outputPath, options? | Promise<string> | PowerShell 스크립트 생성 |
 | `generateAllScripts` | packages, outputDir, options? | Promise<GeneratedScript[]> | 모든 형식 스크립트 생성 |
 
-Electron GUI의 shared `generateInstallScripts`도 비동기 생성기이며, npm 패키지가 포함된 경우 공통 `ScriptGenerator`의 npm plan/runtime section을 재사용합니다. delivery pipeline은 실제 다운로드가 끝난 뒤 생성기를 기다린 다음 아카이브를 만듭니다. npm을 포함하지 않는 GUI 묶음은 기존 non-npm 설치기 분기를 계속 사용합니다.
+Electron GUI의 shared `generateInstallScripts`도 비동기 생성기이며, npm 또는 Conda 패키지가 포함된 경우 공통 `ScriptGenerator`의 해당 설치 section을 재사용합니다. delivery pipeline은 실제 다운로드가 끝난 뒤 생성기를 기다린 다음 아카이브를 만듭니다. 성공 결과의 실제 파일 경로를 Conda·npm mapping으로 전달하므로 metadata filename이나 다른 패키지의 파일을 추측하지 않습니다. 두 패키지 타입이 없는 GUI 묶음은 기존 non-npm 설치기 분기를 계속 사용합니다.
 
 ### 내부 메서드
 
@@ -207,11 +207,11 @@ CLI와 GUI는 `npmRootPackages`에 직접 요청 목록과 해결된 확정 버�
 
 상위 폴더의 사용자 `package.json`은 변경하지 않습니다. `npm-project`는 비어 있거나 이 스크립트가 생성한 프로젝트여야 하며, 소유 표시가 없는 기존 프로젝트나 심볼릭 링크 대상은 오류로 처리합니다. 설치용 manifest는 유지하지만 프로젝트 루트의 lockfile은 생성하지 않으며 npm 자체 업데이트 확인도 끕니다. Node.js와 npm이 필요하며, 도구 부재·빈 파일 목록·의존성 누락·손상된 tarball·설치 명령 실패는 오류 종료로 이어집니다. npm의 일반 설치 lifecycle은 유지합니다. 이 스크립트는 의존성을 전달된 파일에 연결하며, OS·아키텍처 간 네이티브 패키지 변환이나 설치 lifecycle의 외부 다운로드 대체는 수행하지 않습니다.
 
-Conda는 pip와 별도의 설치 블록을 생성합니다. CLI는 완료된 Conda 다운로드 항목의 실제 파일 경로를 `condaPackageFiles`로 전달하므로 `--no-deps` 입력의 메타데이터에 파일명이 없어도 다운로드한 파일을 참조합니다. 이 옵션을 생략한 API 호출은 각 Conda 항목의 정확한 `metadata.filename`을 사용합니다. 파일명 누락·빈 명시 목록·잘못된 상대 경로·지원하지 않는 확장자는 생성 오류이며, 다른 패키지의 `.tar.bz2`를 함께 설치하지 않도록 폴더 전체를 확장자로 탐색하지 않습니다. 실행 시에는 선언된 파일의 존재를 확인합니다.
+Conda는 pip와 별도의 설치 블록을 생성합니다. CLI와 GUI는 완료된 Conda 다운로드 항목의 실제 파일 경로를 `condaPackageFiles`로 전달하므로 `--no-deps` 입력의 메타데이터에 파일명이 없어도 다운로드한 파일을 참조합니다. 이 옵션을 생략한 API 호출은 각 Conda 항목의 정확한 `metadata.filename`을 사용합니다. 파일명 누락·빈 명시 목록·잘못된 상대 경로·지원하지 않는 확장자는 생성 오류이며, 다른 패키지의 `.tar.bz2`를 함께 설치하지 않도록 폴더 전체를 확장자로 탐색하지 않습니다. 실행 시에는 선언된 파일의 존재를 확인합니다.
 
 Conda 블록은 [명시적 로컬 아카이브 설치](https://docs.conda.io/projects/conda/en/stable/commands/install.html)를 사용합니다. 기본 대상 `SCRIPT_DIR/conda-env`가 없으면 `conda create --offline --yes --no-default-packages --prefix ...`를, 기존 Conda 환경이면 `conda install --offline --yes --prefix ...`를 실행합니다. `DEPS_SMUGGLER_CONDA_PREFIX`로 대상을 지정할 수 있고 상대 경로는 스크립트 폴더 기준입니다. 일반 파일·디렉터리를 기존 환경으로 덮어쓰지 않으며, 필수 파일이나 Conda가 없거나 명령이 실패하면 Bash·PowerShell 모두 non-zero로 종료합니다. `includeErrorHandling: false`여도 Conda 실패를 성공으로 처리하지 않습니다.
 
-명시적 파일 설치는 전달된 파일 집합을 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. Python noarch 패키지는 대상 환경에 호환되는 Python이 필요하므로, `--no-deps` 묶음은 기존 환경을 지정하거나 런타임을 별도로 준비해야 합니다. GUI와 CLI는 npm 설치 계획과 runtime을 공유하지만, GUI의 현재 Conda `pip install` 동작 변경은 이 문서 범위가 아니며 #137에서 별도로 다룹니다.
+명시적 파일 설치는 전달된 파일 집합을 설치하며 의존성·버전·아키텍처 호환성을 다시 해결하지 않습니다. Python noarch 패키지는 대상 환경에 호환되는 Python이 필요하므로, `--no-deps` 묶음은 기존 환경을 지정하거나 런타임을 별도로 준비해야 합니다. 기본 환경 경로는 `SCRIPT_DIR/conda-env`이고 `DEPS_SMUGGLER_CONDA_PREFIX`에 절대 경로나 스크립트 기준 상대 경로를 지정할 수 있습니다. GUI와 CLI는 npm·Conda 설치 section을 공유하며, Conda가 포함된 묶음은 Conda 명령이 성공해야 전체 성공으로 처리합니다.
 
 일반 `ScriptGenerator`에는 APT·APK 전용 설치 블록이 없습니다. OS 다운로드 전용 스크립트는 별도의 `OSScriptGenerator`가 제공합니다. `includeVerification`/`mirrorPath` 옵션은 이 클래스에 없습니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -288,17 +288,17 @@ DEPS_SMUGGLER_NATIVE_DOCKER=1 bash scripts/verify-worktree.sh \
 
 ### Conda 설치 스크립트 오프라인 검증
 
-`src/core/packager/conda-install-script.integration.test.ts`는 생성한 Bash와 Windows PowerShell 스크립트를 실제 프로세스로 실행합니다. 기본 회귀는 기록용 실행 파일로 pip·Conda 인자 분리, `.conda`·`.tar.bz2`의 정확한 경로, 공백·인용 문자, 루트만 포함한 목록, 환경 경로 지정, 재실행과 오류 종료를 검사합니다. 기록용 실행 파일의 성공을 실제 Conda 설치 성공으로 간주하지 않습니다. CLI 단위 테스트는 다운로드 항목에 메타데이터 파일명이 없어도 실제 완료 경로를 전달하며 다른 타입의 파일을 Conda 목록에 섞지 않는지 확인합니다.
+`src/core/packager/conda-install-script.integration.test.ts`는 생성한 Bash와 Windows PowerShell 스크립트를 실제 프로세스로 실행합니다. 기본 회귀는 기록용 실행 파일로 pip·Conda 인자 분리, `.conda`·`.tar.bz2`의 정확한 경로, 공백·인용 문자, 루트만 포함한 목록, 환경 경로 지정, 재실행과 오류 종료를 검사합니다. 기록용 실행 파일의 성공을 실제 Conda 설치 성공으로 간주하지 않습니다. CLI와 Electron delivery pipeline 단위 테스트는 다운로드 항목의 실제 완료 경로를 `condaPackageFiles`로 전달하며, metadata filename fallback과 다른 타입의 파일이 Conda 목록에 섞이지 않는지 확인합니다.
 
-`src/core/packager/conda-native-consumer.integration.test.ts`는 Ubuntu CI의 기존 Miniconda를 사용하는 native 검증을 별도로 실행합니다.
+`src/core/packager/conda-native-consumer.integration.test.ts`는 Ubuntu CI에서 이미 제공되는 Conda를 사용하는 native 검증을 별도로 실행합니다. 두 CLI 사례는 canonical Conda 생성기의 `.conda` fixture를 새 prefix에 설치하고 Python noarch `.tar.bz2` fixture를 호환 Python runtime이 준비된 prefix에 설치합니다. 두 GUI 사례는 delivery pipeline이 만든 ZIP에서 generic `.conda`를 새 prefix에 설치하고, 공개 `six 1.16.0` `.tar.bz2`를 준비된 Python prefix에 설치·import한 뒤 반복 실행과 sentinel 보존을 검사합니다. 모든 사례는 임시 prefix·캐시와 channel HTTP trap을 사용해 bundle 밖의 파일과 네트워크 의존을 드러냅니다.
 
 ```bash
 DEPS_SMUGGLER_NATIVE_CONDA=1 bash scripts/verify-worktree.sh src/core/packager/conda-native-consumer.integration.test.ts
 ```
 
-기본 실행에서는 native 검증을 건너뛰며, 명시적으로 opt-in한 환경에서 Linux나 필수 도구 조건이 맞지 않으면 실패합니다. 임시 prefix·캐시·설정과 `CONDA_REGISTER_ENVS=false`로 사용자 환경 등록 파일까지 격리합니다. 실제 Conda로 두 아카이브 형식을 설치하고 패키지 목록과 설치 파일을 검사하며, 설정한 로컬 채널의 HTTP 요청이 없는지 확인합니다. Python noarch 설치는 호환되는 Python이 있는 임시 환경에서 별도로 검사합니다. 일반 noarch 파일의 설치만으로 Python import 성공을 주장하지 않습니다. 도구 설치나 호스트 base 환경 변경은 수행하지 않습니다.
+기본 실행에서는 native 검증을 건너뛰며, 명시적으로 opt-in한 환경에서 필수 Linux·Conda 조건이 맞지 않으면 실패합니다. 임시 prefix·캐시·설정과 `CONDA_REGISTER_ENVS=false`로 환경 등록을 격리하고, `--offline` 설치에서 channel HTTP 요청이 없는지 확인합니다. native 성공 여부는 CI 실행 결과로 판단합니다.
 
-Python 검증 환경은 runner의 base 환경에 설치된 Python과 전이 의존성 기록에 해당하는 캐시 아카이브만 임시 경로로 복사해 준비합니다. 필요한 아카이브가 없으면 구체적인 준비 오류로 실패합니다. 생성 스크립트에는 `CONDA_OFFLINE=false`를 전달해 스크립트 자체의 `--offline` 옵션을 검증하며, 환경 준비·설치·import 단계별 실행 시간을 CI 로그에 남깁니다.
+Python noarch 사례는 호환 runtime archive를 별도 임시 prefix에 준비하며, 필요한 archive가 없으면 구체적인 준비 오류로 실패합니다. 생성 스크립트에는 `CONDA_OFFLINE=false`를 전달해 스크립트 자체의 `--offline` 옵션을 검증하며, 환경 준비·설치·import 단계별 실행 시간을 CI 로그에 남깁니다.
 
 ### npm 설치 스크립트 오프라인 검증
 
@@ -310,7 +310,7 @@ Python 검증 환경은 runner의 base 환경에 설치된 Python과 전이 의�
 
 위 npm 소비자 테스트는 bundle 루트에 사용자 `package.json`이 있는 경우와 없는 경우를 모두 실행합니다. 사용자 manifest가 있으면 바이트를 보존하고 해당 프로젝트를 추가 패키지로 설치하지 않아야 하며, 없으면 새로 만들지 않아야 합니다. 이는 Windows npm 10에서 `--prefix` 때문에 현재 bundle 폴더가 추가 설치 대상이 되어 발생했던 오류를 검출합니다.
 
-`src/core/packager/gui-mixed-native-consumer.integration.test.ts`는 실제 `createDeliveryPipeline`, shared script generator, archive packager를 실행해 local fixture 기반 pip·npm 묶음을 ZIP으로 만든다. router 자체는 `electron/services/download-package-router.test.ts`에서 실제 destination을 성공 결과에 넣는지 별도로 검증한다. consumer는 생성된 ZIP만 새 디렉터리에 풀고 독립 Python venv·npm cache·loopback registry 차단 환경에서 `install.sh`를 실행한다. 직접 npm root와 전이 모듈의 `require`가 모두 성공하고 pip와 npm 설치가 모두 성공한 경우에만 완료 메시지와 종료 코드 `0`을 허용한다. npm 실패나 파일 경로 누락은 전체 성공으로 바꾸지 않는다. Windows PowerShell 실행은 해당 CI 환경에서 확인하며, 이 local fixture 테스트는 실제 공개 패키지 배포물이나 Conda native 설치를 주장하지 않는다.
+`src/core/packager/gui-mixed-native-consumer.integration.test.ts`는 실제 `createDeliveryPipeline`, shared script generator, archive packager를 실행해 local fixture 기반 pip·npm 묶음을 ZIP으로 만든다. router 자체는 `electron/services/download-package-router.test.ts`에서 실제 destination을 성공 결과에 넣는지 별도로 검증한다. consumer는 생성된 ZIP만 새 디렉터리에 풀고 독립 Python venv·npm cache·loopback registry 차단 환경에서 `install.sh`를 실행한다. 직접 npm root와 전이 모듈의 `require`가 모두 성공하고 pip와 npm 설치가 모두 성공한 경우에만 완료 메시지와 종료 코드 `0`을 허용한다. npm 실패나 파일 경로 누락은 전체 성공으로 바꾸지 않는다. Windows PowerShell 실행은 해당 CI 환경에서 확인하며, 이 local fixture 테스트는 실제 공개 패키지 배포물을 사용한 검증과 구분한다.
 
 별도 수동 검증에서는 이전 GUI 산출물의 공개 패키지를 수정된 delivery pipeline으로 다시 묶었다. 원본 출력 디렉터리를 지우고 ZIP만 새 환경에 전달한 두 번의 실행에서 `colorama 0.4.6`, `is-odd 3.0.1`, `is-number 6.0.0` 로딩과 npm 레지스트리 요청 0건을 확인했다. 이는 위 로컬 fixture 검사와 별도이며, 수정된 pipeline 산출물 검증이지 새로 빌드한 GUI 앱 자체의 실행 검증이나 Conda 설치 검증은 아니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -300,6 +300,8 @@ DEPS_SMUGGLER_NATIVE_CONDA=1 bash scripts/verify-worktree.sh src/core/packager/c
 
 Python noarch 사례는 호환 runtime archive를 별도 임시 prefix에 준비하며, 필요한 archive가 없으면 구체적인 준비 오류로 실패합니다. 생성 스크립트에는 `CONDA_OFFLINE=false`를 전달해 스크립트 자체의 `--offline` 옵션을 검증하며, 환경 준비·설치·import 단계별 실행 시간을 CI 로그에 남깁니다.
 
+임시 경로와 GUI ZIP 추출 경로에는 공백을 포함하지만 prefix의 마지막 디렉터리 이름에는 공백을 넣지 않습니다. CI의 Conda 26.7.1은 해당 이름을 환경 이름으로 검증해 공백이 있으면 설치 전에 거부합니다.
+
 ### npm 설치 스크립트 오프라인 검증
 
 `src/cli/npm-root-resolution.integration.test.ts`는 로컬 레지스트리와 실제 tarball로 의존성 포함 CLI를 실행합니다. 버전을 생략한 직접 패키지와 전이 의존성이 모두 실제 버전으로 아카이브·manifest에 포함돼야 합니다. ZIP과 TAR.GZ를 각각 새 디렉터리에 풀고, 아카이브에 포함된 설치 스크립트만 격리된 npm 캐시·설정으로 실행해 직접 모듈과 그 의존성을 실제로 불러옵니다. 압축 외부의 스크립트는 복사하지 않으며 설치 중 레지스트리 접근이 없는지도 검사합니다. 단위 테스트도 npm `flatList`가 루트를 제외하는 실제 반환 형식을 사용하며, 버전 선택자와 요청 ID·아키텍처·메타데이터 보존을 검사합니다.

--- a/electron/services/download-orchestrator.test.ts
+++ b/electron/services/download-orchestrator.test.ts
@@ -288,7 +288,7 @@ describe('createDownloadOrchestrator', () => {
         id: 'pip-requests-2.28.0',
         name: 'requests',
       }),
-    ], { npmPackageFiles: [], npmRootPackages: undefined });
+    ], { npmPackageFiles: [], npmRootPackages: undefined, condaPackageFiles: [] });
     expect(archivePackager.createArchiveFromDirectory).toHaveBeenCalledWith(
       '/tmp/out',
       '/tmp/out.tar.gz',

--- a/electron/services/download/delivery-pipeline.test.ts
+++ b/electron/services/download/delivery-pipeline.test.ts
@@ -93,7 +93,61 @@ describe('createDeliveryPipeline', () => {
     expect(generateInstallScripts).toHaveBeenCalledWith('/tmp/out', [...base.deliveredPackages, npm], {
       npmRootPackages: roots,
       npmPackageFiles: [{ filePath: '/tmp/out/packages/npm/custom-name.tgz', relativePath: 'npm/custom-name.tgz' }],
+      condaPackageFiles: [],
     });
+  });
+
+  it('Conda 결과의 실제 파일 경로를 packages 기준 상대 경로로 스크립트 생성기에 전달한다', async () => {
+    const generateInstallScripts = vi.fn().mockResolvedValue(undefined);
+    const pipeline = createDeliveryPipeline({
+      archivePackager: { createArchiveFromDirectory: vi.fn().mockResolvedValue('/tmp/out.zip') } as never,
+      generateInstallScripts,
+      initializeEmailSender: vi.fn() as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn() as never,
+    });
+    const base = createBaseParams();
+    const conda = { id: 'conda-six', type: 'conda', name: 'six', version: '1.16.0' };
+    await pipeline.finalizeDownload({
+      ...base,
+      deliveredPackages: [...base.deliveredPackages, conda],
+      results: [...base.results, { id: conda.id, success: true, filePath: '/tmp/out/packages/conda/six-1.16.0-0.tar.bz2' }],
+      options: { ...base.options, includeScripts: true },
+      progressEmitter: { emitDownloadStatus: vi.fn() } as never,
+      isCancelled: () => false,
+    });
+
+    expect(generateInstallScripts).toHaveBeenCalledWith('/tmp/out', [...base.deliveredPackages, conda], {
+      npmPackageFiles: [],
+      npmRootPackages: undefined,
+      condaPackageFiles: [{ relativePath: 'conda/six-1.16.0-0.tar.bz2' }],
+    });
+  });
+
+  it('Conda 성공 결과에 실제 파일 경로가 없으면 스크립트와 아카이브를 만들지 않는다', async () => {
+    const generateInstallScripts = vi.fn().mockResolvedValue(undefined);
+    const createArchiveFromDirectory = vi.fn().mockResolvedValue('/tmp/out.zip');
+    const pipeline = createDeliveryPipeline({
+      archivePackager: { createArchiveFromDirectory } as never,
+      generateInstallScripts,
+      initializeEmailSender: vi.fn() as never,
+      getFileSplitter: vi.fn() as never,
+      stat: vi.fn() as never,
+    });
+    const base = createBaseParams();
+    const conda = { id: 'conda-six', type: 'conda', name: 'six', version: '1.16.0' };
+    const result = await pipeline.finalizeDownload({
+      ...base,
+      deliveredPackages: [...base.deliveredPackages, conda],
+      results: [...base.results, { id: conda.id, success: true }],
+      options: { ...base.options, includeScripts: true },
+      progressEmitter: { emitDownloadStatus: vi.fn() } as never,
+      isCancelled: () => false,
+    });
+
+    expect(result).toMatchObject({ success: false, error: 'Conda 패키지 파일 경로가 없습니다: six@1.16.0' });
+    expect(generateInstallScripts).not.toHaveBeenCalled();
+    expect(createArchiveFromDirectory).not.toHaveBeenCalled();
   });
 
   it('지원하지 않는 출력 형식이면 실패 payload를 반환해야 함', async () => {

--- a/electron/services/download/delivery-pipeline.ts
+++ b/electron/services/download/delivery-pipeline.ts
@@ -68,9 +68,19 @@ export function createDeliveryPipeline(deps: DeliveryPipelineDeps): DeliveryPipe
               relativePath: path.relative(path.join(outputDir, 'packages'), filePath).split(path.sep).join('/'),
             };
           });
+          const condaPackageFiles = deliveredPackages.filter(pkg => pkg.type === 'conda').map(pkg => {
+            const filePath = results.find(result => result.id === pkg.id && result.success)?.filePath;
+            if (!filePath) {
+              throw new Error(`Conda 패키지 파일 경로가 없습니다: ${pkg.name}@${pkg.version}`);
+            }
+            return {
+              relativePath: path.relative(path.join(outputDir, 'packages'), filePath).split(path.sep).join('/'),
+            };
+          });
           await deps.generateInstallScripts(outputDir, deliveredPackages, {
             npmPackageFiles,
             npmRootPackages: options.npmRootPackages,
+            condaPackageFiles,
           });
         } catch (error) {
           return {

--- a/src/core/packager/conda-install-script.ts
+++ b/src/core/packager/conda-install-script.ts
@@ -1,0 +1,152 @@
+import type { PackageInfo } from '../../types';
+
+export interface CondaPackageFile {
+  relativePath: string;
+}
+
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function powerShellQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+
+export function getCondaArchivePaths(
+  packages: PackageInfo[],
+  packageFiles?: CondaPackageFile[],
+): string[] {
+  const relativePaths = packageFiles !== undefined
+    ? packageFiles.map(file => file.relativePath)
+    : packages.map(pkg => {
+      const filename = pkg.metadata?.filename;
+      if (typeof filename !== 'string' || filename.length === 0) {
+        throw new Error(`Conda 패키지 ${pkg.name}@${pkg.version}의 아카이브 파일명이 없습니다 (metadata.filename)`);
+      }
+      return filename;
+    });
+
+  if (relativePaths.length === 0) {
+    throw new Error('Conda 패키지 파일 매핑이 비어 있습니다.');
+  }
+
+  const normalized = new Set<string>();
+  for (const relativePath of relativePaths) {
+    if (typeof relativePath !== 'string') {
+      throw new Error('Conda 패키지 파일 경로가 유효하지 않습니다.');
+    }
+    const portablePath = relativePath.replace(/\\/g, '/');
+    const segments = portablePath.split('/');
+    if (
+      portablePath.length === 0 ||
+      portablePath.startsWith('/') ||
+      /^[A-Za-z]:\//.test(portablePath) ||
+      segments.some(segment => segment.length === 0 || segment === '.' || segment === '..') ||
+      !/\.(?:conda|tar\.bz2)$/i.test(portablePath)
+    ) {
+      throw new Error(`Conda 패키지 파일 경로가 유효하지 않습니다: ${relativePath}`);
+    }
+    normalized.add(portablePath);
+  }
+
+  return [...normalized];
+}
+
+export function buildCondaBashInstallLines(condaArchivePaths: string[]): string[] {
+  const lines: string[] = [];
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('# Conda 패키지 오프라인 설치');
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('');
+  lines.push('install_conda_packages() {');
+  lines.push('    log_info "Conda 패키지 설치 중..."');
+  lines.push('    if ! command -v conda &> /dev/null; then');
+  lines.push('        log_error "Conda가 설치되어 있지 않습니다."');
+  lines.push('        return 1');
+  lines.push('    fi');
+  lines.push('');
+  lines.push('    local conda_relative_path conda_archive_path');
+  lines.push('    local conda_archive_paths=()');
+  for (const relativePath of condaArchivePaths) {
+    lines.push(`    conda_relative_path=${shellQuote(relativePath)}`);
+    lines.push('    conda_archive_path="$SCRIPT_DIR/$PACKAGE_DIR/$conda_relative_path"');
+    lines.push('    if [[ ! -f "$conda_archive_path" ]]; then');
+    lines.push('        log_error "Conda 아카이브를 찾을 수 없습니다: $conda_archive_path"');
+    lines.push('        return 1');
+    lines.push('    fi');
+    lines.push('    conda_archive_paths+=("$conda_archive_path")');
+  }
+  lines.push('');
+  lines.push('    local conda_prefix="${DEPS_SMUGGLER_CONDA_PREFIX:-$SCRIPT_DIR/conda-env}"');
+  lines.push('    if [[ "$conda_prefix" != /* ]]; then conda_prefix="$SCRIPT_DIR/$conda_prefix"; fi');
+  lines.push('    if [[ -e "$conda_prefix" && ! -d "$conda_prefix" ]]; then');
+  lines.push('        log_error "Conda 환경 경로가 디렉터리가 아닙니다: $conda_prefix"');
+  lines.push('        return 1');
+  lines.push('    fi');
+  lines.push('    if [[ -f "$conda_prefix/conda-meta/history" ]]; then');
+  lines.push('        conda install --offline --yes --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
+  lines.push('            log_error "Conda 패키지 설치에 실패했습니다."');
+  lines.push('            return 1');
+  lines.push('        }');
+  lines.push('    elif [[ -e "$conda_prefix" ]]; then');
+  lines.push('        log_error "기존 경로가 Conda 환경이 아닙니다: $conda_prefix"');
+  lines.push('        return 1');
+  lines.push('    else');
+  lines.push('        conda create --offline --yes --no-default-packages --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
+  lines.push('            log_error "Conda 환경 생성에 실패했습니다."');
+  lines.push('            return 1');
+  lines.push('        }');
+  lines.push('    fi');
+  lines.push('    log_info "Conda 패키지 설치 완료: $conda_prefix"');
+  lines.push('}');
+  lines.push('');
+  return lines;
+}
+
+export function buildCondaPowerShellInstallLines(condaArchivePaths: string[]): string[] {
+  const lines: string[] = [];
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('# Conda 패키지 오프라인 설치');
+  lines.push('#-------------------------------------------------------------------------------');
+  lines.push('');
+  lines.push('function Install-CondaPackages {');
+  lines.push('    Write-Info "Conda 패키지 설치 중..."');
+  lines.push('    if (-not (Get-Command conda -ErrorAction SilentlyContinue)) {');
+  lines.push('        throw "Conda가 설치되어 있지 않습니다."');
+  lines.push('    }');
+  lines.push('');
+  lines.push('    $CondaArchivePaths = @()');
+  for (const relativePath of condaArchivePaths) {
+    lines.push(`    $CondaArchivePath = Join-Path -Path $PackageDir -ChildPath ${powerShellQuote(relativePath)}`);
+    lines.push('    if (-not (Test-Path -LiteralPath $CondaArchivePath -PathType Leaf)) {');
+    lines.push('        throw "Conda 아카이브를 찾을 수 없습니다: $CondaArchivePath"');
+    lines.push('    }');
+    lines.push('    $CondaArchivePaths += $CondaArchivePath');
+  }
+  lines.push('');
+  lines.push('    $CondaPrefix = $env:DEPS_SMUGGLER_CONDA_PREFIX');
+  lines.push('    if ([string]::IsNullOrWhiteSpace($CondaPrefix)) {');
+  lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath \'conda-env\'');
+  lines.push('    } elseif (-not [System.IO.Path]::IsPathRooted($CondaPrefix)) {');
+  lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath $CondaPrefix');
+  lines.push('    }');
+  lines.push('    if (Test-Path -LiteralPath $CondaPrefix -PathType Leaf) {');
+  lines.push('        throw "Conda 환경 경로가 디렉터리가 아닙니다: $CondaPrefix"');
+  lines.push('    }');
+  lines.push('    $CondaHistory = Join-Path -Path $CondaPrefix -ChildPath \'conda-meta/history\'');
+  lines.push('    if (Test-Path -LiteralPath $CondaHistory -PathType Leaf) {');
+  lines.push('        & conda install --offline --yes --prefix $CondaPrefix @CondaArchivePaths');
+  lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
+  lines.push('    } elseif (Test-Path -LiteralPath $CondaPrefix) {');
+  lines.push('        throw "기존 경로가 Conda 환경이 아닙니다: $CondaPrefix"');
+  lines.push('    } else {');
+  lines.push('        & conda create --offline --yes --no-default-packages --prefix $CondaPrefix @CondaArchivePaths');
+  lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 환경 생성에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
+  lines.push('    }');
+  lines.push('    Write-Info "Conda 패키지 설치 완료: $CondaPrefix"');
+  lines.push('}');
+  lines.push('');
+  return lines;
+}

--- a/src/core/packager/conda-native-consumer.integration.test.ts
+++ b/src/core/packager/conda-native-consumer.integration.test.ts
@@ -5,7 +5,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
+import { getArchivePackager } from './archive-packager';
+import { getFileSplitter } from './file-splitter';
 import { getScriptGenerator, type ScriptOptions } from './script-generator';
+import { createDeliveryPipeline } from '../../../electron/services/download/delivery-pipeline';
+import { initializeEmailSender } from '../mailer/email-sender';
+import { generateInstallScripts } from '../shared';
 import type { PackageInfo } from '../../types';
 
 const execFile = promisify(execFileCallback);
@@ -520,6 +525,178 @@ nativeSuite('native Conda offline installer consumer', () => {
     );
     expect(second.code, `${second.stdout}\n${second.stderr}`).toBe(0);
     expect(second.signal).toBeNull();
+    expect(await fs.promises.readFile(sentinel, 'utf8')).toBe('preserve');
+    expect(requests).toBe(0);
+  }, 300_000);
+
+  it('consumes a GUI pipeline ZIP with Conda archives from an isolated fresh prefix', async () => {
+    const setup = await prepareNative();
+    const source = await createPackageSource(
+      setup.tempRoot,
+      'depssmuggler-gui-native-data',
+      '1.0.0'
+    );
+    const fixtureDir = path.join(setup.tempRoot, 'fixtures');
+    await fs.promises.mkdir(fixtureDir, { recursive: true });
+    const archive = await createFixture(
+      setup.python,
+      source,
+      fixtureDir,
+      'depssmuggler-gui-native-data-1.0.0-0.conda'
+    );
+    const outputDir = path.join(setup.tempRoot, 'gui delivery output');
+    const packageDir = path.join(outputDir, 'packages');
+    await fs.promises.mkdir(packageDir, { recursive: true });
+    const deliveredPath = path.join(packageDir, path.basename(archive));
+    await fs.promises.copyFile(archive, deliveredPath);
+    const delivered = [{
+      id: 'conda-gui-native-data',
+      type: 'conda',
+      name: 'depssmuggler-gui-native-data',
+      version: '1.0.0',
+      filename: path.basename(archive),
+      metadata: { filename: path.basename(archive) },
+    }];
+    const pipeline = createDeliveryPipeline({
+      archivePackager: getArchivePackager(),
+      generateInstallScripts,
+      initializeEmailSender,
+      getFileSplitter,
+      stat: fs.promises.stat,
+    });
+    const completion = await pipeline.finalizeDownload({
+      outputDir,
+      options: { outputDir, outputFormat: 'zip', includeScripts: true, deliveryMethod: 'local' },
+      deliveredPackages: delivered,
+      packageInfos: delivered as PackageInfo[],
+      results: [{ id: delivered[0].id, success: true, filePath: deliveredPath }],
+      failedDownloadCount: 0,
+      progressEmitter: { emitDownloadStatus: () => undefined } as never,
+      isCancelled: () => false,
+    });
+    expect(completion.success, JSON.stringify(completion)).toBe(true);
+    const archivePath = String(completion.outputPath);
+    const bundle = path.join(setup.tempRoot, 'gui archive extracted');
+    await fs.promises.mkdir(bundle, { recursive: true });
+    await execFile(
+      setup.python,
+      ['-c', 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', archivePath, bundle],
+      { env: setup.env, timeout: 30_000 }
+    );
+    expect(fs.existsSync(path.join(bundle, 'install.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(bundle, 'install.ps1'))).toBe(true);
+    await fs.promises.rm(outputDir, { recursive: true, force: true });
+    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: path.join(setup.tempRoot, 'gui conda prefix') };
+    const install = await runBash(path.join(bundle, 'install.sh'), env);
+    expect(install.code, `${install.stdout}\n${install.stderr}`).toBe(0);
+    expect(install.signal).toBeNull();
+    const listed = JSON.parse(
+      (await execFile(setup.executable, ['list', '--json', '--prefix', env.DEPS_SMUGGLER_CONDA_PREFIX], { env, timeout: 30_000 })).stdout
+    ) as Array<{ name: string; version: string }>;
+    expect(listed).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'depssmuggler-gui-native-data', version: '1.0.0' }),
+    ]));
+    expect(
+      await fs.promises.readFile(
+        path.join(env.DEPS_SMUGGLER_CONDA_PREFIX, 'share', 'depssmuggler-gui-native-data.txt'),
+        'utf8'
+      )
+    ).toBe('depssmuggler-gui-native-data-1.0.0\n');
+    expect(requests).toBe(0);
+  }, 300_000);
+
+  it('installs a published six archive delivered through the GUI pipeline', async () => {
+    const setup = await prepareNative();
+    const archive = path.join(setup.tempRoot, 'six-1.16.0-pyhd3eb1b0_1.tar.bz2');
+    const response = await fetch(
+      'https://repo.anaconda.com/pkgs/main/noarch/six-1.16.0-pyhd3eb1b0_1.tar.bz2',
+      { signal: AbortSignal.timeout(60_000) }
+    );
+    expect(response.ok).toBe(true);
+    await fs.promises.writeFile(archive, Buffer.from(await response.arrayBuffer()));
+    const outputDir = path.join(setup.tempRoot, 'published GUI output');
+    const packageDir = path.join(outputDir, 'packages');
+    await fs.promises.mkdir(packageDir, { recursive: true });
+    const deliveredPath = path.join(packageDir, path.basename(archive));
+    await fs.promises.copyFile(archive, deliveredPath);
+    const delivered = [{
+      id: 'conda-published-six',
+      type: 'conda',
+      name: 'six',
+      version: '1.16.0',
+      filename: path.basename(archive),
+      metadata: { filename: path.basename(archive) },
+    }];
+    const completion = await createDeliveryPipeline({
+      archivePackager: getArchivePackager(),
+      generateInstallScripts,
+      initializeEmailSender,
+      getFileSplitter,
+      stat: fs.promises.stat,
+    }).finalizeDownload({
+      outputDir,
+      options: { outputDir, outputFormat: 'zip', includeScripts: true, deliveryMethod: 'local' },
+      deliveredPackages: delivered,
+      packageInfos: delivered as PackageInfo[],
+      results: [{ id: delivered[0].id, success: true, filePath: deliveredPath }],
+      failedDownloadCount: 0,
+      progressEmitter: { emitDownloadStatus: () => undefined } as never,
+      isCancelled: () => false,
+    });
+    expect(completion.success, JSON.stringify(completion)).toBe(true);
+    const bundle = path.join(setup.tempRoot, 'published GUI extracted');
+    await fs.promises.mkdir(bundle, { recursive: true });
+    await execFile(
+      setup.python,
+      ['-c', 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', String(completion.outputPath), bundle],
+      { env: setup.env, timeout: 30_000 }
+    );
+    expect(fs.existsSync(path.join(bundle, 'install.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(bundle, 'install.ps1'))).toBe(true);
+    await fs.promises.rm(outputDir, { recursive: true, force: true });
+    const prefix = path.join(setup.tempRoot, 'published six prefix');
+    const runtimeArchives = await collectPythonRuntimeArchives(setup);
+    await execFile(
+      setup.executable,
+      [
+        'create',
+        '--offline',
+        '--yes',
+        '--no-default-packages',
+        '--prefix',
+        prefix,
+        ...runtimeArchives.map((runtimeArchive) => runtimeArchive.source),
+      ],
+      { env: setup.env, timeout: 120_000, maxBuffer: 2 * 1024 * 1024 }
+    );
+    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: prefix };
+    const before = await execFile(
+      path.join(prefix, 'bin', 'python'),
+      ['-c', 'import importlib.util; print(importlib.util.find_spec("six") is None)'],
+      { env, timeout: 30_000 }
+    );
+    expect(before.stdout.trim()).toBe('True');
+    const install = await runBash(path.join(bundle, 'install.sh'), env);
+    expect(install.code, `${install.stdout}\n${install.stderr}`).toBe(0);
+    expect(install.signal).toBeNull();
+    const listed = JSON.parse(
+      (await execFile(setup.executable, ['list', '--json', '--prefix', prefix], { env, timeout: 30_000 })).stdout
+    ) as Array<{ name: string; version: string }>;
+    expect(listed.some((entry) => entry.name === 'six' && entry.version === '1.16.0')).toBe(true);
+    const imported = await execFile(
+      path.join(env.DEPS_SMUGGLER_CONDA_PREFIX, 'bin', 'python'),
+      ['-c', 'import json,six,sys; print(json.dumps({"version":six.__version__,"file":six.__file__,"prefix":sys.prefix}))'],
+      { env, timeout: 30_000 }
+    );
+    const module = JSON.parse(imported.stdout.trim()) as { version: string; file: string; prefix: string };
+    expect(module.version).toBe('1.16.0');
+    expect(module.prefix).toBe(prefix);
+    expect(module.file.startsWith(`${prefix}${path.sep}`)).toBe(true);
+    const sentinel = path.join(prefix, 'sentinel');
+    await fs.promises.writeFile(sentinel, 'preserve');
+    const repeat = await runBash(path.join(bundle, 'install.sh'), env);
+    expect(repeat.code, `${repeat.stdout}\n${repeat.stderr}`).toBe(0);
+    expect(repeat.signal).toBeNull();
     expect(await fs.promises.readFile(sentinel, 'utf8')).toBe('preserve');
     expect(requests).toBe(0);
   }, 300_000);

--- a/src/core/packager/conda-native-consumer.integration.test.ts
+++ b/src/core/packager/conda-native-consumer.integration.test.ts
@@ -586,7 +586,7 @@ nativeSuite('native Conda offline installer consumer', () => {
     expect(fs.existsSync(path.join(bundle, 'install.sh'))).toBe(true);
     expect(fs.existsSync(path.join(bundle, 'install.ps1'))).toBe(true);
     await fs.promises.rm(outputDir, { recursive: true, force: true });
-    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: path.join(setup.tempRoot, 'gui conda prefix') };
+    const env = { ...setup.env, DEPS_SMUGGLER_CONDA_PREFIX: path.join(setup.tempRoot, 'gui-conda-prefix') };
     const install = await runBash(path.join(bundle, 'install.sh'), env);
     expect(install.code, `${install.stdout}\n${install.stderr}`).toBe(0);
     expect(install.signal).toBeNull();
@@ -654,7 +654,7 @@ nativeSuite('native Conda offline installer consumer', () => {
     expect(fs.existsSync(path.join(bundle, 'install.sh'))).toBe(true);
     expect(fs.existsSync(path.join(bundle, 'install.ps1'))).toBe(true);
     await fs.promises.rm(outputDir, { recursive: true, force: true });
-    const prefix = path.join(setup.tempRoot, 'published six prefix');
+    const prefix = path.join(setup.tempRoot, 'published-six-prefix');
     const runtimeArchives = await collectPythonRuntimeArchives(setup);
     await execFile(
       setup.executable,

--- a/src/core/packager/gui-conda-install-script.integration.test.ts
+++ b/src/core/packager/gui-conda-install-script.integration.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { generateInstallScripts } from '../shared';
+
+describe('GUI Conda installer script consumer', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const directory of tempDirs.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform === 'win32')('실제 생성 스크립트가 fake conda 경계에서 create와 install을 구분한다', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'depssmuggler-gui-conda-'));
+    tempDirs.push(root);
+    const outputDir = path.join(root, 'bundle with spaces');
+    const archive = 'conda/fixture-1.0-0.tar.bz2';
+    const archivePath = path.join(outputDir, 'packages', archive);
+    const binDir = path.join(root, 'bin');
+    const logPath = path.join(root, 'conda-argv.jsonl');
+    fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(archivePath, 'fixture archive');
+    fs.writeFileSync(path.join(binDir, 'conda'), `#!/bin/sh
+printf '%s\\n' "$*" >> "${logPath}"
+command="$1"
+prefix=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '--prefix' ]; then prefix="$2"; fi
+  shift
+done
+if [ "\${DEPS_TEST_CONDA_FAIL:-}" = "1" ]; then exit 23; fi
+if [ "$command" = "create" ] || [ "$command" = "install" ]; then
+  mkdir -p "$prefix/conda-meta"
+  touch "$prefix/conda-meta/history"
+fi
+`, { mode: 0o755 });
+
+    await generateInstallScripts(outputDir, [{ id: 'conda-fixture', type: 'conda', name: 'fixture', version: '1.0' }], {
+      condaPackageFiles: [{ relativePath: archive }],
+    });
+    const scriptPath = path.join(outputDir, 'install.sh');
+    const run = (env: NodeJS.ProcessEnv) => new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+      const child = spawn('/bin/bash', [scriptPath], { cwd: outputDir, env });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+      child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+      child.once('error', reject);
+      child.once('close', (code) => resolve({ code, stdout, stderr }));
+    });
+    const env = { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`, DEPS_SMUGGLER_CONDA_PREFIX: '' };
+    expect((await run(env)).code).toBe(0);
+    fs.writeFileSync(path.join(outputDir, 'conda-env', 'sentinel'), 'keep');
+    expect((await run(env)).code).toBe(0);
+    expect(fs.readFileSync(path.join(outputDir, 'conda-env', 'sentinel'), 'utf8')).toBe('keep');
+    const calls = fs.readFileSync(logPath, 'utf8').trim().split('\n');
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain('create --offline --yes --no-default-packages');
+    expect(calls[1]).toContain('install --offline --yes');
+    expect(calls[0]).toContain('bundle with spaces');
+    expect(calls[0]).toContain(`${outputDir}/./packages/${archive}`);
+    expect(calls[1]).toContain(`${outputDir}/./packages/${archive}`);
+
+    const failed = await run({ ...env, DEPS_TEST_CONDA_FAIL: '1' });
+    expect(failed.code).toBe(1);
+    expect(failed.stdout).not.toContain('Installation complete!');
+  }, 30_000);
+});

--- a/src/core/packager/script-generator.ts
+++ b/src/core/packager/script-generator.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs-extra';
 import { createNpmInstallPlan, NpmPackageFile } from './npm-install-plan';
 import { buildNpmBashInstallLines, buildNpmPowerShellInstallLines } from './npm-install-script';
 import { PackageInfo } from '../../types';
+import { getCondaArchivePaths, buildCondaBashInstallLines, buildCondaPowerShellInstallLines, type CondaPackageFile } from './conda-install-script';
 import logger from '../../utils/logger';
 import { stripLeadingDotSlash, toUnixPath, getWriteOptions } from '../shared/path-utils';
 import { buildDockerArchiveFilename } from '../downloaders/docker-utils';
@@ -21,9 +22,7 @@ export interface ScriptOptions {
   condaPackageFiles?: CondaPackageFile[]; // 압축물 packages/ 내부 Conda archive 상대 경로
 }
 
-export interface CondaPackageFile {
-  relativePath: string;
-}
+export type { CondaPackageFile } from './conda-install-script';
 
 export interface GeneratedScript {
   path: string;
@@ -84,45 +83,6 @@ export class ScriptGenerator {
     return `'${value.replace(/'/g, "''")}'`;
   }
 
-  private getCondaArchivePaths(
-    packages: PackageInfo[],
-    packageFiles?: CondaPackageFile[],
-  ): string[] {
-    const relativePaths = packageFiles !== undefined
-      ? packageFiles.map(file => file.relativePath)
-      : packages.map(pkg => {
-        const filename = pkg.metadata?.filename;
-        if (typeof filename !== 'string' || filename.length === 0) {
-          throw new Error(`Conda 패키지 ${pkg.name}@${pkg.version}의 아카이브 파일명이 없습니다 (metadata.filename)`);
-        }
-        return filename;
-      });
-
-    if (relativePaths.length === 0) {
-      throw new Error('Conda 패키지 파일 매핑이 비어 있습니다.');
-    }
-
-    const normalized = new Set<string>();
-    for (const relativePath of relativePaths) {
-      if (typeof relativePath !== 'string') {
-        throw new Error('Conda 패키지 파일 경로가 유효하지 않습니다.');
-      }
-      const portablePath = relativePath.replace(/\\/g, '/');
-      const segments = portablePath.split('/');
-      if (
-        portablePath.length === 0 ||
-        portablePath.startsWith('/') ||
-        /^[A-Za-z]:\//.test(portablePath) ||
-        segments.some(segment => segment.length === 0 || segment === '.' || segment === '..') ||
-        !/\.(?:conda|tar\.bz2)$/i.test(portablePath)
-      ) {
-        throw new Error(`Conda 패키지 파일 경로가 유효하지 않습니다: ${relativePath}`);
-      }
-      normalized.add(portablePath);
-    }
-
-    return [...normalized];
-  }
 
   /**
    * Bash 설치 스크립트 생성 (Linux/macOS용)
@@ -275,53 +235,8 @@ export class ScriptGenerator {
     // Conda 패키지 설치
     if (packagesByType.has('conda')) {
       const condaPackages = packagesByType.get('conda') || [];
-      const condaArchivePaths = this.getCondaArchivePaths(condaPackages, options.condaPackageFiles);
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('# Conda 패키지 오프라인 설치');
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('');
-      lines.push('install_conda_packages() {');
-      lines.push('    log_info "Conda 패키지 설치 중..."');
-      lines.push('    if ! command -v conda &> /dev/null; then');
-      lines.push('        log_error "Conda가 설치되어 있지 않습니다."');
-      lines.push('        return 1');
-      lines.push('    fi');
-      lines.push('');
-      lines.push('    local conda_relative_path conda_archive_path');
-      lines.push('    local conda_archive_paths=()');
-      for (const relativePath of condaArchivePaths) {
-        lines.push(`    conda_relative_path=${this.shellQuote(relativePath)}`);
-        lines.push('    conda_archive_path="$SCRIPT_DIR/$PACKAGE_DIR/$conda_relative_path"');
-        lines.push('    if [[ ! -f "$conda_archive_path" ]]; then');
-        lines.push('        log_error "Conda 아카이브를 찾을 수 없습니다: $conda_archive_path"');
-        lines.push('        return 1');
-        lines.push('    fi');
-        lines.push('    conda_archive_paths+=("$conda_archive_path")');
-      }
-      lines.push('');
-      lines.push('    local conda_prefix="${DEPS_SMUGGLER_CONDA_PREFIX:-$SCRIPT_DIR/conda-env}"');
-      lines.push('    if [[ "$conda_prefix" != /* ]]; then conda_prefix="$SCRIPT_DIR/$conda_prefix"; fi');
-      lines.push('    if [[ -e "$conda_prefix" && ! -d "$conda_prefix" ]]; then');
-      lines.push('        log_error "Conda 환경 경로가 디렉터리가 아닙니다: $conda_prefix"');
-      lines.push('        return 1');
-      lines.push('    fi');
-      lines.push('    if [[ -f "$conda_prefix/conda-meta/history" ]]; then');
-      lines.push('        conda install --offline --yes --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
-      lines.push('            log_error "Conda 패키지 설치에 실패했습니다."');
-      lines.push('            return 1');
-      lines.push('        }');
-      lines.push('    elif [[ -e "$conda_prefix" ]]; then');
-      lines.push('        log_error "기존 경로가 Conda 환경이 아닙니다: $conda_prefix"');
-      lines.push('        return 1');
-      lines.push('    else');
-      lines.push('        conda create --offline --yes --no-default-packages --prefix "$conda_prefix" "${conda_archive_paths[@]}" || {');
-      lines.push('            log_error "Conda 환경 생성에 실패했습니다."');
-      lines.push('            return 1');
-      lines.push('        }');
-      lines.push('    fi');
-      lines.push('    log_info "Conda 패키지 설치 완료: $conda_prefix"');
-      lines.push('}');
-      lines.push('');
+      const condaArchivePaths = getCondaArchivePaths(condaPackages, options.condaPackageFiles);
+      lines.push(...buildCondaBashInstallLines(condaArchivePaths));
     }
 
     // npm 패키지 설치
@@ -692,48 +607,8 @@ export class ScriptGenerator {
     // Conda 패키지 설치
     if (packagesByType.has('conda')) {
       const condaPackages = packagesByType.get('conda') || [];
-      const condaArchivePaths = this.getCondaArchivePaths(condaPackages, options.condaPackageFiles);
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('# Conda 패키지 오프라인 설치');
-      lines.push('#-------------------------------------------------------------------------------');
-      lines.push('');
-      lines.push('function Install-CondaPackages {');
-      lines.push('    Write-Info "Conda 패키지 설치 중..."');
-      lines.push('    if (-not (Get-Command conda -ErrorAction SilentlyContinue)) {');
-      lines.push('        throw "Conda가 설치되어 있지 않습니다."');
-      lines.push('    }');
-      lines.push('');
-      lines.push('    $CondaArchivePaths = @()');
-      for (const relativePath of condaArchivePaths) {
-        lines.push(`    $CondaArchivePath = Join-Path -Path $PackageDir -ChildPath ${this.powerShellQuote(relativePath)}`);
-        lines.push('    if (-not (Test-Path -LiteralPath $CondaArchivePath -PathType Leaf)) {');
-        lines.push('        throw "Conda 아카이브를 찾을 수 없습니다: $CondaArchivePath"');
-        lines.push('    }');
-        lines.push('    $CondaArchivePaths += $CondaArchivePath');
-      }
-      lines.push('');
-      lines.push('    $CondaPrefix = $env:DEPS_SMUGGLER_CONDA_PREFIX');
-      lines.push('    if ([string]::IsNullOrWhiteSpace($CondaPrefix)) {');
-      lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath \'conda-env\'');
-      lines.push('    } elseif (-not [System.IO.Path]::IsPathRooted($CondaPrefix)) {');
-      lines.push('        $CondaPrefix = Join-Path -Path $ScriptDir -ChildPath $CondaPrefix');
-      lines.push('    }');
-      lines.push('    if (Test-Path -LiteralPath $CondaPrefix -PathType Leaf) {');
-      lines.push('        throw "Conda 환경 경로가 디렉터리가 아닙니다: $CondaPrefix"');
-      lines.push('    }');
-      lines.push('    $CondaHistory = Join-Path -Path $CondaPrefix -ChildPath \'conda-meta/history\'');
-      lines.push('    if (Test-Path -LiteralPath $CondaHistory -PathType Leaf) {');
-      lines.push('        & conda install --offline --yes --prefix $CondaPrefix @CondaArchivePaths');
-      lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
-      lines.push('    } elseif (Test-Path -LiteralPath $CondaPrefix) {');
-      lines.push('        throw "기존 경로가 Conda 환경이 아닙니다: $CondaPrefix"');
-      lines.push('    } else {');
-      lines.push('        & conda create --offline --yes --no-default-packages --prefix $CondaPrefix @CondaArchivePaths');
-      lines.push('        if ($LASTEXITCODE -ne 0) { throw "Conda 환경 생성에 실패했습니다: 종료 코드 $LASTEXITCODE" }');
-      lines.push('    }');
-      lines.push('    Write-Info "Conda 패키지 설치 완료: $CondaPrefix"');
-      lines.push('}');
-      lines.push('');
+      const condaArchivePaths = getCondaArchivePaths(condaPackages, options.condaPackageFiles);
+      lines.push(...buildCondaPowerShellInstallLines(condaArchivePaths));
     }
 
     // npm 패키지 설치

--- a/src/core/shared/script-utils.test.ts
+++ b/src/core/shared/script-utils.test.ts
@@ -72,4 +72,29 @@ describe('generateInstallScripts', () => {
     })).rejects.toThrow('is-odd@3.0.1');
     expect(fs.existsSync(path.join(outputDir, 'install.sh'))).toBe(false);
   });
+
+  it('GUI Conda 스크립트는 실제 전달 경로를 Conda 오프라인 명령에 연결한다', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'script-utils-conda-'));
+    outputDirs.push(outputDir);
+    await generateInstallScripts(outputDir, [
+      { id: 'conda-six', type: 'conda', name: 'six', version: '1.16.0' },
+    ], { condaPackageFiles: [{ relativePath: 'nested/six-1.16.0-pyhd3eb1b0_1.tar.bz2' }] });
+    const bash = fs.readFileSync(path.join(outputDir, 'install.sh'), 'utf8');
+    const powershell = fs.readFileSync(path.join(outputDir, 'install.ps1'), 'utf8');
+    expect(bash).toContain('conda create --offline --yes --no-default-packages');
+    expect(powershell).toContain('conda create --offline --yes --no-default-packages');
+    expect(bash).toContain('nested/six-1.16.0-pyhd3eb1b0_1.tar.bz2');
+    expect(powershell).toContain('nested/six-1.16.0-pyhd3eb1b0_1.tar.bz2');
+    expect(bash).not.toContain('pip install');
+    expect(powershell).not.toContain('pip install');
+  });
+
+  it('GUI Conda 파일 매핑이 없으면 잘못된 pip 스크립트를 만들지 않는다', async () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'script-utils-conda-missing-'));
+    outputDirs.push(outputDir);
+    await expect(generateInstallScripts(outputDir, [
+      { id: 'conda-six', type: 'conda', name: 'six', version: '1.16.0' },
+    ])).rejects.toThrow();
+    expect(fs.existsSync(path.join(outputDir, 'install.sh'))).toBe(false);
+  });
 });

--- a/src/core/shared/script-utils.ts
+++ b/src/core/shared/script-utils.ts
@@ -6,10 +6,17 @@ import { isWindows } from './path-utils';
 import type { PackageInfo } from '../../types';
 import { createNpmInstallPlan, type NpmInstallPlan, type NpmPackageFile } from '../packager/npm-install-plan';
 import { buildNpmBashInstallLines, buildNpmPowerShellInstallLines } from '../packager/npm-install-script';
+import {
+  getCondaArchivePaths,
+  buildCondaBashInstallLines,
+  buildCondaPowerShellInstallLines,
+  type CondaPackageFile,
+} from '../packager/conda-install-script';
 
 export interface InstallScriptOptions {
   npmRootPackages?: PackageInfo[];
   npmPackageFiles?: NpmPackageFile[];
+  condaPackageFiles?: CondaPackageFile[];
 }
 
 /**
@@ -35,8 +42,15 @@ export async function generateInstallScripts(
         options.npmRootPackages,
       )
     : undefined;
-  const bashScript = generateBashScript(packages, npmPlan);
-  const psScript = generatePowerShellScript(packages, npmPlan);
+  const condaPackages = packages.filter(pkg => pkg.type === 'conda');
+  const condaArchivePaths = condaPackages.length > 0
+    ? getCondaArchivePaths(
+        condaPackages.map(pkg => ({ ...pkg, type: 'conda' as const })),
+        options.condaPackageFiles,
+      )
+    : undefined;
+  const bashScript = generateBashScript(packages, npmPlan, condaArchivePaths);
+  const psScript = generatePowerShellScript(packages, npmPlan, condaArchivePaths);
 
   // Windows에서는 mode 옵션이 무시되므로 조건부 처리
   const bashWriteOptions = isWindows ? {} : { mode: 0o755 };
@@ -62,12 +76,11 @@ export async function generateInstallScripts(
 /**
  * Bash 설치 스크립트 생성
  */
-function generateBashScript(packages: DownloadPackage[], npmPlan?: NpmInstallPlan): string {
+function generateBashScript(
+  packages: DownloadPackage[], npmPlan?: NpmInstallPlan, condaArchivePaths?: string[],
+): string {
   const pipPackages = packages.filter((p) => p.type === 'pip');
-  const condaPackages = packages.filter((p) => p.type === 'conda');
   const mavenPackages = packages.filter((p) => p.type === 'maven');
-  const hasPythonPackages =
-    pipPackages.length > 0 || condaPackages.length > 0;
 
   return `#!/bin/bash
 # DepsSmuggler 설치 스크립트
@@ -79,13 +92,14 @@ echo "Installing packages..."
 
 SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
 
-${npmPlan ? `PACKAGE_DIR="$SCRIPT_DIR/packages"
+${npmPlan || condaArchivePaths ? `PACKAGE_DIR="./packages"
 log_info() { echo "$@"; }
 log_error() { echo "$@" >&2; }
-${buildNpmBashInstallLines(npmPlan).join('\n')}
+${npmPlan ? buildNpmBashInstallLines(npmPlan).join('\n') : ''}
+${condaArchivePaths ? buildCondaBashInstallLines(condaArchivePaths).join('\n') : ''}
 ` : ''}
 
-${hasPythonPackages ? `PIP_FIND_LINK_ARGS=()
+${pipPackages.length > 0 ? `PIP_FIND_LINK_ARGS=()
 while IFS= read -r -d '' directory; do
     PIP_FIND_LINK_ARGS+=(--find-links="$directory")
 done < <(find "$SCRIPT_DIR/packages" -type d -print0)
@@ -94,9 +108,7 @@ done < <(find "$SCRIPT_DIR/packages" -type d -print0)
 ${pipPackages.length > 0 ? `# pip 패키지 설치
 ${pipPackages.map((p) => `pip install --no-index "\${PIP_FIND_LINK_ARGS[@]}" ${p.name}==${p.version}`).join('\n')}
 ` : ''}
-${condaPackages.length > 0 ? `# conda 패키지 설치
-${condaPackages.map((p) => `pip install --no-index "\${PIP_FIND_LINK_ARGS[@]}" ${p.name}==${p.version}`).join('\n')}
-` : ''}
+${condaArchivePaths ? 'install_conda_packages || exit 1' : ''}
 ${mavenPackages.length > 0 ? `# Maven 아티팩트 복사
 echo "Maven artifacts are in packages/ directory"
 ` : ''}
@@ -108,12 +120,11 @@ echo "Installation complete!"
 /**
  * PowerShell 설치 스크립트 생성
  */
-function generatePowerShellScript(packages: DownloadPackage[], npmPlan?: NpmInstallPlan): string {
+function generatePowerShellScript(
+  packages: DownloadPackage[], npmPlan?: NpmInstallPlan, condaArchivePaths?: string[],
+): string {
   const pipPackages = packages.filter((p) => p.type === 'pip');
-  const condaPackages = packages.filter((p) => p.type === 'conda');
   const mavenPackages = packages.filter((p) => p.type === 'maven');
-  const hasPythonPackages =
-    pipPackages.length > 0 || condaPackages.length > 0;
 
   return `# DepsSmuggler 설치 스크립트
 # 생성일: ${new Date().toISOString()}
@@ -126,12 +137,13 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 $PackagesDir = Join-Path -Path $ScriptDir -ChildPath 'packages'
 
-${npmPlan ? `$PackageDir = $PackagesDir
+${npmPlan || condaArchivePaths ? `$PackageDir = $PackagesDir
 function Write-Info { param([string]$Message) Write-Host $Message }
-${buildNpmPowerShellInstallLines(npmPlan).join('\n')}
+${npmPlan ? buildNpmPowerShellInstallLines(npmPlan).join('\n') : ''}
+${condaArchivePaths ? buildCondaPowerShellInstallLines(condaArchivePaths).join('\n') : ''}
 ` : ''}
 
-${hasPythonPackages ? `$PipFindLinkArgs = @("--find-links=$PackagesDir")
+${pipPackages.length > 0 ? `$PipFindLinkArgs = @("--find-links=$PackagesDir")
 $PipFindLinkArgs += @(
     Get-ChildItem -Path $PackagesDir -Directory -Recurse |
         ForEach-Object { "--find-links=$($_.FullName)" }
@@ -142,9 +154,7 @@ ${pipPackages.length > 0 ? `# pip 패키지 설치
 ${pipPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==${p.version}
 if ($LASTEXITCODE -ne 0) { throw "pip 패키지 설치에 실패했습니다: 종료 코드 $LASTEXITCODE" }`).join('\n')}
 ` : ''}
-${condaPackages.length > 0 ? `# conda 패키지 설치
-${condaPackages.map((p) => `pip install --no-index @PipFindLinkArgs ${p.name}==${p.version}`).join('\n')}
-` : ''}
+${condaArchivePaths ? 'Install-CondaPackages' : ''}
 ${mavenPackages.length > 0 ? `# Maven 아티팩트 복사
 Write-Host "Maven artifacts are in packages/ directory"
 ` : ''}


### PR DESCRIPTION
GUI에서 Conda 파일을 내려받아도 설치 스크립트가 `pip install`을 호출해 설치에 실패했습니다. GUI와 CLI가 공통 Conda 설치 블록을 사용하도록 바꾸고, 완료된 다운로드의 실제 `.conda`·`.tar.bz2` 경로를 전달합니다.

대상 환경이 없으면 오프라인으로 생성하고, 기존 Conda 환경이면 해당 환경에 설치합니다. 파일·도구 누락이나 Conda 명령 실패는 전체 설치 실패로 처리합니다. Python noarch 패키지는 호환되는 Python 환경이 필요하며 `DEPS_SMUGGLER_CONDA_PREFIX`로 대상을 지정할 수 있습니다.

검증:
- 전체 테스트: 3022 통과 / 164 건너뜀. TypeScript·lint 통과(기존 경고 포함).
- GUI 파일 매핑, 스크립트 생성, 실제 Bash 실행의 생성·재설치·실패 전파 검증.
- 기존 CLI Conda 및 GUI pip/npm 소비자 회귀 통과.
- Ubuntu CI native Conda 검증을 확장: GUI ZIP만 추출해 일반 `.conda`를 새 환경에 설치하고, 공개 `six 1.16.0`을 임시 Python 환경에 설치·import·재설치합니다. 로컬에는 Conda가 없어 native 4건은 건너뛰었으며 CI 결과를 확인합니다.

README, Packagers, 테스트 문서에 공통 설치기와 환경 조건을 반영했습니다.

Closes #137
