### PR TITLE
fix(yum): 설치 선행 의존성을 기본 다운로드에 포함

### DIFF
--- a/docs/os-package-downloader.md
+++ b/docs/os-package-downloader.md
@@ -308,7 +308,9 @@ XML 속성을 일괄 숫자 변환하지 않으므로 RPM 버전·release·의�
 
 `YumDependencyResolver`는 모든 활성 저장소의 로딩이 성공한 뒤 패키지·provides 인덱스를 반영합니다. primary 누락이나 조회·파싱 실패를 빈 검색 결과로 숨기지 않으며, 실패한 시도의 일부 목록은 다음 재시도에서 사용하지 않습니다. 정상적으로 저장한 저장소별 디스크 캐시는 재사용합니다.
 
-YUM 파싱 결과는 `{ schemaVersion: 1, packages }` 캐시로 저장합니다. 이전 배열 형식, 알 수 없는 스키마와 잘못된 버전 타입은 다시 파싱해 같은 키에 저장하며, 현재 형식은 JSON 저장·복원 뒤에도 버전·release·의존성 버전 문자열을 유지합니다.
+YUM 파싱 결과는 `{ schemaVersion: 2, packages }` 캐시로 저장합니다. 이전 배열 형식과 schema 1, 알 수 없는 스키마와 잘못된 버전 타입은 다시 파싱해 같은 키에 저장하며, 현재 형식은 JSON 저장·복원 뒤에도 버전·release·의존성 버전 문자열을 유지합니다. schema 1에서 `pre=1` 요구 항목을 선택 의존성으로 저장했던 결과도 다시 파싱합니다.
+
+`rpm:requires`의 `pre=1`은 설치 시 필요한 선행 요구 항목이며 선택 의존성이 아닙니다. 일반 requires와 함께 기본 의존성 목록에 포함합니다. 예를 들어 Rocky의 `filesystem → setup → system-release` 관계는 `includeRecommends`를 켜지 않아도 따라가며, `system-release`는 해당 기능을 제공하는 `rocky-release`로 해결합니다. 별도 recommends 항목과 기존 시스템 런타임 필터는 그대로 적용합니다. [RPM Requires 설명](https://rpm.org/docs/4.20.x/manual/spec.html#requires)
 
 YUM `primary.xml.gz`의 `rpm:provides`에는 패키지 자체의 이름을 항상 포함하고, `OSPackageInfo.provides`에 있는 capability 이름을 중복 없이 추가합니다. 이름은 XML 속성으로 escape하므로 `libtinfo.so.6()(64bit)` 같은 라이브러리 capability도 생성 저장소의 DNF 검색에 전달됩니다. 현재 `provides` 타입은 `string[]`이므로 RPM provide의 flags·epoch·ver·rel 속성은 별도로 보존하거나 비교하지 않습니다.
 
@@ -635,7 +637,7 @@ class OSRepoPackager {
 
 YUM 저장소를 생성할 때 `primary.xml.gz`의 각 RPM에는 self-provide와 입력 패키지의 distinct `provides` capability 이름이 기록됩니다. 이 정보는 다운로드된 RPM payload에서 새로 추출하지 않고 resolver/parser가 가진 `OSPackageInfo.provides`를 사용합니다. 현재 모델은 capability 이름만 표현하므로 versioned 또는 flags가 붙은 RPM provides의 의미까지 native solver에서 재현한다고 보장하지 않습니다.
 
-Rocky 9 Bash 묶음에서는 `libtinfo.so.6()(64bit)` 조회와 해당 기능의 DNF 의존성 해결을 확인했습니다. 빈 installroot의 전체 Bash 설치는 별도로 누락된 `setup` 패키지 때문에 아직 실패하며 [#147](https://github.com/jonggeun2001/DepsSmuggler/issues/147)에서 추적합니다.
+Rocky 9 Bash의 기본 CLI 묶음에는 `setup`과 그 하위 의존성이 포함됩니다. 네트워크를 차단한 Rocky 컨테이너에서 생성 저장소만 사용해 `filesystem`과 `setup`을 실제 업그레이드하고 설치 버전을 확인했습니다. 빈 installroot는 기존 필터가 제외하는 libc·loader 런타임 때문에 완전한 OS 설치에 사용할 수 없습니다. 기존 OS에서 Bash까지 업그레이드할 때 나타난 `/usr/bin/sh` 파일 제공 정보 누락은 별도 [#154](https://github.com/jonggeun2001/DepsSmuggler/issues/154)에서 추적합니다.
 
 APT는 수신한 `Packages`의 `aptControlFields`에서 의존성 조건과 대안, `Pre-Depends`, `Provides`, `Conflicts`, `Breaks`, `Replaces`, `Multi-Arch`, `Installed-Size` 등 Control 필드를 보존합니다. 여러 줄 값이 있으면 Debian continuation 문법으로 출력하므로 설명의 들여쓰기와 빈 문단 표기도 유지됩니다. 상위 저장소가 짧은 설명과 `Description-md5`만 제공하면 그 값을 유지하며, 별도 Translation 파일을 받거나 DEB의 긴 설명을 추출하지는 않습니다. `Packages.gz`에는 같은 `Packages` 내용을 압축합니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -186,7 +186,9 @@ DEPS_SMUGGLER_NATIVE_MAVEN=1 bash scripts/verify-worktree.sh \
 
 `src/core/downloaders/os-metadata-parsers.test.ts`는 실제 gzip XML 파서에 1,001개의 표준 엔티티를 전달해 정상 디코딩을 확인하고, 100,000회 한도 초과 및 취소 오류 전달을 검증합니다. `src/core/resolver/os-resolvers.test.ts`는 primary 누락, 비활성 저장소 제외, 뒤쪽 저장소 실패 후 일부 목록이 남지 않는지와 동일 resolver 재시도를 확인합니다.
 
-같은 파서 테스트는 버전 `1.0`, release `01`, 의존성 버전 `1.0`의 값과 런타임 문자열 타입을 확인합니다. 숫자 모양이 아닌 버전과 숫자형 epoch·파일 크기·설치 크기도 함께 검사합니다. Resolver 테스트는 이전 숫자형 배열 캐시와 잘못된 스키마를 다시 파싱하고, 스키마 1 결과를 JSON으로 저장·복원한 새 resolver가 문자열을 유지하며 캐시를 재사용하는지 확인합니다.
+같은 파서 테스트는 버전 `1.0`, release `01`, 의존성 버전 `1.0`의 값과 런타임 문자열 타입을 확인합니다. 숫자 모양이 아닌 버전과 숫자형 epoch·파일 크기·설치 크기도 함께 검사합니다. Resolver 테스트는 이전 숫자형 배열 캐시와 스키마 1, 잘못된 스키마를 다시 파싱하고, 스키마 2 결과를 JSON으로 저장·복원한 새 resolver가 문자열과 필수 선행 의존성을 유지하며 캐시를 재사용하는지 확인합니다.
+
+`src/core/downloaders/yum-prerequisites.integration.test.ts`는 loopback 서버의 원본 YUM XML을 parser와 기본 resolver로 읽어 `pre=1` 요구 항목을 필수 의존성으로 포함하는지 확인합니다. 별도 recommends와 순환 관계를 포함한 fixture로 누락이나 무한 탐색을 검사하며, 이 검사는 native RPM 설치를 대신하지 않습니다.
 
 `src/cli/yum-metadata-failure.integration.test.ts`는 로컬 HTTP 서버의 repomd/primary XML을 실제 자식 CLI로 읽습니다. XML 제한 초과 시 저장소·원인과 종료 코드 `1`이 전달되고 빈 검색 성공으로 바뀌지 않아야 합니다. 이 세 파일은 외부 저장소 없이 기본 테스트에서 실행합니다.
 

--- a/src/core/downloaders/os-metadata-parsers.test.ts
+++ b/src/core/downloaders/os-metadata-parsers.test.ts
@@ -304,7 +304,7 @@ describe('OS metadata parsers', () => {
             name: 'openssl',
             operator: '=',
             version: '3.0.0',
-            isOptional: true,
+            isOptional: false,
           }),
         ],
       }),
@@ -363,7 +363,7 @@ describe('OS metadata parsers', () => {
       size: 123,
       installedSize: 456,
       dependencies: expect.arrayContaining([
-        { name: 'fixture-dependency', operator: '=', version: '1.0', isOptional: true },
+        { name: 'fixture-dependency', operator: '=', version: '1.0', isOptional: false },
         { name: 'fixture-rc', operator: '=', version: '1.0.0~rc1', isOptional: false },
       ]),
     }));

--- a/src/core/downloaders/yum-prerequisites.integration.test.ts
+++ b/src/core/downloaders/yum-prerequisites.integration.test.ts
@@ -1,0 +1,200 @@
+import { createServer, type Server } from 'node:http';
+import { gzipSync } from 'node:zlib';
+import { afterEach, describe, expect, it } from 'vitest';
+import { YumDependencyResolver } from '../resolver/yum-resolver';
+import type { OSDistribution, Repository } from './os-shared/types';
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('YUM prerequisite fixture did not expose a port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function xml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function entry(name: string, options: {
+  flags?: string;
+  epoch?: string;
+  version?: string;
+  pre?: string;
+} = {}): string {
+  const attributes = [
+    `name="${xml(name)}"`,
+    options.flags ? `flags="${options.flags}"` : '',
+    options.epoch ? `epoch="${options.epoch}"` : '',
+    options.version ? `ver="${xml(options.version)}"` : '',
+    options.pre ? `pre="${options.pre}"` : '',
+  ].filter(Boolean).join(' ');
+  return `<rpm:entry ${attributes} />`;
+}
+
+function rpmPackage(options: {
+  name: string;
+  version: string;
+  release: string;
+  epoch?: string;
+  requires?: string;
+  provides?: string;
+  recommends?: string;
+}): string {
+  const requires = options.requires || '';
+  const provides = options.provides || '';
+  const recommends = options.recommends || '';
+  return `
+    <package type="rpm">
+      <name>${xml(options.name)}</name>
+      <arch>x86_64</arch>
+      <version epoch="${options.epoch ?? '0'}" ver="${xml(options.version)}" rel="${xml(options.release)}" />
+      <checksum type="sha256">${xml(options.name)}-${xml(options.version)}-${xml(options.release)}</checksum>
+      <summary>Fixture ${xml(options.name)}</summary>
+      <description>Fixture ${xml(options.name)}</description>
+      <packager>Fixture</packager>
+      <url>https://fixture.invalid/${xml(options.name)}</url>
+      <time file="0" build="0" />
+      <size package="100" installed="100" archive="100" />
+      <location href="Packages/${xml(options.name)}-${xml(options.version)}-${xml(options.release)}.x86_64.rpm" />
+      <format xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+        <rpm:license>MIT</rpm:license>
+        <rpm:requires>${requires}</rpm:requires>
+        <rpm:provides>${provides}</rpm:provides>
+        <rpm:recommends>${recommends}</rpm:recommends>
+      </format>
+    </package>`;
+}
+
+function primaryXml(): Buffer {
+  const packages = [
+    rpmPackage({
+      name: 'bash', version: '5.1.8', release: '9.el9',
+      requires: entry('filesystem', { flags: 'GE', epoch: '0', version: '3.16' }),
+      recommends: entry('weak-extra', { flags: 'EQ', epoch: '0', version: '1.0' }),
+    }),
+    rpmPackage({
+      name: 'filesystem', version: '3.16', release: '5.el9', epoch: '1',
+      requires: `${entry('setup', { flags: 'EQ', epoch: '0', version: '2.13.7', pre: '1' })}${entry('pre-zero', { flags: 'GE', epoch: '0', version: '1.2', pre: '0' })}`,
+    }),
+    rpmPackage({ name: 'setup', version: '2.13.7', release: '10.el9', requires: `${entry('system-release')}${entry('plain-required')}` }),
+    rpmPackage({ name: 'pre-zero', version: '1.2.4', release: '3.el9' }),
+    rpmPackage({ name: 'plain-required', version: '4.0.0', release: '1.el9' }),
+    rpmPackage({
+      name: 'rocky-release', version: '9.8', release: '1.el9',
+      requires: entry('rocky-repos', { flags: 'GE', epoch: '0', version: '9' }),
+      provides: entry('system-release'),
+    }),
+    rpmPackage({
+      name: 'rocky-repos', version: '9.8', release: '1.el9',
+      requires: entry('rocky-release', { flags: 'GE', epoch: '0', version: '9' }),
+    }),
+    rpmPackage({ name: 'weak-extra', version: '1.0', release: '1.el9' }),
+  ];
+  const xmlContent = `<?xml version="1.0" encoding="UTF-8"?>
+    <metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="${packages.length}">
+      ${packages.join('\n')}
+    </metadata>`;
+  return gzipSync(Buffer.from(xmlContent, 'utf8'));
+}
+
+const distribution: OSDistribution = {
+  id: 'rocky-prerequisite-fixture',
+  name: 'Fixture Rocky',
+  version: '9',
+  packageManager: 'yum',
+  architectures: ['x86_64'],
+  defaultRepos: [],
+  extendedRepos: [],
+};
+
+describe('YUM required prerequisite closure through real metadata parsing', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    const activeServer = server;
+    server = undefined;
+    if (activeServer?.listening) {
+      activeServer.closeAllConnections();
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+    }
+  });
+
+  it('keeps pre and unmarked requirements mandatory while excluding weak recommends', async () => {
+    const primary = primaryXml();
+    const requests: string[] = [];
+    const fixtureServer = createServer((request, response) => {
+      const requestPath = request.url ?? '';
+      requests.push(requestPath);
+      if (requestPath === '/repodata/repomd.xml') {
+        response.writeHead(200, { 'content-type': 'application/xml' });
+        response.end(
+          '<?xml version="1.0"?><repomd xmlns="http://linux.duke.edu/metadata/repomd"><revision>1</revision><data type="primary"><checksum type="sha256">fixture</checksum><location href="repodata/primary.xml.gz" /></data></repomd>'
+        );
+        return;
+      }
+      if (requestPath === '/repodata/primary.xml.gz') {
+        response.writeHead(200, { 'content-type': 'application/gzip' });
+        response.end(primary);
+        return;
+      }
+      response.writeHead(404);
+      response.end('fixture not found');
+    });
+    server = fixtureServer;
+    const port = await listen(fixtureServer);
+    const repository: Repository = {
+      id: 'fixture-yum-prerequisites',
+      name: 'Fixture YUM prerequisites',
+      baseUrl: `http://127.0.0.1:${port}`,
+      enabled: true,
+      gpgCheck: false,
+      isOfficial: false,
+    };
+    const resolver = new YumDependencyResolver({
+      distribution,
+      repositories: [repository],
+      architecture: 'x86_64',
+      includeOptional: false,
+      includeRecommends: false,
+    });
+
+    const searchResults = await resolver.searchPackages('bash', 'exact');
+    expect(searchResults).toHaveLength(1);
+    const result = await resolver.resolveDependencies([searchResults[0].latest]);
+
+    expect(requests).toEqual(['/repodata/repomd.xml', '/repodata/primary.xml.gz']);
+    expect(result.unresolved).toEqual([]);
+    const names = result.packages.map((pkg) => pkg.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'bash', 'filesystem', 'setup', 'pre-zero', 'plain-required', 'rocky-release', 'rocky-repos',
+    ]));
+    expect(names).not.toContain('weak-extra');
+    expect(new Set(names).size).toBe(names.length);
+
+    const filesystem = result.packages.find((pkg) => pkg.name === 'filesystem');
+    expect(filesystem).toMatchObject({ version: '3.16', release: '5.el9', epoch: 1 });
+    expect(filesystem?.dependencies).toEqual(expect.arrayContaining([
+      { name: 'setup', version: '2.13.7', operator: '=', isOptional: false },
+      { name: 'pre-zero', version: '1.2', operator: '>=', isOptional: false },
+    ]));
+    const setup = result.packages.find((pkg) => pkg.name === 'setup');
+    expect(setup?.dependencies).toEqual(expect.arrayContaining([
+      { name: 'system-release', version: undefined, operator: undefined, isOptional: false },
+      { name: 'plain-required', version: undefined, operator: undefined, isOptional: false },
+    ]));
+    expect(result.packages.find((pkg) => pkg.name === 'rocky-release')).toMatchObject({
+      version: '9.8', release: '1.el9', epoch: 0,
+    });
+  });
+});

--- a/src/core/downloaders/yum.ts
+++ b/src/core/downloaders/yum.ts
@@ -375,13 +375,13 @@ export class YumMetadataParser {
 
       const flags = entryObj['@_flags'] as string | undefined;
       const ver = entryObj['@_ver'] as string | undefined;
-      const pre = parseNumericAttribute(entryObj['@_pre']);
 
       dependencies.push({
         name,
         version: ver,
         operator: flags ? this.parseRpmFlags(flags) : undefined,
-        isOptional: pre === 1,
+        // pre=1 describes installation ordering, not a weak/optional requirement.
+        isOptional: false,
       });
     }
 

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -651,7 +651,7 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
     expect(cacheSet).toHaveBeenCalledWith(
       expect.any(String),
-      { schemaVersion: 1, packages: parsedPackages }
+      { schemaVersion: 2, packages: parsedPackages }
     );
     const writtenEnvelope = cacheSet.mock.calls[0][1];
     cacheGet.mockResolvedValueOnce(JSON.parse(JSON.stringify(writtenEnvelope)));
@@ -662,14 +662,62 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
   });
 
+  it('YUM resolver는 schema 1 historical optional dependency cache를 재파싱해 필수 prerequisite를 복원한다', async () => {
+    const historicalPackages = [{
+      ...createPackage('filesystem', '3.16'),
+      release: '5.el9',
+      dependencies: [{ name: 'setup', isOptional: true }],
+    }];
+    const reparsedPackages = [{
+      ...historicalPackages[0],
+      dependencies: [{ name: 'setup', isOptional: false }],
+    }];
+    let storedCache: unknown = { schemaVersion: 1, packages: historicalPackages };
+    const cacheGet = vi.fn().mockImplementation(async () => storedCache);
+    const cacheSet = vi.fn().mockImplementation(async (_key: string, value: unknown) => {
+      storedCache = JSON.parse(JSON.stringify(value));
+    });
+    const parseRepomd = vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockResolvedValue({
+      revision: '1',
+      primary: {
+        location: 'repodata/primary.xml.gz',
+        checksum: { type: 'sha256', value: 'deadbeef' },
+      },
+      filelists: null,
+      other: null,
+    });
+    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary')
+      .mockResolvedValue(reparsedPackages);
+    const createResolver = () => new YumDependencyResolver({
+      ...createOptions(repo),
+      cacheManager: { get: cacheGet, set: cacheSet },
+    });
+
+    await accessResolverForTest(createResolver()).loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(parsePrimary).toHaveBeenCalledOnce();
+    expect(cacheSet).toHaveBeenCalledWith(
+      expect.any(String),
+      { schemaVersion: 2, packages: reparsedPackages }
+    );
+    expect((cacheSet.mock.calls[0][1] as { packages: OSPackageInfo[] }).packages[0].dependencies)
+      .toEqual([expect.objectContaining({ name: 'setup', isOptional: false })]);
+
+    await accessResolverForTest(createResolver()).loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(parsePrimary).toHaveBeenCalledOnce();
+  });
+
   it.each([
-    ['unknown schema', { schemaVersion: 2, packages: [] }],
-    ['packages object', { schemaVersion: 1, packages: {} }],
-    ['non-object package', { schemaVersion: 1, packages: [null] }],
-    ['numeric package version', { schemaVersion: 1, packages: [{ ...createPackage('fixture', '1.0'), version: 1 }] }],
-    ['numeric package release', { schemaVersion: 1, packages: [{ ...createPackage('fixture', '1.0'), release: 1 }] }],
+    ['unknown schema', { schemaVersion: 3, packages: [] }],
+    ['packages object', { schemaVersion: 2, packages: {} }],
+    ['non-object package', { schemaVersion: 2, packages: [null] }],
+    ['numeric package version', { schemaVersion: 2, packages: [{ ...createPackage('fixture', '1.0'), version: 1 }] }],
+    ['numeric package release', { schemaVersion: 2, packages: [{ ...createPackage('fixture', '1.0'), release: 1 }] }],
     ['numeric dependency version', {
-      schemaVersion: 1,
+      schemaVersion: 2,
       packages: [{
         ...createPackage('fixture', '1.0'),
         dependencies: [{ name: 'dependency', operator: '=', version: 1 }],
@@ -701,7 +749,7 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
     expect(cacheSet).toHaveBeenCalledWith(
       expect.any(String),
-      { schemaVersion: 1, packages: parsedPackages }
+      { schemaVersion: 2, packages: parsedPackages }
     );
   });
 

--- a/src/core/resolver/yum-resolver.ts
+++ b/src/core/resolver/yum-resolver.ts
@@ -10,7 +10,7 @@ import { isArchitectureCompatible } from '../downloaders/os-shared/repositories'
 import { YumMetadataParser } from '../shared/yum-metadata-parser';
 import type { OSPackageInfo, PackageDependency, OSPackageSearchResult } from '../downloaders/os-shared/types';
 
-const YUM_CACHE_SCHEMA_VERSION = 1;
+const YUM_CACHE_SCHEMA_VERSION = 2;
 
 function isYumCachePackage(value: unknown): value is OSPackageInfo {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;


### PR DESCRIPTION
Rocky 9 Bash를 기본 옵션으로 다운로드하면 `filesystem`의 선행 의존성인 `setup`이 누락되던 문제를 수정합니다. 이제 `rpm:requires`의 `pre=1`을 필수 요구 항목으로 처리해 `setup`과 그 하위 의존성을 함께 반입합니다.

## 변경

- `pre=1`은 설치 순서를 위한 필수 요구 항목입니다. requires를 optional로 변환하던 처리를 제거했습니다. 원본 filesystem RPM의 setup Requires flags 512와 RPM의 `RPMSENSE_SCRIPT_PRE` 의미도 대조했습니다.
- YUM 캐시 스키마를 2로 올려 schema 1에 잘못 저장된 `isOptional:true`를 재파싱합니다. 이전 캐시를 단순히 재사용하면 코드 수정 후에도 누락이 지속되기 때문입니다.
- 선택 recommends, 시스템 런타임 필터, 버전 충돌 시 모든 버전을 받는 정책은 유지합니다. APT/APK 캐시 형식은 변경하지 않습니다.

## 검증

- loopback 원본 repomd/primary XML → 실제 parser → 기본 resolver 회귀: pre=1·pre=0·무표시 requires, `system-release`의 provides, 순환 관계, weak recommends 제외와 버전 문자열 보존.
- schema 1의 filesystem→setup optional 캐시 재파싱·schema 2 JSON 저장/복원·다음 resolver의 cache hit 회귀. 두 문제 모두 원본의 RED를 보존했습니다.
- 실제 CLI는 별도 프로필에 기존 schema 1 캐시를 복사해 실행했습니다. `setup`을 포함한 8종 11개 RPM과 저장소·tar.gz를 생성했습니다. rocky-release/repos/gpg-keys의 두 release를 모두 포함하며, 충돌 시 설치 스크립트를 생략하는 기존 안내도 확인했습니다.
- 전체 Vitest: 3,101 passed / 164 skipped, exit 0 (Node 20.20.2). 두 TypeScript 설정과 lint도 exit 0, lint 오류 0개. 이전 pre=1을 optional로 기대하던 단위 테스트 2개를 수정했습니다.
- 실제 native DNF: 네트워크 없는 기존 Rocky 컨테이너 2개에서 읽기 전용 생성 저장소로 `upgrade filesystem setup` 실제 트랜잭션 성공. 설치 버전 filesystem 3.16-5.el9 / setup 2.13.7-10.el9를 각각 검증했습니다. 저장소 파일 해시는 전후 동일합니다.
- tar.gz 내부 RPM 11개는 디렉터리 RPM과 SHA256이 모두 일치합니다. 실제 CLI에 복사한 schema 1 캐시는 TTL 만료 상태였으므로, 스키마 변경 때문에 재파싱된다는 원인은 별도의 캐시 회귀 테스트로 검증했습니다.
- 전체 Bash 업그레이드의 `/usr/bin/sh` 제공 정보 누락은 별도 #154로 등록했습니다. 빈 installroot는 setup까지 선택하지만 기존 시스템 런타임 제외 정책에 따라 libc/loader transaction check에서 실패합니다. 이 결과를 전체 Bash/빈 OS 설치 성공으로 보고하지 않습니다.

단일 패키지 설치용 의존성 반입의 수정입니다. 기존 시스템 런타임 제외 정책이 적용되므로 새 OS를 빈 installroot에서 bootstrap하는 기능을 추가하지 않습니다. 제품 빌드·설치·배포와 호스트 OS 패키지 변경은 실행하지 않았습니다.

Closes #147
