### PR TITLE
fix: GUI HTTP 오류 응답의 성공 처리 방지

### DIFF
--- a/docs/shared-file-path.md
+++ b/docs/shared-file-path.md
@@ -34,11 +34,11 @@ async function downloadFile(
 ```
 
 - HTTP/HTTPS 모두 지원
-- 301/302의 `Location`으로 재귀 다운로드 (상대 URL 해석이나 최대 횟수 제한은 구현하지 않음)
+- 301/302의 `Location`으로 재귀 다운로드 (상대 URL은 현재 URL 기준으로 해석하며 최대 20회)
 - AbortSignal을 통한 다운로드 취소
 - shouldPause 콜백을 통한 일시정지/재개
 
-현재 헬퍼는 대상 디렉토리를 생성하지 않으며 호출 중 발생한 abort 이벤트를 처리합니다. 이미 취소된 signal 검사, HTTP 오류 상태 거부, 재시도·체크섬 검증은 이 함수에 포함되지 않습니다. 진행률의 total은 Content-Length가 없으면 0입니다.
+현재 헬퍼는 대상 디렉토리를 생성하지 않으며 호출 중 발생한 abort 이벤트를 처리합니다. 이미 취소된 signal이면 요청을 시작하지 않습니다. 유효한 301/302 리다이렉트를 처리한 뒤, 2xx 응답만 파일 스트림에 연결하며 그 밖의 상태는 HTTP 상태 코드가 포함된 오류로 거부합니다. 오류 응답은 저장하지 않으며 대상 파일을 닫고 삭제한 뒤 실패를 반환하므로 이전 시도의 정리가 재시도한 파일을 지우지 않습니다. Location이 없는 redirect나 redirect 한도 초과도 실패입니다. 자동 재시도와 체크섬 검증은 이 함수에 포함되지 않습니다. 진행률의 total은 Content-Length가 없으면 0입니다.
 
 ### FileDownloadOptions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,7 +87,7 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 | OS 패키지          | `src/core/downloaders/os-shared/{archive-packager,dependency-tree}.test.ts`, `src/core/resolver/os-resolver-utils.test.ts`              | 압축 형식·스크립트, 누락 파일, 순환·중복 의존성, 버전·아키텍처 필터, 요청 간 상태 격리                           |
 | Python             | `src/core/shared/{pip-candidate,pip-tags,pip-provider,pypi-utils}.test.ts`                                                              | ABI·플랫폼, Python/패키지 버전 제약, 철회·시험 배포, 후보 없음, 의존성·캐시·실패 후 재시도                       |
 | Conda·Maven        | `src/core/shared/{conda-utils,conda-validator,maven-utils}.test.ts`                                                                     | 압축 인덱스/일반 인덱스/API fallback, noarch, Python 빌드, 채널 거부, classifier, 잘못된·빈 응답                 |
-| HTTP·파일·캐시     | `src/core/shared/{axios-http-client,file-utils}.test.ts`, `src/core/shared/cache/cache-store.test.ts`                                   | 상태·오류·진행률 전달, 바이트 전송, redirect, pause/cancel 정리, TTL 경계, 동시 실패·재시도, 손상 JSON·권한 오류 |
+| HTTP·파일·캐시     | `src/core/shared/{axios-http-client,file-utils}.test.ts`, `src/core/shared/file-utils-http.integration.test.ts`, `src/core/shared/cache/cache-store.test.ts` | 상태·오류·진행률 전달, non-2xx 응답과 partial 정리, redirect, pause/cancel 정리, TTL 경계, 동시 실패·재시도, 손상 JSON·권한 오류 |
 | 메일               | `src/core/mailer/email-sender-errors.test.ts`                                                                                           | 첨부 제한과 같은 크기/초과, 인증·수신자·파일 접근 오류, 부분 발송 중단, 연결 재시도                              |
 | 렌더러 훅          | `src/renderer/pages/settings/use-settings-form-actions.test.ts`, `src/renderer/pages/download-page/hooks/use-os-download-flow.test.ts`  | 입력 검증·미저장 이동 방지, SMTP·캐시 실패, OS 선택, 늦은 응답, 히스토리·장바구니 보존, 구독 해제                |
 
@@ -98,6 +98,12 @@ Phase 1 characterization 범위에서 특히 회귀 게이트로 삼는 테스�
 `bash scripts/verify-worktree.sh electron/main-lifecycle.test.ts src/core/shared/axios-http-client.test.ts`로 앱 시작 경계와 HTTP 어댑터를 검증합니다. 시작 테스트는 Electron 창·핸들러만 대체하고 실제 `main.ts`의 TLS 분기와 loopback HTTPS 서버, axios/Node HTTPS를 실행합니다. 기본값·`true`·잘못된 환경변수 값의 자체 서명 인증서 거부, 신뢰 CA를 명시한 연결 성공, 호스트 이름 불일치 거부, 명시적인 `DEPSSMUGGLER_STRICT_SSL=false` 완화 동작을 구분합니다.
 
 테스트 전용 인증서/키는 `electron/test-fixtures/`에 있고 외부 서버나 개인 인증서는 사용하지 않습니다. 테스트 후 환경변수·axios 기본 agent를 복구하고 연결·서버를 정리합니다. 기존 lifecycle 테스트가 `STRICT_SSL=true`만 지정해 기본값 오류를 놓쳤으므로 미지정 실행을 별도 회귀 사례로 유지합니다. 이 검증은 실제 TLS 연결을 포함하지만 새 packaged 앱의 전체 GUI 실행이나 모든 저장소의 인증서 체인을 검증한 것은 아닙니다.
+
+### HTTP 다운로드 응답 오류 검증
+
+`src/core/shared/file-utils-http.integration.test.ts`는 loopback HTTP 서버의 실제 404·503 응답을 `downloadFile`에 전달합니다. `downloadFile`은 응답을 파일에 연결하기 전에 2xx 여부를 확인하고, 실패 시 상태 코드와 응답 진단을 포함해 reject하며 progress 완료 콜백을 호출하지 않고 destination의 partial 파일을 삭제해야 합니다. 정상 200과 301/302 redirect는 기존 바이트·진행률 동작을 유지하고, 상대 `Location`과 20회 redirect 한도도 검사합니다. 실패한 요청을 downloader 내부에서 자동 성공이나 자동 재시도로 바꾸지 않으며, 명시적인 사용자 재시도만 새 HTTP 요청을 시작합니다.
+
+`use-download-page-controller.test.tsx`의 HTTP 회귀는 실제 orchestrator·router·`downloadFile`·파일 시스템·delivery pipeline을 렌더러 controller에 연결합니다. Conda 항목의 404와 503 요청은 실패 항목·실패 이력만 남기고 파일과 ZIP을 만들지 않아야 합니다. 같은 항목을 같은 경로로 재시도해 200 응답을 받으면 성공 이력과 ZIP을 만들고, ZIP 내부 파일도 전송한 바이트와 일치해야 합니다. 창의 이벤트 전달과 이력 저장 IPC만 테스트 경계로 대체하며 HTTP·파일 저장·압축은 실제로 실행합니다. 입력은 전송 검사용 바이트이므로 이 테스트는 Conda 설치를 검증하지 않습니다.
 
 ### CLI 캐시 설정 검증
 

--- a/src/core/shared/file-utils-http.integration.test.ts
+++ b/src/core/shared/file-utils-http.integration.test.ts
@@ -1,0 +1,146 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getEventListeners } from 'node:events';
+import { afterEach, describe, expect, it } from 'vitest';
+import { downloadFile } from './file-utils';
+
+describe('downloadFile HTTP status handling', () => {
+  const resources: Array<{ server: http.Server; directory: string }> = [];
+
+  afterEach(async () => {
+    await Promise.all(resources.splice(0).map(async ({ server, directory }) => {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }));
+  });
+
+  it.each([
+    [404, 'not found body'],
+    [503, 'service unavailable body'],
+  ] as const)('rejects HTTP %d and removes destination', async (statusCode, body) => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-status-'));
+    const server = http.createServer((_request, response) => {
+      response.writeHead(statusCode, { 'content-length': Buffer.byteLength(body) });
+      response.end(body);
+    });
+    resources.push({ server, directory });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+
+    const destination = path.join(directory, 'package.bin');
+    const progress = [] as Array<[number, number]>;
+    await expect(downloadFile(
+      `http://127.0.0.1:${address.port}/package`,
+      destination,
+      (downloaded, total) => progress.push([downloaded, total]),
+    )).rejects.toThrow(new RegExp(`${statusCode}`));
+    expect(progress).toEqual([]);
+    expect(fs.existsSync(destination)).toBe(false);
+  });
+
+  it.each([
+    ['', Buffer.alloc(0)],
+    ['payload', Buffer.from('payload')],
+  ] as const)('accepts HTTP 200 with exact bytes (%s)', async (label, expected) => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-ok-'));
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-length': expected.length });
+      response.end(expected);
+    });
+    resources.push({ server, directory });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const destination = path.join(directory, `${label || 'empty'}.bin`);
+    await downloadFile(`http://127.0.0.1:${address.port}/package`, destination, () => {});
+    expect(await fs.promises.readFile(destination)).toEqual(expected);
+  });
+
+  it.each([404, 503])('retries the same destination after HTTP %d without stale cleanup', async (status) => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-retry-'));
+    let requests = 0;
+    const server = http.createServer((_request, response) => {
+      requests += 1;
+      if (requests === 1) {
+        response.writeHead(status);
+        response.end('temporary failure');
+      } else {
+        response.writeHead(200, { 'content-length': 5 });
+        response.end('fresh');
+      }
+    });
+    resources.push({ server, directory });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const destination = path.join(directory, 'same.bin');
+    await expect(downloadFile(`http://127.0.0.1:${address.port}/package`, destination, () => {})).rejects.toThrow();
+    expect(fs.existsSync(destination)).toBe(false);
+    await downloadFile(`http://127.0.0.1:${address.port}/package`, destination, () => {});
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(await fs.promises.readFile(destination, 'utf8')).toBe('fresh');
+    expect(requests).toBe(2);
+  }, 10_000);
+
+  it.each([301, 302])('follows relative HTTP %d redirects and rejects missing locations and loops', async (status) => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-redirect-'));
+    let loopRequests = 0;
+    const server = http.createServer((request, response) => {
+      if (request.url === '/relative') {
+        response.writeHead(status, { location: '/final' });
+        response.end();
+      } else if (request.url === '/final') {
+        response.end('redirected');
+      } else if (request.url === '/missing') {
+        response.writeHead(status);
+        response.end();
+      } else {
+        loopRequests += 1;
+        response.writeHead(status, { location: '/loop' });
+        response.end();
+      }
+    });
+    resources.push({ server, directory });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const url = (route: string) => `http://127.0.0.1:${address.port}${route}`;
+    const controller = new AbortController();
+    await downloadFile(url('/relative'), path.join(directory, 'relative.bin'), () => {}, { signal: controller.signal });
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+    controller.abort();
+    expect(await fs.promises.readFile(path.join(directory, 'relative.bin'), 'utf8')).toBe('redirected');
+    await expect(downloadFile(url('/missing'), path.join(directory, 'missing.bin'), () => {})).rejects.toThrow(`HTTP ${status}`);
+    await expect(downloadFile(url('/loop'), path.join(directory, 'loop.bin'), () => {})).rejects.toThrow('20');
+    expect(fs.existsSync(path.join(directory, 'missing.bin'))).toBe(false);
+    expect(fs.existsSync(path.join(directory, 'loop.bin'))).toBe(false);
+    expect(loopRequests).toBe(21);
+  }, 10_000);
+
+  it('does not issue a request for a pre-aborted signal', async () => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-abort-'));
+    let requests = 0;
+    const server = http.createServer((_request, response) => {
+      requests += 1;
+      response.end('unexpected');
+    });
+    resources.push({ server, directory });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const controller = new AbortController();
+    controller.abort();
+    await expect(downloadFile(
+      `http://127.0.0.1:${address.port}/pre-aborted`,
+      path.join(directory, 'aborted.bin'),
+      () => {},
+      { signal: controller.signal },
+    )).rejects.toThrow('Download aborted');
+    expect(requests).toBe(0);
+    expect(fs.existsSync(path.join(directory, 'aborted.bin'))).toBe(false);
+  });
+});

--- a/src/core/shared/file-utils.test.ts
+++ b/src/core/shared/file-utils.test.ts
@@ -14,7 +14,10 @@ vi.mock('archiver', () => ({ default: vi.fn() }));
 vi.mock('../../utils/logger', () => ({ default: { debug: vi.fn() } }));
 
 function transfer(headers: Record<string, string> = { 'content-length': '6' }, statusCode = 200) {
-  const file = Object.assign(new PassThrough(), { close: vi.fn() });
+  const file = Object.assign(new PassThrough(), { close: vi.fn((callback?: () => void) => {
+    file.destroy();
+    callback?.();
+  }) });
   const response = Object.assign(new PassThrough(), { headers, statusCode });
   const request = Object.assign(new EventEmitter(), { destroy: vi.fn() });
   const chunks: Buffer[] = [];
@@ -24,7 +27,10 @@ function transfer(headers: Record<string, string> = { 'content-length': '6' }, s
 }
 
 describe('공유 파일 전송', () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(fs.unlink).mockImplementation((_file, callback) => callback(null));
+  });
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -194,7 +200,7 @@ describe('공유 파일 전송', () => {
     second.response.end(Buffer.from('abcdef'));
     await pending;
     expect(first.file.close).toHaveBeenCalledOnce();
-    expect(fs.unlinkSync).toHaveBeenCalledWith('package.bin');
+    expect(fs.unlink).toHaveBeenCalledWith('package.bin', expect.any(Function));
     expect(https.get).toHaveBeenNthCalledWith(
       2,
       'https://cdn.example/package',

--- a/src/core/shared/file-utils.ts
+++ b/src/core/shared/file-utils.ts
@@ -9,7 +9,7 @@ export type ProgressCallback = (downloaded: number, total: number) => void;
 
 export interface FileDownloadOptions {
   signal?: AbortSignal;
-  shouldPause?: () => boolean;  // 일시정지 여부를 체크하는 콜백
+  shouldPause?: () => boolean; // 일시정지 여부를 체크하는 콜백
 }
 
 /**
@@ -22,96 +22,167 @@ export async function downloadFile(
   onProgress: ProgressCallback,
   options?: FileDownloadOptions
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(destPath);
-    const protocol = url.startsWith('https') ? https : http;
-    let pauseCheckInterval: NodeJS.Timeout | null = null;
+  return downloadAttempt(url, 0);
 
-    // 정리 함수
-    const cleanup = () => {
-      if (pauseCheckInterval) {
-        clearInterval(pauseCheckInterval);
-        pauseCheckInterval = null;
-      }
-    };
+  function downloadAttempt(currentUrl: string, redirects: number): Promise<void> {
+    if (options?.signal?.aborted) return Promise.reject(new Error('Download aborted'));
 
-    const request = protocol
-      .get(url, { headers: { 'User-Agent': 'DepsSmuggler/1.0' } }, (response) => {
-        // 리다이렉트 처리
-        if (response.statusCode === 301 || response.statusCode === 302) {
-          const redirectUrl = response.headers.location;
-          if (redirectUrl) {
-            cleanup();
-            file.close();
-            fs.unlinkSync(destPath);
-            downloadFile(redirectUrl, destPath, onProgress, options)
-              .then(resolve)
-              .catch(reject);
-            return;
-          }
+    return new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(destPath);
+      const protocol = currentUrl.startsWith('https') ? https : http;
+      let pauseCheckInterval: NodeJS.Timeout | null = null;
+      let settled = false;
+      let request: http.ClientRequest | undefined;
+      let activeResponse: http.IncomingMessage | undefined;
+      const onAbort = () => fail(new Error('Download aborted'));
+
+      const cleanup = () => {
+        if (pauseCheckInterval) {
+          clearInterval(pauseCheckInterval);
+          pauseCheckInterval = null;
         }
+        options?.signal?.removeEventListener('abort', onAbort);
+      };
 
-        const totalLength = parseInt(response.headers['content-length'] || '0', 10);
-        let downloadedLength = 0;
-        let isPaused = false;
+      // 이전 시도의 정리가 끝난 다음에만 재시도가 같은 경로를 사용할 수 있다.
+      const closeAndRemove = (done: (error?: Error) => void) => {
+        file.close((closeError?: NodeJS.ErrnoException | null) => {
+          fs.unlink(destPath, (unlinkError) => {
+            done(
+              closeError || (unlinkError?.code !== 'ENOENT' ? unlinkError : undefined) || undefined
+            );
+          });
+        });
+      };
 
-        response.on('data', (chunk: Buffer) => {
-          downloadedLength += chunk.length;
-          onProgress(downloadedLength, totalLength);
+      function fail(error: Error) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        activeResponse?.unpipe(file);
+        activeResponse?.destroy();
+        request?.destroy();
+        closeAndRemove((cleanupError) => {
+          reject(
+            cleanupError
+              ? new Error(`${error.message} (파일 정리 실패: ${cleanupError.message})`)
+              : error
+          );
+        });
+      }
 
-          // 일시정지 콜백 체크
-          if (options?.shouldPause?.() && !isPaused) {
-            isPaused = true;
-            response.pause();
-            logger.debug('[downloadFile] Stream paused', { downloadedLength, totalLength });
+      file.on('error', fail);
+      options?.signal?.addEventListener('abort', onAbort, { once: true });
 
-            // 주기적으로 재개 여부 확인
-            pauseCheckInterval = setInterval(() => {
-              if (!options?.shouldPause?.()) {
-                isPaused = false;
-                cleanup();
-                response.resume();
-                logger.debug('[downloadFile] Stream resumed', { downloadedLength, totalLength });
+      try {
+        request = protocol.get(
+          currentUrl,
+          { headers: { 'User-Agent': 'DepsSmuggler/1.0' } },
+          (response) => {
+            activeResponse = response;
+            if (settled) {
+              response.destroy();
+              return;
+            }
+
+            if (response.statusCode === 301 || response.statusCode === 302) {
+              const redirectUrl = response.headers.location;
+              if (!redirectUrl) {
+                fail(new Error(`HTTP ${response.statusCode}: 리다이렉트 Location이 없습니다.`));
+                return;
               }
-            }, 100);
+              if (redirects >= 20) {
+                fail(
+                  new Error(`HTTP ${response.statusCode}: 리다이렉트 제한(20회)을 초과했습니다.`)
+                );
+                return;
+              }
+              let nextUrl: string;
+              try {
+                nextUrl = new URL(redirectUrl, currentUrl).href;
+              } catch (error) {
+                fail(error instanceof Error ? error : new Error(String(error)));
+                return;
+              }
+              settled = true;
+              cleanup();
+              response.destroy();
+              request?.destroy();
+              closeAndRemove((error) => {
+                if (error) reject(error);
+                else downloadAttempt(nextUrl, redirects + 1).then(resolve, reject);
+              });
+              return;
+            }
+
+            const status = response.statusCode ?? 0;
+            if (status < 200 || status >= 300) {
+              fail(
+                new Error(
+                  `HTTP ${status}${response.statusMessage ? ` ${response.statusMessage}` : ''}: 다운로드에 실패했습니다.`
+                )
+              );
+              return;
+            }
+
+            const totalLength = parseInt(response.headers['content-length'] || '0', 10);
+            let downloadedLength = 0;
+            let isPaused = false;
+
+            response.on('data', (chunk: Buffer) => {
+              downloadedLength += chunk.length;
+              onProgress(downloadedLength, totalLength);
+
+              // 일시정지 콜백 체크
+              if (options?.shouldPause?.() && !isPaused) {
+                isPaused = true;
+                response.pause();
+                logger.debug('[downloadFile] Stream paused', { downloadedLength, totalLength });
+
+                // 주기적으로 재개 여부 확인
+                pauseCheckInterval = setInterval(() => {
+                  if (!options?.shouldPause?.()) {
+                    isPaused = false;
+                    if (pauseCheckInterval) clearInterval(pauseCheckInterval);
+                    pauseCheckInterval = null;
+                    response.resume();
+                    logger.debug('[downloadFile] Stream resumed', {
+                      downloadedLength,
+                      totalLength,
+                    });
+                  }
+                }, 100);
+              }
+            });
+
+            response.pipe(file);
+
+            file.once('finish', () => {
+              file.close((error?: NodeJS.ErrnoException | null) => {
+                if (error) {
+                  fail(error);
+                  return;
+                }
+                if (settled) return;
+                settled = true;
+                cleanup();
+                resolve();
+              });
+            });
           }
-        });
-
-        response.pipe(file);
-
-        file.on('finish', () => {
-          cleanup();
-          file.close();
-          resolve();
-        });
-      })
-      .on('error', (err) => {
-        cleanup();
-        file.close();
-        fs.unlink(destPath, () => {});
-        reject(err);
-      });
-
-    // AbortSignal 처리
-    if (options?.signal) {
-      options.signal.addEventListener('abort', () => {
-        cleanup();
-        request.destroy();
-        file.close();
-        fs.unlink(destPath, () => {});
-        reject(new Error('Download aborted'));
-      });
-    }
-  });
+        );
+        request.on('error', fail);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
 }
 
 /**
  * ZIP 압축 파일 생성
  */
-export async function createZipArchive(
-  sourceDir: string,
-  outputPath: string
-): Promise<void> {
+export async function createZipArchive(sourceDir: string, outputPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(outputPath);
     const archive = archiver('zip', { zlib: { level: 9 } });
@@ -128,10 +199,7 @@ export async function createZipArchive(
 /**
  * tar.gz 압축 파일 생성
  */
-export async function createTarGzArchive(
-  sourceDir: string,
-  outputPath: string
-): Promise<void> {
+export async function createTarGzArchive(sourceDir: string, outputPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(outputPath);
     const archive = archiver('tar', { gzip: true, gzipOptions: { level: 9 } });

--- a/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
+++ b/src/renderer/pages/download-page/hooks/use-download-page-controller.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
 import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { groupDownloadItems } from '../utils';
 import type { DownloadStoreItem } from '../../../stores/download-store';
 import { act, renderHook, waitFor } from '@testing-library/react';
@@ -49,6 +55,10 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('./use-os-download-flow', () => ({
   useOSDownloadFlow: () => osFlowMock.value,
+}));
+
+vi.mock('../../../../../electron/utils/logger', () => ({
+  createScopedLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
 }));
 
 type DownloadListenerMap = {
@@ -579,4 +589,95 @@ describe('useDownloadPageController', () => {
       ])
     );
   });
+
+  it.each([503, 404])('실제 HTTP %s 실패 후 같은 항목 재시도는 성공 산출물만 기록한다', async (failureStatus) => {
+    const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'depssmuggler-http-status-'));
+    const payload = Buffer.from('synthetic transport payload');
+    let requests = 0;
+    const server = http.createServer((_request, response) => {
+      requests += 1;
+      if (requests === 1) {
+        response.writeHead(failureStatus, { 'content-type': 'text/plain' });
+        response.end(`failure-${failureStatus}`);
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'application/octet-stream', 'content-length': payload.length });
+      response.end(payload);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('HTTP fixture did not bind');
+
+    try {
+      const packageItem = {
+        id: `conda-http-${failureStatus}`,
+        type: 'conda',
+        name: 'fixture',
+        version: '1.0.0',
+        downloadUrl: `http://127.0.0.1:${address.port}/fixture-1.0.0-0.tar.bz2`,
+        addedAt: Date.now(),
+      };
+      const { electronAPI, listeners, rendered, stores } = await loadController({
+        cartItems: [packageItem],
+        defaultDownloadPath: outputDir,
+      });
+      const { createDownloadOrchestrator } = await import('../../../../../electron/services/download-orchestrator');
+      const dispatch = (channel: string, data: unknown) => {
+        if (channel === 'download:progress') listeners.progress?.(data as Record<string, unknown>);
+        if (channel === 'download:status') listeners.status?.(data as Record<string, unknown>);
+        if (channel === 'download:all-complete') listeners.allComplete?.(data as Record<string, unknown>);
+      };
+      const orchestrator = createDownloadOrchestrator({
+        getMainWindow: () => ({
+          isDestroyed: () => false,
+          webContents: { isDestroyed: () => false, send: dispatch },
+        } as never),
+      });
+      electronAPI.download.start.mockImplementation((data) => orchestrator.startDownload(data as never));
+      await act(async () => { await rendered.result.current.handleStartDownload(); });
+      await waitFor(() => expect(rendered.result.current.packagingStatus).toBe('failed'), { timeout: 10_000 });
+      expect(electronAPI.history.add).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed', outputPath: outputDir })
+      );
+      expect(fs.existsSync(`${outputDir}.zip`)).toBe(false);
+      const packagePath = path.join(outputDir, 'packages', 'fixture-1.0.0-0.tar.bz2');
+      expect(fs.existsSync(packagePath)).toBe(false);
+      const failedHistoryCalls = electronAPI.history.add.mock.calls.length;
+      expect(failedHistoryCalls).toBe(1);
+
+      const failedItem = rendered.result.current.downloadItems[0];
+      expect(failedItem.status).toBe('failed');
+      expect(failedItem.error).toContain(`HTTP ${failureStatus}`);
+      await act(async () => { await rendered.result.current.executeRetryDownload(failedItem); });
+      await waitFor(() => expect(rendered.result.current.packagingStatus).toBe('completed'), { timeout: 10_000 });
+      expect(requests).toBe(2);
+      expect(electronAPI.history.add).toHaveBeenCalledTimes(failedHistoryCalls + 1);
+      expect(electronAPI.history.add).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'success', outputPath: `${outputDir}.zip` })
+      );
+      expect(stores.useDownloadStore.getState().isDownloading).toBe(false);
+      const outputPath = rendered.result.current.completedOutputPath;
+      expect(outputPath).toMatch(/\.zip$/);
+      expect(fs.existsSync(outputPath)).toBe(true);
+      expect((await fs.promises.stat(outputPath)).size).toBeGreaterThan(0);
+      expect(await fs.promises.readFile(packagePath)).toEqual(payload);
+      const python = process.platform === 'win32' ? 'py' : 'python3';
+      const args = process.platform === 'win32' ? ['-3', '-c'] : ['-c'];
+      args.push(
+        'import sys,zipfile,base64; z=zipfile.ZipFile(sys.argv[1]); print(base64.b64encode(z.read("packages/fixture-1.0.0-0.tar.bz2")).decode())',
+        outputPath,
+      );
+      const inspected = await promisify(execFile)(python, args, { timeout: 30_000 });
+      expect(inspected.stdout.trim()).toBe(payload.toString('base64'));
+      rendered.unmount();
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.promises.rm(outputDir, { recursive: true, force: true });
+      await fs.promises.rm(`${outputDir}.zip`, { force: true });
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
GUI 다운로드가 HTTP 503·404의 오류 본문을 정상 패키지로 저장하고 ZIP과 성공 이력을 만들던 문제를 수정합니다. 공유 `downloadFile`은 HTTP 성공 상태를 확인한 뒤에만 본문을 파일에 연결합니다.

실패 시 요청을 중단하고 파일을 닫아 삭제한 뒤 실패를 반환합니다. 같은 경로로 즉시 재시도해도 이전 시도의 정리가 새 파일을 지우지 않습니다. 유효한 301/302는 상대 Location을 해석해 최대 20회 따라가며, Location 누락·반복 초과는 실패합니다. 취소 listener와 일시정지 timer도 시도 종료 시 정리합니다.

검증:
- 실제 loopback 404·503에서 수정 전 성공 처리되는 RED 2건을 확인했습니다.
- 실제 파일 전송 9건: 오류·정상/빈 200·같은 경로 재시도·상대 리다이렉트·잘못된 리다이렉트·사전 취소.
- GUI controller를 실제 orchestrator/router/다운로드/압축 경로에 연결해 Conda 항목의 404·503 실패 이력과 ZIP 부재를 검증했습니다. 재시도한 200은 성공 이력과 ZIP을 만들며, ZIP 내부 바이트까지 비교합니다. 창 이벤트 전달·이력 저장 IPC만 테스트 경계로 대체합니다.
- 전체 테스트 3033 통과 / 164 건너뜀. TypeScript·lint 통과(경고 포함).

파일 유틸리티와 테스트 문서에 오류 처리·재시도 계약을 반영했습니다. 성공 헤더 이후 연결이 끊기는 별도 문제는 #139에서 처리합니다.

Closes #138
