### PR TITLE
fix: YUM 파일 제공 정보 누락으로 인한 오프라인 Bash 업그레이드 실패 수정

### DIFF
--- a/docs/os-package-downloader.md
+++ b/docs/os-package-downloader.md
@@ -308,11 +308,13 @@ XML 속성을 일괄 숫자 변환하지 않으므로 RPM 버전·release·의�
 
 `YumDependencyResolver`는 모든 활성 저장소의 로딩이 성공한 뒤 패키지·provides 인덱스를 반영합니다. primary 누락이나 조회·파싱 실패를 빈 검색 결과로 숨기지 않으며, 실패한 시도의 일부 목록은 다음 재시도에서 사용하지 않습니다. 정상적으로 저장한 저장소별 디스크 캐시는 재사용합니다.
 
-YUM 파싱 결과는 `{ schemaVersion: 2, packages }` 캐시로 저장합니다. 이전 배열 형식과 schema 1, 알 수 없는 스키마와 잘못된 버전 타입은 다시 파싱해 같은 키에 저장하며, 현재 형식은 JSON 저장·복원 뒤에도 버전·release·의존성 버전 문자열을 유지합니다. schema 1에서 `pre=1` 요구 항목을 선택 의존성으로 저장했던 결과도 다시 파싱합니다.
+YUM 파싱 결과는 `{ schemaVersion: 3, packages }` 캐시로 저장합니다. 이전 배열 형식과 schema 1·2, 알 수 없는 스키마와 잘못된 버전·파일 정보 타입은 다시 파싱해 같은 키에 저장합니다. 현재 형식은 JSON 저장·복원 뒤에도 버전·release·의존성 버전 문자열과 primary 파일 정보를 유지합니다. schema 1에서 `pre=1`을 선택 의존성으로 저장했거나 schema 2에서 파일 제공 정보를 누락한 결과도 다시 파싱합니다.
 
 `rpm:requires`의 `pre=1`은 설치 시 필요한 선행 요구 항목이며 선택 의존성이 아닙니다. 일반 requires와 함께 기본 의존성 목록에 포함합니다. 예를 들어 Rocky의 `filesystem → setup → system-release` 관계는 `includeRecommends`를 켜지 않아도 따라가며, `system-release`는 해당 기능을 제공하는 `rocky-release`로 해결합니다. 별도 recommends 항목과 기존 시스템 런타임 필터는 그대로 적용합니다. [RPM Requires 설명](https://rpm.org/docs/4.20.x/manual/spec.html#requires)
 
 YUM `primary.xml.gz`의 `rpm:provides`에는 패키지 자체의 이름을 항상 포함하고, `OSPackageInfo.provides`에 있는 capability 이름을 중복 없이 추가합니다. 이름은 XML 속성으로 escape하므로 `libtinfo.so.6()(64bit)` 같은 라이브러리 capability도 생성 저장소의 DNF 검색에 전달됩니다. 현재 `provides` 타입은 `string[]`이므로 RPM provide의 flags·epoch·ver·rel 속성은 별도로 보존하거나 비교하지 않습니다.
+
+`primary.xml.gz`의 `<format><file>` 항목은 `OSPackageInfo.rpmPrimaryFiles`에 경로와 `file`·`dir`·`ghost` 타입으로 보존합니다. 로컬 저장소의 primary와 filelists 양쪽에 해당 패키지의 파일 정보를 기록하므로 `/usr/bin/sh` 같은 파일 제공 항목을 DNF가 조회할 수 있습니다. 경로는 XML escape하고 중복 항목은 한 번만 출력합니다. 보존 범위는 상위 primary에 실린 파일이며, 상위 filelists 전체를 내려받거나 RPM의 전체 파일 목록을 추출하지는 않습니다.
 
 ```typescript
 interface RepomdInfo {
@@ -637,7 +639,7 @@ class OSRepoPackager {
 
 YUM 저장소를 생성할 때 `primary.xml.gz`의 각 RPM에는 self-provide와 입력 패키지의 distinct `provides` capability 이름이 기록됩니다. 이 정보는 다운로드된 RPM payload에서 새로 추출하지 않고 resolver/parser가 가진 `OSPackageInfo.provides`를 사용합니다. 현재 모델은 capability 이름만 표현하므로 versioned 또는 flags가 붙은 RPM provides의 의미까지 native solver에서 재현한다고 보장하지 않습니다.
 
-Rocky 9 Bash의 기본 CLI 묶음에는 `setup`과 그 하위 의존성이 포함됩니다. 네트워크를 차단한 Rocky 컨테이너에서 생성 저장소만 사용해 `filesystem`과 `setup`을 실제 업그레이드하고 설치 버전을 확인했습니다. 빈 installroot는 기존 필터가 제외하는 libc·loader 런타임 때문에 완전한 OS 설치에 사용할 수 없습니다. 기존 OS에서 Bash까지 업그레이드할 때 나타난 `/usr/bin/sh` 파일 제공 정보 누락은 별도 [#154](https://github.com/jonggeun2001/DepsSmuggler/issues/154)에서 추적합니다.
+Rocky 9 Bash의 기본 CLI 묶음에는 `setup`과 그 하위 의존성이 포함됩니다. 네트워크를 차단한 기존 Rocky 9.3 컨테이너에서 생성 저장소만 사용해 `/usr/bin/sh` 제공 패키지를 조회하고 `bash`·`filesystem`·`setup`을 실제 업그레이드했습니다. 새 컨테이너 두 번에서 Bash `5.1.8-9.el9`, filesystem `3.16-5.el9`, setup `2.13.7-10.el9` 설치와 기존 ca-certificates 유지, 새 Bash 실행을 확인했습니다. 빈 installroot는 기존 필터가 제외하는 libc·loader 런타임 때문에 완전한 OS 설치에 사용할 수 없습니다.
 
 APT는 수신한 `Packages`의 `aptControlFields`에서 의존성 조건과 대안, `Pre-Depends`, `Provides`, `Conflicts`, `Breaks`, `Replaces`, `Multi-Arch`, `Installed-Size` 등 Control 필드를 보존합니다. 여러 줄 값이 있으면 Debian continuation 문법으로 출력하므로 설명의 들여쓰기와 빈 문단 표기도 유지됩니다. 상위 저장소가 짧은 설명과 `Description-md5`만 제공하면 그 값을 유지하며, 별도 Translation 파일을 받거나 DEB의 긴 설명을 추출하지는 않습니다. `Packages.gz`에는 같은 `Packages` 내용을 압축합니다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -186,9 +186,11 @@ DEPS_SMUGGLER_NATIVE_MAVEN=1 bash scripts/verify-worktree.sh \
 
 `src/core/downloaders/os-metadata-parsers.test.ts`는 실제 gzip XML 파서에 1,001개의 표준 엔티티를 전달해 정상 디코딩을 확인하고, 100,000회 한도 초과 및 취소 오류 전달을 검증합니다. `src/core/resolver/os-resolvers.test.ts`는 primary 누락, 비활성 저장소 제외, 뒤쪽 저장소 실패 후 일부 목록이 남지 않는지와 동일 resolver 재시도를 확인합니다.
 
-같은 파서 테스트는 버전 `1.0`, release `01`, 의존성 버전 `1.0`의 값과 런타임 문자열 타입을 확인합니다. 숫자 모양이 아닌 버전과 숫자형 epoch·파일 크기·설치 크기도 함께 검사합니다. Resolver 테스트는 이전 숫자형 배열 캐시와 스키마 1, 잘못된 스키마를 다시 파싱하고, 스키마 2 결과를 JSON으로 저장·복원한 새 resolver가 문자열과 필수 선행 의존성을 유지하며 캐시를 재사용하는지 확인합니다.
+같은 파서 테스트는 버전 `1.0`, release `01`, 의존성 버전 `1.0`의 값과 런타임 문자열 타입을 확인합니다. 숫자 모양이 아닌 버전과 숫자형 epoch·파일 크기·설치 크기도 함께 검사합니다. Resolver 테스트는 이전 숫자형 배열 캐시와 스키마 1·2, 잘못된 스키마·파일 정보를 다시 파싱하고, 스키마 3 결과를 JSON으로 저장·복원한 새 resolver가 문자열·필수 선행 의존성·primary 파일 정보를 유지하며 캐시를 재사용하는지 확인합니다.
 
 `src/core/downloaders/yum-prerequisites.integration.test.ts`는 loopback 서버의 원본 YUM XML을 parser와 기본 resolver로 읽어 `pre=1` 요구 항목을 필수 의존성으로 포함하는지 확인합니다. 별도 recommends와 순환 관계를 포함한 fixture로 누락이나 무한 탐색을 검사하며, 이 검사는 native RPM 설치를 대신하지 않습니다.
+
+`src/core/downloaders/yum-file-provides.integration.test.ts`는 loopback primary XML의 파일 제공 정보를 실제 parser → JSON 저장·복원 → 저장소 생성 경로로 검증합니다. `/usr/bin/sh`, 단일·복수 파일, dir·ghost 타입, XML 특수문자, 중복과 파일 없는 패키지를 검사하며 생성 primary·filelists의 패키지별 연결을 확인합니다. fixture RPM은 가짜 payload이므로 실제 설치는 별도 native DNF 검증이 필요합니다.
 
 `src/cli/yum-metadata-failure.integration.test.ts`는 로컬 HTTP 서버의 repomd/primary XML을 실제 자식 CLI로 읽습니다. XML 제한 초과 시 저장소·원인과 종료 코드 `1`이 전달되고 빈 검색 성공으로 바뀌지 않아야 합니다. 이 세 파일은 외부 저장소 없이 기본 테스트에서 실행합니다.
 

--- a/src/core/downloaders/os-shared/repo-packager.ts
+++ b/src/core/downloaders/os-shared/repo-packager.ts
@@ -275,6 +275,7 @@ export class OSRepoPackager {
         lines.push(`      </rpm:requires>`);
       }
 
+      lines.push(...this.generateYumFileEntries(pkg, '      '));
       lines.push(`    </format>`);
       lines.push(`  </package>`);
     }
@@ -295,11 +296,20 @@ export class OSRepoPackager {
       const release = this.escapeXml(pkg.release || '1');
       lines.push(`  <package pkgid="${pkg.checksum?.value || ''}" name="${this.escapeXml(pkg.name)}" arch="${pkg.architecture}">`);
       lines.push(`    <version epoch="0" ver="${this.escapeXml(pkg.version)}" rel="${release}"/>`);
+      lines.push(...this.generateYumFileEntries(pkg, '    '));
       lines.push(`  </package>`);
     }
 
     lines.push('</filelists>');
     return lines.join('\n');
+  }
+
+  /** Retain primary file records in both indexes so native solvers can find file providers. */
+  private generateYumFileEntries(pkg: OSPackageInfo, indent: string): string[] {
+    return [...new Set((pkg.rpmPrimaryFiles ?? []).map((file) => {
+      const type = file.type === 'file' ? '' : ` type="${file.type}"`;
+      return `${indent}<file${type}>${this.escapeXml(file.path)}</file>`;
+    }))];
   }
 
   /**

--- a/src/core/downloaders/os-shared/types.ts
+++ b/src/core/downloaders/os-shared/types.ts
@@ -106,6 +106,12 @@ export interface Checksum {
   value: string;
 }
 
+/** File records retained from RPM primary metadata (not the complete RPM file list). */
+export interface RpmPrimaryFile {
+  path: string;
+  type: 'file' | 'dir' | 'ghost';
+}
+
 /**
  * OS 패키지 정보
  */
@@ -140,6 +146,8 @@ export interface OSPackageInfo {
   dependencies: PackageDependency[];
   /** 제공하는 기능/패키지 */
   provides?: string[];
+  /** RPM primary 파일 제공 정보 (JSON 직렬화 가능, 전체 filelists의 부분집합) */
+  rpmPrimaryFiles?: RpmPrimaryFile[];
   /** 충돌하는 패키지 */
   conflicts?: string[];
   /** 대체하는 패키지 */

--- a/src/core/downloaders/yum-file-provides.integration.test.ts
+++ b/src/core/downloaders/yum-file-provides.integration.test.ts
@@ -1,0 +1,204 @@
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { XMLParser } from 'fast-xml-parser';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDownloadedFileKey } from './os-shared/package-file-utils';
+import { OSRepoPackager } from './os-shared/repo-packager';
+import { YumMetadataParser } from './yum';
+import type { OSPackageInfo, Repository } from './os-shared/types';
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('YUM file fixture server did not expose a port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function packageXml(options: {
+  name: string;
+  version: string;
+  release: string;
+  files?: string;
+}): string {
+  return `
+    <package type="rpm">
+      <name>${escapeXml(options.name)}</name>
+      <arch>x86_64</arch>
+      <version epoch="0" ver="${escapeXml(options.version)}" rel="${escapeXml(options.release)}" />
+      <checksum type="sha256">${options.name}-checksum</checksum>
+      <summary>Fixture ${escapeXml(options.name)}</summary>
+      <description>Fixture ${escapeXml(options.name)}</description>
+      <size package="10" installed="10" archive="10" />
+      <location href="Packages/${escapeXml(options.name)}-${escapeXml(options.version)}-${escapeXml(options.release)}.x86_64.rpm" />
+      <format xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+        <rpm:license>MIT</rpm:license>
+        ${options.files ?? ''}
+      </format>
+    </package>`;
+}
+
+function primaryXml(): Buffer {
+  const primary = [
+    packageXml({
+      name: 'shell-fixture', version: '1.0', release: '1.el9',
+      files: '<file>/usr/bin/sh</file><file type="dir">/usr/bin</file><file type="ghost">/var/lib/&amp;&lt;quote&gt;</file><file>/usr/bin/sh</file><file type="invalid">/ignored</file><file />',
+    }),
+    packageXml({
+      name: 'single-fixture', version: '2.0', release: '2.el9',
+      files: '<file>/single/plain</file>',
+    }),
+    packageXml({ name: 'typed-single-fixture', version: '4.0', release: '4.el9', files: '<file type="ghost">/etc/ghost &quot;entry&quot;</file>' }),
+    packageXml({ name: 'empty-fixture', version: '3.0', release: '3.el9' }),
+  ].join('\n');
+  return gzipSync(Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
+    <metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="4">
+      ${primary}
+    </metadata>`, 'utf8'));
+}
+
+const repositoryBase: Omit<Repository, 'baseUrl'> = {
+  id: 'yum-file-fixture',
+  name: 'YUM file fixture',
+  enabled: true,
+  gpgCheck: false,
+  isOfficial: false,
+};
+
+describe('YUM primary file metadata survives parser, JSON, and local repository packaging', () => {
+  let server: Server | undefined;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    const activeServer = server;
+    server = undefined;
+    if (activeServer?.listening) {
+      activeServer.closeAllConnections();
+      await new Promise<void>((resolve) => activeServer.close(() => resolve()));
+    }
+    if (tempDir) {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('parses single/array file forms, preserves typed paths through JSON, and emits escaped primary/filelists entries', async () => {
+    const primary = primaryXml();
+    const fixtureServer = createServer((request, response) => {
+      if (request.url === '/repodata/repomd.xml') {
+        response.writeHead(200, { 'content-type': 'application/xml' });
+        response.end('<?xml version="1.0"?><repomd><data type="primary"><location href="repodata/primary.xml.gz" /></data></repomd>');
+        return;
+      }
+      if (request.url === '/repodata/primary.xml.gz') {
+        response.writeHead(200, { 'content-type': 'application/gzip' });
+        response.end(primary);
+        return;
+      }
+      response.writeHead(404);
+      response.end('not found');
+    });
+    server = fixtureServer;
+    const port = await listen(fixtureServer);
+    const repository: Repository = { ...repositoryBase, baseUrl: `http://127.0.0.1:${port}` };
+    const parser = new YumMetadataParser(repository, 'x86_64');
+    const repomd = await parser.parseRepomd();
+    const parsed = await parser.parsePrimary(repomd.primary?.location ?? '');
+    const roundTripped = JSON.parse(JSON.stringify(parsed)) as OSPackageInfo[];
+
+    const shell = roundTripped.find((pkg) => pkg.name === 'shell-fixture');
+    const single = roundTripped.find((pkg) => pkg.name === 'single-fixture');
+    const empty = roundTripped.find((pkg) => pkg.name === 'empty-fixture');
+    expect(shell?.rpmPrimaryFiles).toEqual([
+      { path: '/usr/bin/sh', type: 'file' },
+      { path: '/usr/bin', type: 'dir' },
+      { path: '/var/lib/&<quote>', type: 'ghost' },
+    ]);
+    expect(single?.rpmPrimaryFiles).toEqual([{ path: '/single/plain', type: 'file' }]);
+    expect(empty?.rpmPrimaryFiles).toBeUndefined();
+
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'yum-file-provides-'));
+    const payloads = new Map<string, string>();
+    for (const pkg of roundTripped) {
+      const source = path.join(tempDir, `${pkg.name}.rpm`);
+      fs.writeFileSync(source, `${pkg.name} payload`);
+      payloads.set(getDownloadedFileKey(pkg), source);
+    }
+    const repoPath = path.join(tempDir, 'repo');
+    await new OSRepoPackager().createLocalRepo(roundTripped, payloads, {
+      packageManager: 'yum',
+      outputPath: repoPath,
+      repoName: 'fixture-yum',
+      includeSetupScript: false,
+    });
+
+    const primaryOutput = await fsp.readFile(path.join(repoPath, 'repodata/primary.xml.gz'));
+    const filelistsOutput = await fsp.readFile(path.join(repoPath, 'repodata/filelists.xml.gz'));
+    const primaryText = (await import('node:zlib')).gunzipSync(primaryOutput).toString('utf8');
+    const filelistsText = (await import('node:zlib')).gunzipSync(filelistsOutput).toString('utf8');
+    const block = (content: string, name: string): string => {
+      const match = content
+        .split('<package ')
+        .map((part) => `<package ${part}`)
+        .find((part) => part.includes(`<name>${name}</name>`) || part.includes(`name="${name}"`));
+      expect(match, `missing ${name} package block`).toBeTruthy();
+      return match ?? '';
+    };
+    const primaryShell = block(primaryText, 'shell-fixture');
+    const primarySingle = block(primaryText, 'single-fixture');
+    const primaryEmpty = block(primaryText, 'empty-fixture');
+    const filelistsShell = block(filelistsText, 'shell-fixture');
+    const filelistsSingle = block(filelistsText, 'single-fixture');
+    const filelistsEmpty = block(filelistsText, 'empty-fixture');
+    expect(primaryShell).toContain('<file>/usr/bin/sh</file>');
+    expect(primaryShell).toContain('<file type="dir">/usr/bin</file>');
+    expect(primaryShell).toContain('<file type="ghost">/var/lib/&amp;&lt;quote&gt;</file>');
+    expect(primaryShell.match(/<file>\/usr\/bin\/sh<\/file>/g)).toHaveLength(1);
+    expect(primaryShell).not.toContain('/single/plain');
+    expect(primarySingle).toContain('<file>/single/plain</file>');
+    expect(primaryEmpty).not.toContain('<file');
+    expect(filelistsShell).toContain('<file>/usr/bin/sh</file>');
+    expect(filelistsShell).toContain('<file type="dir">/usr/bin</file>');
+    expect(filelistsShell).toContain('<file type="ghost">/var/lib/&amp;&lt;quote&gt;</file>');
+    expect(filelistsShell.match(/<file>\/usr\/bin\/sh<\/file>/g)).toHaveLength(1);
+    expect(filelistsSingle).toContain('<file>/single/plain</file>');
+    expect(filelistsEmpty).not.toContain('<file');
+    expect(filelistsText).not.toContain('name="undefined"');
+    const xmlParser = new XMLParser({ ignoreAttributes: false, parseAttributeValue: false });
+    const primaryPackages = xmlParser.parse(primaryText).metadata.package;
+    const filelistsPackages = xmlParser.parse(filelistsText).filelists.package;
+    for (const pkg of roundTripped) {
+      const primaryPkg = primaryPackages.find((entry: Record<string, unknown>) => entry.name === pkg.name);
+      const filelistsPkg = filelistsPackages.find((entry: Record<string, unknown>) => entry['@_name'] === pkg.name);
+      expect(filelistsPkg['@_pkgid']).toBe(primaryPkg.checksum['#text']);
+      expect(filelistsPkg.version).toEqual(primaryPkg.version);
+      expect(filelistsPkg.version['@_ver']).toBe(pkg.version);
+      expect(filelistsPkg.version['@_rel']).toBe(pkg.release);
+      const expectedFiles = pkg.rpmPrimaryFiles?.map((file) => file.type === 'file'
+        ? file.path : { '#text': file.path, '@_type': file.type });
+      const normalizedFiles = (value: unknown) => value === undefined ? undefined : Array.isArray(value) ? value : [value];
+      expect(normalizedFiles(primaryPkg.format.file)).toEqual(expectedFiles);
+      expect(normalizedFiles(filelistsPkg.file)).toEqual(expectedFiles);
+    }
+    expect(roundTripped.find((pkg) => pkg.name === 'typed-single-fixture')?.rpmPrimaryFiles)
+      .toEqual([{ path: '/etc/ghost "entry"', type: 'ghost' }]);
+  });
+});

--- a/src/core/downloaders/yum.ts
+++ b/src/core/downloaders/yum.ts
@@ -16,6 +16,7 @@ import type {
   VersionOperator,
   Checksum,
   ChecksumType,
+  RpmPrimaryFile,
 } from './os-shared/types';
 import { BaseOSDownloader, type BaseDownloaderOptions } from './os-shared/base-downloader';
 import { resolveRepoUrl } from './os-shared/repositories';
@@ -327,6 +328,7 @@ export class YumMetadataParser {
     const obsoletes = this.parseRpmProvides(formatEl?.['rpm:obsoletes']);
     const suggests = this.parseRpmProvides(formatEl?.['rpm:suggests']);
     const recommends = this.parseRpmProvides(formatEl?.['rpm:recommends']);
+    const rpmPrimaryFiles = this.parseRpmPrimaryFiles(formatEl?.file);
 
     return {
       name,
@@ -344,11 +346,32 @@ export class YumMetadataParser {
       license,
       dependencies,
       provides: provides.length > 0 ? provides : undefined,
+      rpmPrimaryFiles: rpmPrimaryFiles.length > 0 ? rpmPrimaryFiles : undefined,
       conflicts: conflicts.length > 0 ? conflicts : undefined,
       obsoletes: obsoletes.length > 0 ? obsoletes : undefined,
       suggests: suggests.length > 0 ? suggests : undefined,
       recommends: recommends.length > 0 ? recommends : undefined,
     };
+  }
+
+  private parseRpmPrimaryFiles(files: unknown): RpmPrimaryFile[] {
+    const result: RpmPrimaryFile[] = [];
+    const seen = new Set<string>();
+    for (const entry of Array.isArray(files) ? files : [files]) {
+      const record = entry && typeof entry === 'object'
+        ? entry as Record<string, unknown>
+        : undefined;
+      const filePath = typeof entry === 'string' ? entry : record?.['#text'];
+      const type = record?.['@_type'] ?? 'file';
+      if (typeof filePath !== 'string' || !filePath ||
+          (type !== 'file' && type !== 'dir' && type !== 'ghost')) continue;
+      const key = JSON.stringify([filePath, type]);
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push({ path: filePath, type });
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/core/resolver/os-resolvers.test.ts
+++ b/src/core/resolver/os-resolvers.test.ts
@@ -651,7 +651,7 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
     expect(cacheSet).toHaveBeenCalledWith(
       expect.any(String),
-      { schemaVersion: 2, packages: parsedPackages }
+      { schemaVersion: 3, packages: parsedPackages }
     );
     const writtenEnvelope = cacheSet.mock.calls[0][1];
     cacheGet.mockResolvedValueOnce(JSON.parse(JSON.stringify(writtenEnvelope)));
@@ -668,7 +668,7 @@ describe('OS dependency resolvers', () => {
       release: '5.el9',
       dependencies: [{ name: 'setup', isOptional: true }],
     }];
-    const reparsedPackages = [{
+    const reparsedPackages: OSPackageInfo[] = [{
       ...historicalPackages[0],
       dependencies: [{ name: 'setup', isOptional: false }],
     }];
@@ -699,7 +699,7 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
     expect(cacheSet).toHaveBeenCalledWith(
       expect.any(String),
-      { schemaVersion: 2, packages: reparsedPackages }
+      { schemaVersion: 3, packages: reparsedPackages }
     );
     expect((cacheSet.mock.calls[0][1] as { packages: OSPackageInfo[] }).packages[0].dependencies)
       .toEqual([expect.objectContaining({ name: 'setup', isOptional: false })]);
@@ -710,14 +710,77 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    ['unknown schema', { schemaVersion: 3, packages: [] }],
-    ['packages object', { schemaVersion: 2, packages: {} }],
-    ['non-object package', { schemaVersion: 2, packages: [null] }],
-    ['numeric package version', { schemaVersion: 2, packages: [{ ...createPackage('fixture', '1.0'), version: 1 }] }],
-    ['numeric package release', { schemaVersion: 2, packages: [{ ...createPackage('fixture', '1.0'), release: 1 }] }],
-    ['numeric dependency version', {
+  it('YUM resolver는 파일 정보가 없는 schema 2 cache를 재파싱해 primary 파일 목록을 보존한다', async () => {
+    const reparsedPackages: OSPackageInfo[] = [{
+      ...createPackage('filesystem', '3.16'),
+      release: '5.el9',
+      dependencies: [{ name: 'setup', isOptional: false }],
+      rpmPrimaryFiles: [
+        { path: '/usr/bin/sh', type: 'file' },
+        { path: '/usr/lib', type: 'dir' },
+        { path: '/var/empty', type: 'ghost' },
+      ],
+    }];
+    let storedCache: unknown = {
       schemaVersion: 2,
+      packages: [{ ...reparsedPackages[0], rpmPrimaryFiles: undefined }],
+    };
+    const cacheGet = vi.fn().mockImplementation(async () => storedCache);
+    const cacheSet = vi.fn().mockImplementation(async (_key: string, value: unknown) => {
+      storedCache = JSON.parse(JSON.stringify(value));
+    });
+    const parseRepomd = vi.spyOn(YumMetadataParser.prototype, 'parseRepomd').mockResolvedValue({
+      revision: '1',
+      primary: {
+        location: 'repodata/primary.xml.gz',
+        checksum: { type: 'sha256', value: 'deadbeef' },
+      },
+      filelists: null,
+      other: null,
+    });
+    const parsePrimary = vi.spyOn(YumMetadataParser.prototype, 'parsePrimary')
+      .mockResolvedValue(reparsedPackages);
+    const createResolver = () => new YumDependencyResolver({
+      ...createOptions(repo),
+      cacheManager: { get: cacheGet, set: cacheSet },
+    });
+
+    const cachedResolver = createResolver();
+    await accessResolverForTest(cachedResolver).loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(parsePrimary).toHaveBeenCalledOnce();
+    expect(cacheSet).toHaveBeenCalledWith(
+      expect.any(String),
+      { schemaVersion: 3, packages: reparsedPackages }
+    );
+    expect((cacheSet.mock.calls[0][1] as { packages: OSPackageInfo[] }).packages[0])
+      .toEqual(expect.objectContaining({
+        rpmPrimaryFiles: reparsedPackages[0].rpmPrimaryFiles,
+      }));
+
+    const cachedHitResolver = createResolver();
+    await accessResolverForTest(cachedHitResolver).loadMetadata();
+
+    expect(parseRepomd).toHaveBeenCalledOnce();
+    expect(parsePrimary).toHaveBeenCalledOnce();
+    await expect(accessResolverForTest(cachedHitResolver).findPackagesForDependency({ name: 'filesystem' }))
+      .resolves.toEqual([expect.objectContaining({ rpmPrimaryFiles: reparsedPackages[0].rpmPrimaryFiles })]);
+  });
+
+  it.each([
+    ['unknown schema', { schemaVersion: 4, packages: [] }],
+    ['packages object', { schemaVersion: 3, packages: {} }],
+    ['non-object package', { schemaVersion: 3, packages: [null] }],
+    ['numeric package version', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), version: 1 }] }],
+    ['numeric package release', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), release: 1 }] }],
+    ['malformed primary files array', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), rpmPrimaryFiles: {} }] }],
+    ['malformed primary file path', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), rpmPrimaryFiles: [{ path: 1, type: 'file' }] }] }],
+    ['malformed primary file type', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), rpmPrimaryFiles: [{ path: '/usr/bin/sh', type: 'link' }] }] }],
+    ['empty primary file path', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), rpmPrimaryFiles: [{ path: '', type: 'file' }] }] }],
+    ['null primary file', { schemaVersion: 3, packages: [{ ...createPackage('fixture', '1.0'), rpmPrimaryFiles: [null] }] }],
+    ['numeric dependency version', {
+      schemaVersion: 3,
       packages: [{
         ...createPackage('fixture', '1.0'),
         dependencies: [{ name: 'dependency', operator: '=', version: 1 }],
@@ -749,7 +812,7 @@ describe('OS dependency resolvers', () => {
     expect(parsePrimary).toHaveBeenCalledOnce();
     expect(cacheSet).toHaveBeenCalledWith(
       expect.any(String),
-      { schemaVersion: 2, packages: parsedPackages }
+      { schemaVersion: 3, packages: parsedPackages }
     );
   });
 

--- a/src/core/resolver/yum-resolver.ts
+++ b/src/core/resolver/yum-resolver.ts
@@ -10,7 +10,7 @@ import { isArchitectureCompatible } from '../downloaders/os-shared/repositories'
 import { YumMetadataParser } from '../shared/yum-metadata-parser';
 import type { OSPackageInfo, PackageDependency, OSPackageSearchResult } from '../downloaders/os-shared/types';
 
-const YUM_CACHE_SCHEMA_VERSION = 2;
+const YUM_CACHE_SCHEMA_VERSION = 3;
 
 function isYumCachePackage(value: unknown): value is OSPackageInfo {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
@@ -24,6 +24,15 @@ function isYumCachePackage(value: unknown): value is OSPackageInfo {
   ) {
     return false;
   }
+
+  if (pkg.rpmPrimaryFiles !== undefined && (
+    !Array.isArray(pkg.rpmPrimaryFiles) ||
+    !pkg.rpmPrimaryFiles.every((file) => (
+      file && typeof file === 'object' && !Array.isArray(file) &&
+      typeof file.path === 'string' && file.path.length > 0 &&
+      (file.type === 'file' || file.type === 'dir' || file.type === 'ghost')
+    ))
+  )) return false;
 
   return pkg.dependencies.every((dependency) => (
     dependency &&


### PR DESCRIPTION
## 문제와 변경

Closes #154

Rocky Bash의 기본 CLI 묶음으로 기존 OS를 업그레이드하면, 설치된 ca-certificates가 요구하는 `/usr/bin/sh` 제공 정보를 로컬 저장소에서 찾지 못해 실패했습니다. 상위 primary에는 Bash의 파일 22개가 있었지만 파서가 이를 버리고 생성 filelists도 비워 두고 있었습니다.

- primary의 파일 경로와 file·dir·ghost 타입을 `rpmPrimaryFiles`로 보존하고, 생성 primary/filelists에 패키지별로 escape·중복 제거해 기록합니다.
- YUM 캐시를 schema 3으로 올려 파일 정보가 없는 schema 2와 이전 캐시를 다시 파싱합니다. 잘못된 파일 정보도 재파싱하며 현재 캐시는 JSON 저장·복원 후 재사용합니다.
- 상위 primary의 파일 정보만 보존합니다. 전체 upstream filelists 수집, RPM 파일 추출, 기존 시스템 런타임 필터나 충돌 선택 정책 확장은 포함하지 않습니다.

## 검증

- 수정 전: loopback parser 회귀와 유효한 schema 2 캐시 회귀 실패를 확인했습니다. 이전 CLI 묶음으로 실제 Bash 업그레이드도 두 번 실패했습니다.
- 수정 후: 실제 CLI `os download bash --distro rocky-9 --arch x86_64 --format both --archive-format tar.gz --scripts` 성공. TTL 이내 schema 2 캐시 3개를 schema 3으로 갱신했습니다.
- 생성 저장소 8종/11 RPM과 archive의 SHA256이 일치하고, 수정 전 #147 묶음의 11 RPM과도 동일합니다. Bash 파일 22개는 원본 primary 및 생성 primary/filelists 간 일치합니다.
- 네트워크 차단·로컬 저장소 read-only mount한 새 Rocky 9.3 컨테이너 2회에서 `/usr/bin/sh` 제공 패키지 조회 및 `dnf upgrade bash filesystem setup` 실제 트랜잭션 성공. Bash 5.1.8-9.el9, filesystem 3.16-5.el9, setup 2.13.7-10.el9 설치·기존 ca-certificates 유지·새 Bash 실행을 확인했습니다.
- `bash scripts/verify-worktree.sh`: 3108 passed / 164 skipped. 최종 관련 회귀 47 passed. main/electron TypeScript 검사 및 lint 오류 0, `git diff --check` 통과.

## 문서와 범위

`docs/os-package-downloader.md`와 `docs/testing.md`에 캐시 형식, 파일 정보 보존 범위, 회귀 및 native 검증을 반영했습니다. 빈 installroot의 전체 OS 설치는 기존 시스템 런타임 필터로 인해 보장하지 않습니다. 로컬 제품 빌드·설치·릴리스 배포는 수행하지 않았습니다.
